### PR TITLE
docs(spec): 冻结 FR-0005 错误模型与适配器注册表契约

### DIFF
--- a/docs/exec-plans/FR-0005-standardized-error-model-and-adapter-registry.md
+++ b/docs/exec-plans/FR-0005-standardized-error-model-and-adapter-registry.md
@@ -1,0 +1,88 @@
+# FR-0005-standardized-error-model-and-adapter-registry 执行计划
+
+## 关联信息
+
+- item_key：`FR-0005-standardized-error-model-and-adapter-registry`
+- Issue：`#65`
+- item_type：`FR`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`FR-0005-standardized-error-model-and-adapter-registry`
+
+## 目标
+
+- 为父事项 `#65` 建立可审查、可合并、可追溯的 formal spec 套件，冻结错误模型与 adapter registry 的 requirement、边界与验收语义。
+- 把 `#69` 与 `#70` 收敛为后续独立实现 Work Item，而不是让当前 formal spec PR 提前进入实现回合。
+
+## 范围
+
+- 本次纳入：
+  - `docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
+  - `docs/exec-plans/FR-0005-standardized-error-model-and-adapter-registry.md`
+  - `docs/releases/v0.2.0.md`
+  - `docs/sprints/2026-S15.md`
+- 本次不纳入：
+  - Core / Adapter 实现改动
+  - harness、fake adapter、gate 或 validator 设计细节
+  - `src/**`、`scripts/**`、`tests/**` 的运行时改造
+
+## 当前停点
+
+- GitHub `#65` 已明确当前 FR 只要求 formal spec 收口，并把 `#69`、`#70` 指定为下游 Work Item。
+- 仓库主干尚不存在 `docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`，当前 formal spec 入口仍待创建。
+- 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-65-fr-0005-v0-2-0`。
+
+## 下一步动作
+
+- 起草 `FR-0005` 的 `spec.md`、`plan.md`、`risks.md` 与 `contracts/README.md`。
+- 运行 formal spec 相关门禁，并通过受控入口创建 `spec` PR。
+- 等待 checks 全绿后执行 guardian；若存在阻断，只修当前 head 的最新阻断项。
+- 合并后同步 `#65` 的 formal spec 入口，保持 GitHub 与主干真相一致。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.2.0` 冻结“标准化错误模型 + adapter registry”这一共享契约，使后续 harness、validator 与版本 gate 能围绕统一失败语义与统一 adapter 发现语义展开。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`v0.2.0` formal spec 主线事项。
+- 阻塞：
+  - 无外部阻塞；当前主要工作是 formal spec 收口、受控 PR、guardian 与 merge gate。
+
+## 已验证项
+
+- `gh issue view 65`
+  - 结果：`FR-0005` 为 `v0.2.0` FR 容器，formal spec 待创建，子 Work Item 为 `#69`、`#70`
+- `gh issue view 69`
+  - 结果：`#69` 为“实现标准化错误模型”的后续 Work Item
+- `gh issue view 70`
+  - 结果：`#70` 为“实现适配器注册表”的后续 Work Item
+- `gh issue view 64`
+  - 结果：`FR-0004` 负责 `InputTarget` 与 `CollectionPolicy`
+- `gh issue view 66`
+  - 结果：`FR-0006` 负责 adapter contract test harness
+- `gh issue view 67`
+  - 结果：`FR-0007` 负责版本 gate 与回归检查
+- 已阅读：`vision.md`
+- 已阅读：`docs/roadmap-v0-to-v1.md`
+- 已阅读：`WORKFLOW.md`
+- 已阅读：`docs/AGENTS.md`
+- 已阅读：`spec_review.md`
+- 已阅读：`docs/releases/v0.2.0.md`
+
+## 未决风险
+
+- 若 formal spec 没有把 `invalid_input`、`unsupported`、`runtime_contract` 与 `platform` 拆开，`#69` 将难以形成稳定实现边界。
+- 若 registry 被写成带平台副作用的发现机制，`FR-0006` 的 fake adapter / harness 将无法建立稳定入口。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对 `docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`、`docs/exec-plans/FR-0005-standardized-error-model-and-adapter-registry.md`、`docs/releases/v0.2.0.md` 与 `docs/sprints/2026-S15.md` 的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `f9bf12ad92f6f9afab3d3761c7df8c8b48a07ef9`
+- 说明：当前为 formal spec kickoff 停点；后续如只补充 checks / guardian / merge gate 元数据，可由 guardian state 绑定当前受审 head。

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -20,6 +20,9 @@
 ## 纳入事项
 
 - `FR-0003-github-delivery-structure-and-repo-semantic-split`：`v0.2.0` governance requirement 主线，对应 Issue `#55`
+- `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约主线之一，对应 Issue `#65`
+- `#69`：`FR-0005` 下的“实现标准化错误模型” Work Item
+- `#70`：`FR-0005` 下的“实现适配器注册表” Work Item
 - `GOV-0027-governance-contract-rewrite`：治理契约重写与口径收敛，对应 Issue `#56`
 - `GOV-0028-harness-compat-migration`：后续 harness 兼容迁移，对应 Issue `#57`
 - `GOV-0029-remove-legacy-todo-md`：移除 legacy `TODO.md` 的正式治理流入口与存量 compat 残留，对应 Issue `#58`
@@ -36,7 +39,9 @@
   - `docs/sprints/2026-S15.md`
 - spec：
   - `docs/specs/FR-0003-github-delivery-structure-and-repo-semantic-split/`
+  - `docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
 - exec-plan：
+  - `docs/exec-plans/FR-0005-standardized-error-model-and-adapter-registry.md`
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`
   - `docs/exec-plans/GOV-0028-harness-compat-migration.md`
   - `docs/exec-plans/GOV-0029-remove-legacy-todo-md.md`

--- a/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/contracts/README.md
+++ b/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/contracts/README.md
@@ -1,0 +1,25 @@
+# FR-0005 contracts
+
+本目录用于记录 `FR-0005` 的稳定契约入口。
+
+当前 FR 的正式契约结论如下：
+
+- Core 统一承载失败 envelope，`error` 最小字段固定为 `category`、`code`、`message`、`details`
+- `category` 的最小集合固定为：
+  - `invalid_input`
+  - `unsupported`
+  - `runtime_contract`
+  - `platform`
+- `invalid_input` 表示请求未进入有效分发；`unsupported` 表示请求合法但当前 adapter / capability 集合不满足
+- `runtime_contract` 表示 registry、adapter 声明、成功 payload 或 host-side 运行时契约失配，必须 fail-closed
+- `platform` 表示 adapter 已进入平台语义边界，但被平台事实或平台资源条件阻断
+- adapter registry 只冻结以下语义职责：
+  - materialize 明确的 adapter 绑定集合
+  - 以稳定 `adapter_key` 做唯一查找
+  - 暴露 capability 声明结果，供 Core 做分发前判断
+  - 对歧义注册、无效声明、无效 capability 元数据按 `runtime_contract` fail-closed
+- adapter registry 不冻结以下实现细节：
+  - 模块扫描、插件市场、import 约定
+  - registry 的类结构、方法名、缓存策略或实例化时机
+  - fake adapter、harness、validator 或 gate 的目录和运行方式
+- capability discovery 的正式约束是 side-effect-free：不得依赖真实平台网络、登录态或浏览器执行

--- a/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/plan.md
+++ b/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/plan.md
@@ -1,0 +1,83 @@
+# FR-0005 实施计划
+
+## 关联信息
+
+- item_key：`FR-0005-standardized-error-model-and-adapter-registry`
+- Issue：`#65`
+- item_type：`FR`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 exec-plan：`docs/exec-plans/FR-0005-standardized-error-model-and-adapter-registry.md`
+
+## 实施目标
+
+- 为 `FR-0005` 建立 formal spec 套件，冻结标准化错误模型与 adapter registry 的 requirement、边界与验收语义。
+- 让 `#69` 与 `#70` 能以清晰分工进入后续实现，而不在 formal spec PR 中提前进入执行态。
+
+## 分阶段拆分
+
+- 阶段 1：建立 `FR-0005` formal spec 套件，冻结错误分类、registry 职责、discovery 约束与 fail-closed 语义。
+- 阶段 2：由 `#69` 独立实现标准化错误模型，把 `invalid_input`、`unsupported`、`runtime_contract`、`platform` 的分类与 envelope 映射落入 Core / Adapter 运行时。
+- 阶段 3：由 `#70` 独立实现 adapter registry，把注册、查找、capability discovery 与 fail-closed 行为落入运行时。
+- 阶段 4：由 `FR-0006` 在已批准的 error model 与 registry contract 上建立 harness、fake adapter 与验证工具契约。
+- 阶段 5：由 `FR-0007` 在已批准的 contract 与 harness 能力上定义 gate、回归检查与平台泄漏检查流程。
+
+## 实现约束
+
+- 不允许触碰的边界：
+  - 当前 PR 只允许修改 `FR-0005` formal spec 套件、必要的风险/契约文档、当前执行回合所需的最小 `exec-plan`，以及 `v0.2.0` / `2026-S15` 的最小索引更新
+  - 不在本 PR 中修改 `src/**`、`scripts/**`、`tests/**`
+  - 不把 harness、fake adapter、validator、gate、双参考适配器回归或平台泄漏检查提前并入本 FR
+  - 不把 registry 的代码结构、模块路径、类名或 import 机制冻结成 formal contract
+- 与上位文档的一致性约束：
+  - 与 `vision.md`、`docs/roadmap-v0-to-v1.md` 的 `v0.2.0` 边界保持一致
+  - 与 `FR-0004`、`FR-0006`、`FR-0007` 保持职责切分，不制造交叉 requirement
+  - formal spec 与实现默认分 PR
+
+## 测试与验证策略
+
+- 单元测试：
+  - 无。当前 formal spec PR 不引入实现代码；`#69` 与 `#70` 再为错误分类映射、registry fail-closed 与 discovery 语义补测试
+- 集成/契约测试：
+  - 当前 formal spec PR 运行 `docs_guard`、`spec_guard`、`context_guard` 与 `open_pr --class spec --dry-run`
+  - `#69` 后续覆盖错误 envelope、分类映射与失败路径回归
+  - `#70` 后续覆盖 registry materialization、lookup、capability discovery 与 fail-closed 回归
+- 手动验证：
+  - 核对 `#65`、`#69`、`#70` 与 `FR-0004`、`FR-0006`、`FR-0007` 的 GitHub 边界
+  - 核对 `docs/releases/v0.2.0.md`、`docs/sprints/2026-S15.md` 与 `docs/specs/FR-0005-*/` 的索引映射一致
+
+## TDD 范围
+
+- 先写测试的模块：
+  - `#69`：错误 envelope 分类映射、invalid / unsupported / runtime_contract / platform 边界
+  - `#70`：registry lookup、capability discovery、重复 key / 非法声明 / fail-closed 行为
+- 暂不纳入 TDD 的模块与理由：
+  - formal spec 文档本身不产生运行时代码；harness / fake adapter / gate 的测试策略属于 `FR-0006`、`FR-0007`
+
+## 并行 / 串行关系
+
+- 可并行项：
+  - formal spec 套件编写
+  - 风险文档与 contracts 文档整理
+  - release / sprint 最小索引更新
+- 串行依赖项：
+  - `#69` 与 `#70` 必须等待当前 formal spec 合入 `main`
+  - `FR-0006` 与 `FR-0007` 必须消费已批准的错误模型与 registry contract，而不是反向定义本 FR
+  - merge 前必须完成当前 PR 的 checks、guardian 与 merge gate
+- 阻塞项：
+  - 若 formal spec 没有把 `invalid_input`、`unsupported`、`runtime_contract`、`platform` 的边界写清，后续实现将无法稳定拆分到 `#69` 与 `#70`
+
+## 进入实现前条件
+
+- [ ] `spec review` 已通过
+- [x] 关键风险已记录并有缓解策略
+- [x] 关键依赖可用
+- [x] `#69` 与 `#70` 的职责切分已明确
+
+## spec review 结论
+
+- 结论：当前 formal spec 目标清晰，已把错误模型、registry、discovery 与 fail-closed 语义收敛到 `FR-0005`，且未吞并相邻 FR 的 formal scope
+- 未决问题：
+  - `#69` 需要在实现前把现存 `runtime_contract` / `platform` 错误映射迁移到新分类集合
+  - `#70` 需要在实现前决定 registry 的具体承载方式，但该选择不得反向改写本 spec 的语义边界
+- implementation-ready 判定：待当前 formal spec PR 完成 checks、guardian、merge gate 后，`#69` 与 `#70` 可据此进入各自实现回合

--- a/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/plan.md
+++ b/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/plan.md
@@ -44,7 +44,7 @@
   - `#70` 后续覆盖 registry materialization、lookup、capability discovery 与 fail-closed 回归
 - 手动验证：
   - 核对 `#65`、`#69`、`#70` 与 `FR-0004`、`FR-0006`、`FR-0007` 的 GitHub 边界
-  - 核对 `docs/releases/v0.2.0.md`、`docs/sprints/2026-S15.md` 与 `docs/specs/FR-0005-*/` 的索引映射一致
+  - 核对 `docs/releases/v0.2.0.md`、`docs/sprints/2026-S15.md` 与 `docs/specs/FR-0005-standardized-error-model-and-adapter-registry/` 的索引映射一致
 
 ## TDD 范围
 

--- a/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/risks.md
+++ b/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/risks.md
@@ -1,0 +1,15 @@
+# FR-0005 风险清单
+
+## 风险项
+
+| 风险 | 影响 | 缓解策略 | 回滚策略 |
+| --- | --- | --- | --- |
+| 把错误分类写得过细并绑定到当前代码结构 | 后续 `#69` 只能机械复制当前实现，失去在不改语义前提下重构的空间 | 只冻结分类边界、失败语义与 envelope 契约，不冻结类名、模块路径、异常继承关系 | 使用独立 revert PR 回退 `FR-0005` formal spec，并重新收敛分类边界 |
+| 把 `unsupported`、`invalid_input`、`runtime_contract` 混写 | Core 无法稳定判断失败来源，harness 与 gate 也无法复用统一语义 | 在 `spec.md` 中显式拆开“请求不合法”“请求合法但不支持”“契约失配”三类失败 | 回退有歧义的 formal spec 修改，恢复到上一个清晰可判定的错误边界 |
+| 把 registry discovery 写成真实平台副作用 | 后续 `FR-0006` 无法在不访问真实平台的前提下验证 contract | 在 spec 中固定 discovery 只消费稳定声明，不要求网络、登录态或浏览器副作用 | 回退 discovery 相关 formal spec，恢复到 side-effect-free 的最小契约 |
+| formal spec 与 GitHub FR 状态失配 | 仓内已落地 formal spec，但 Issue 仍声明 `formal spec: 待创建`，导致真相不一致 | 在 merge 后同步更新 `#65` 的 formal spec 入口，并保持 Issue 继续作为未完结 requirement 容器 | 若同步失败，先保留 FR issue 为 OPEN，并补发 issue 更新或独立 docs-only 修正 |
+
+## 合并前核对
+
+- [x] 高风险项已有缓解策略
+- [x] 回滚路径可执行

--- a/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/spec.md
+++ b/docs/specs/FR-0005-standardized-error-model-and-adapter-registry/spec.md
@@ -1,0 +1,164 @@
+# FR-0005 v0.2.0 standardized error model and adapter registry
+
+## 关联信息
+
+- item_key：`FR-0005-standardized-error-model-and-adapter-registry`
+- Issue：`#65`
+- item_type：`FR`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+
+## 背景与目标
+
+- 背景：`v0.1.0` 已证明最小 Core 可以运行真实参考适配器，但当前错误返回与 adapter 装配仍停留在“能跑即可”的阶段。进入 `v0.2.0` 后，Core 需要把“错误如何分类”和“适配器如何被发现、注册、查找”冻结为稳定契约，才能支撑后续 harness、fake adapter、版本 gate 与双参考适配器回归。
+- 目标：为 `v0.2.0` 冻结标准化错误模型与 adapter registry 的 formal contract，明确它们与 Core / Adapter 的职责边界、发现与失败语义，以及后续 Work Item `#69`、`#70` 的实施入口。
+
+## 范围
+
+- 本次纳入：
+  - 冻结错误分类的最小语义集合
+  - 冻结 adapter registry 的职责边界与最小运行时契约
+  - 明确 capability discovery、adapter 注册、adapter 查找与失败路径的统一语义
+  - 明确 `fail-closed`、`invalid`、`unsupported` 的边界
+  - 明确 `FR-0005` 与 `FR-0004`、`FR-0006`、`FR-0007` 的边界
+  - 明确 `#69` 与 `#70` 如何作为本 FR 的后续 Work Item 进入实现
+- 本次不纳入：
+  - `InputTarget` 与 `CollectionPolicy` 的字段设计或输入建模语义
+  - fake adapter、adapter contract test harness、验证工具与 gate 运行方式
+  - 双参考适配器回归、平台泄漏检查与版本门禁规则
+  - Core / Adapter 的具体代码结构、类层次、模块路径或 import 机制
+  - `src/**`、`scripts/**`、`tests/**` 的实现改造
+
+## 需求说明
+
+- 功能需求：
+  - Core 必须通过统一的 adapter registry 语义解析可用 adapter，而不是依赖平台特定分支、隐式默认值或调用方自行拼装运行时对象。
+  - Core 必须在不执行真实平台采集的前提下，获取“某个 adapter 是否存在”和“某个 adapter 声明支持哪些 capability”的最小发现结果。
+  - 错误模型必须为请求校验、registry 查找、adapter 契约失配和平台执行失败提供一致的失败 envelope 语义。
+  - discovery 与 lookup 的结果必须可被后续 harness、fake adapter 和 gate 复用，但本 FR 不定义这些工具本身。
+- 契约需求：
+  - 失败 envelope 的顶层字段继续由 Core 统一承载，最小结构保持 `task_id`、`adapter_key`、`capability`、`status=failed`、`error`。
+  - `error` 的最小字段固定为 `category`、`code`、`message`、`details`。
+  - `category` 在 `v0.2.0` 的最小集合固定为：
+    - `invalid_input`：请求形状、必填字段、类型或当前契约禁止的调用方式不合法，且失败发生在进入 registry 有效查找或 adapter 平台执行之前。
+    - `unsupported`：请求本身合法，但目标 adapter 或 capability 不存在，或目标存在但未声明支持该 capability。
+    - `runtime_contract`：registry、adapter 声明、capability 元数据、成功 payload 或 host-side 运行时契约失配；此类问题必须 fail-closed。
+    - `platform`：adapter 已接管平台语义，并因平台事实、登录态、签名、资源、风控或平台响应失败而无法完成执行。
+  - `invalid_input` 与 `unsupported` 必须区分：
+    - 前者表示“请求不合法，不能进入有效分发”。
+    - 后者表示“请求合法，但当前 registry / adapter 集合无法满足”。
+  - `runtime_contract` 与 `platform` 必须区分：
+    - 前者表示 Core / registry / adapter contract 破损或未满足约定。
+    - 后者表示 contract 有效，但平台执行失败。
+  - adapter registry 的最小职责固定为：
+    - 接收明确的 adapter 绑定集合并形成可查询视图
+    - 以稳定 `adapter_key` 提供唯一查找结果
+    - 暴露每个 adapter 的 capability 声明结果，供 Core 做分发前判断
+    - 对重复 key、歧义注册、无效 adapter 声明和无效 capability 元数据返回统一 fail-closed 语义
+  - adapter registry 的最小非职责固定为：
+    - 不定义模块扫描、插件市场、远程发现或 import 约定
+    - 不负责生成 `InputTarget`、`CollectionPolicy` 或平台输入
+    - 不负责 fake adapter、测试 harness 或 gate 调度
+    - 不负责平台资源准备、登录态管理或浏览器注入
+  - capability discovery 必须满足以下约束：
+    - 发现结果来源于 adapter 对外声明的稳定 capability 元数据，而不是一次真实采集结果
+    - discovery 不得要求真实平台网络访问、登录态或浏览器副作用
+    - 若 capability 声明缺失、形状非法或不可判定，Core 必须返回 `runtime_contract`，不得静默回退
+  - fail-closed 语义固定为：
+    - registry 无法形成唯一、可验证的 adapter 视图时，Core 必须返回 `runtime_contract`
+    - Core 不得在 registry 失效时推断默认 adapter、猜测 capability、跳过校验或回退到平台特定分支
+    - adapter 声明与实际返回结果不一致时，Core 必须按 `runtime_contract` 失败，而不是把缺失字段视作成功
+  - `details` 的语义固定为：
+    - `details` 用于承载机器可判定的补充上下文
+    - `invalid_input` 可承载非法字段名、非法值类型或缺失字段列表
+    - `unsupported` 可承载已知 `adapter_key` 或 capability 列表
+    - `runtime_contract` 可承载失配来源、无效字段、声明形状错误或错误类型
+    - `platform` 可承载平台 code、平台消息、资源上下文或平台提示，但不改变统一 envelope 结构
+- 非功能需求：
+  - formal spec 必须让 reviewer 在不阅读实现代码的前提下判定错误分类与 registry 边界。
+  - spec 必须保留实现自由度，不把 registry 具体方法名、类结构、模块布局或缓存策略写死。
+  - error model 与 registry 的语义必须可支撑后续双参考适配器与 fake adapter 复用，而不把这些事项提前吞入本 FR。
+
+## 约束
+
+- 阶段约束：
+  - 本事项服务于 `v0.2.0` 的“把能跑变成可验证”，只冻结共享契约，不进入实现。
+  - 本事项不能提前替代 `FR-0006` 的 harness / fake adapter / 验证工具语义，也不能替代 `FR-0007` 的 gate / regression 语义。
+- 架构约束：
+  - Core 负责统一错误 envelope、registry 消费与 fail-closed 规则；Adapter 负责平台语义与平台错误细节。
+  - 平台特定错误码、签名、登录态、反爬、浏览器桥接与资源细节不得渗入 Core 的分类规则。
+  - registry 可以由不同实现机制承载，但对 Core 暴露的查找与 discovery 语义必须稳定。
+
+## GWT 验收场景
+
+### 场景 1
+
+Given Core 持有一个已 materialize 的 adapter registry，且其中存在 `adapter_key=xhs` 并声明支持 `content_detail_by_url`  
+When 调用方向 Core 请求查找 `xhs` 并验证该 capability  
+Then Core 必须在进入平台执行前得到确定的“adapter 存在且 capability 受支持”的结论
+
+### 场景 2
+
+Given 请求的 `adapter_key` 不存在于当前 registry  
+When Core 进行 adapter 查找  
+Then Core 必须返回 `category=unsupported` 的失败 envelope，而不是推断默认 adapter 或回退到其他注册项
+
+### 场景 3
+
+Given 当前 registry 存在重复 key、歧义注册、无效 adapter 声明或无效 capability 元数据  
+When Core 尝试 materialize、discover 或 lookup  
+Then Core 必须返回 `category=runtime_contract` 的失败 envelope，并按 fail-closed 终止该次执行
+
+### 场景 4
+
+Given 请求缺少当前 contract 要求的最小字段，或字段类型不合法  
+When Core 在进入有效 registry 分发前校验请求  
+Then Core 必须返回 `category=invalid_input` 的失败 envelope
+
+### 场景 5
+
+Given adapter 已被成功查找到，且 capability 声明有效  
+When adapter 在真实平台执行过程中遇到登录失效、签名错误、内容不存在或平台风控  
+Then Core 必须返回 `category=platform` 的统一失败 envelope，并保留 adapter 提供的结构化平台细节
+
+### 场景 6
+
+Given registry 与请求都合法，但目标 adapter 未声明支持当前 capability  
+When Core 在执行前校验 capability  
+Then Core 必须返回 `category=unsupported` 的失败 envelope，而不是让 adapter 进入不受支持的执行路径
+
+## 异常与边界场景
+
+- 异常场景：
+  - registry 为空本身不自动构成 `runtime_contract`；只有当请求需要的 adapter / capability 无法满足时，才返回 `unsupported`。
+  - registry 形状非法、查找结果抛异常、capability 元数据不可判定、adapter 成功 payload 失配，都必须归入 `runtime_contract`。
+  - adapter 抛出未映射到平台语义的宿主异常时，Core 不得直接把该异常冒泡到调用方，必须按统一错误模型处理。
+- 边界场景：
+  - 本 FR 只冻结“registry 对 Core 的契约”，不规定 registry 如何从模块、配置或插件系统中构建。
+  - 本 FR 只冻结“discovery 的语义结果”，不规定后续 harness 如何调用这些结果。
+  - 本 FR 不定义 fake adapter、harness、validator、版本 gate 的目录、脚本或测试形态。
+  - `FR-0004` 负责冻结输入建模；`FR-0005` 只消费“已经合法进入分发”的请求与错误分类。
+  - `FR-0006` 负责冻结 fake adapter / harness / validator 的验证基座；`FR-0005` 只提供其依赖的 error model 与 registry contract。
+  - `FR-0007` 负责冻结 gate / regression / 平台泄漏检查流程；`FR-0005` 不直接定义这些门禁。
+
+## 验收标准
+
+- [ ] `invalid_input`、`unsupported`、`runtime_contract`、`platform` 四类错误的语义边界已冻结
+- [ ] fail-closed、invalid、unsupported 的判定条件已清楚区分
+- [ ] adapter registry 的职责、非职责与 discovery 约束已冻结
+- [ ] registry 与 adapter 生命周期 / discovery 之间的契约边界已冻结，且不要求真实平台副作用
+- [ ] spec 明确规定 registry / adapter / success payload 失配时必须走 `runtime_contract`
+- [ ] spec 明确规定平台执行失败必须走 `platform`
+- [ ] `FR-0004`、`FR-0006`、`FR-0007` 的边界，以及 `#69` / `#70` 的后续实现拆分已写清
+- [ ] 当前 formal spec PR 未混入实现代码、脚本、测试或 gate 运行时改造
+
+## 依赖与外部前提
+
+- 外部依赖：
+  - GitHub Phase `#63` 已建立 `v0.2.0` 上位阶段容器
+  - GitHub FR `#65` 已作为 canonical requirement 容器存在
+- 上下游影响：
+  - `#69` 在本 spec 基础上实现标准化错误模型，负责把错误分类映射到 Core / Adapter 运行时与失败 envelope
+  - `#70` 在本 spec 基础上实现 adapter registry，负责把注册、lookup、capability discovery 与 fail-closed 行为落到运行时
+  - `FR-0006` 后续可在本 spec 基础上为 fake adapter / harness / validator 建立可验证契约
+  - `FR-0007` 后续可在本 spec 基础上把双参考适配器回归与平台泄漏检查接入固定 gate

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -14,6 +14,7 @@
 ## 入口事项
 
 - `FR-0002-content-detail-runtime-v0-1`：`v0.1.0` 业务主线 formal spec，对应 Issue `#38`
+- `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约 formal spec，对应 Issue `#65`
 - `CHORE-0041-runtime-cli-skeleton`：`v0.1.0` 首个 runtime / CLI 实现切片，对应 Issue `#41`，受审 PR `#44`
 - `CHORE-0039-platform-facts-xhs-douyin-detail`：小红书 / 抖音 detail 平台知识提取，对应 Issue `#39`
 - `CHORE-0047-xhs-reference-adapter`：小红书参考适配器实现切片，对应 Issue `#47`，受审 PR `#48`
@@ -23,6 +24,8 @@
 - `GOV-0027-governance-contract-rewrite`：`FR-0003` 首个治理 Work Item，对应 Issue `#56`
 - `GOV-0028-harness-compat-migration`：后续 harness 兼容迁移 Work Item，对应 Issue `#57`
 - `GOV-0029-remove-legacy-todo-md`：移除 legacy `TODO.md` 的正式治理流入口，对应 Issue `#58`
+- `#69`：`FR-0005` 下的“实现标准化错误模型” Work Item
+- `#70`：`FR-0005` 下的“实现适配器注册表” Work Item
 
 ## 进入前依赖
 
@@ -53,11 +56,12 @@
 ## 本轮新增入口
 
 - `FR-0003` / `GOV-0027` 已在当前 sprint 建立治理入口；相关 formal spec、exec-plan、decision 与 release/sprint 索引工件见下方“关联工件”。
+- `FR-0005` 已在当前 sprint 建立错误模型与 adapter registry 的 formal spec 入口；后续实现拆分为 `#69` 与 `#70`。
 
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`
+- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#65`、`#69`、`#70`
 - `pre-v0.2.0` governance 事项树：`#54`、`#55`、`#56`、`#57`、`#58`
 
 ## 关联工件
@@ -66,6 +70,7 @@
 - release：`docs/releases/v0.2.0.md`
 - spec：`docs/specs/FR-0002-content-detail-runtime-v0-1/`
 - spec：`docs/specs/FR-0003-github-delivery-structure-and-repo-semantic-split/`
+- spec：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
 - research：
   - `docs/research/platforms/xhs-content-detail.md`
   - `docs/research/platforms/douyin-content-detail.md`
@@ -75,6 +80,7 @@
   - `docs/exec-plans/CHORE-0039-platform-facts-xhs-douyin-detail.md`
   - `docs/exec-plans/CHORE-0047-xhs-reference-adapter.md`
   - `docs/exec-plans/FR-0002-content-detail-runtime-v0-1.md`
+  - `docs/exec-plans/FR-0005-standardized-error-model-and-adapter-registry.md`
   - `docs/exec-plans/CHORE-0041-runtime-cli-skeleton.md`（active，绑定 Issue `#41` / PR `#44`）
   - `docs/exec-plans/CHORE-0050-douyin-reference-adapter.md`
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`


### PR DESCRIPTION
## 摘要

- PR Class: `spec`
- 变更目的：
- 主要改动：

## Issue 摘要



## 关联事项

- Issue: #65
- item_key: `FR-0005-standardized-error-model-and-adapter-registry`
- item_type: `FR`
- release: `v0.2.0`
- sprint: `2026-S15`
- Closing: Refs #65

## 风险

- 风险级别：`high`
- 审查关注：

## 验证

- 已执行：
- 未执行：

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
