### PR TITLE
feat(runtime): 接入 FR-0004 Core 共享输入模型

### DIFF
--- a/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
+++ b/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
@@ -40,7 +40,8 @@
 - 首轮 guardian 针对 PR `#90` / head `727cf564c58094b99d60d90bf739b39aaf368f6a` 给出 `REQUEST_CHANGES`：指出 `CollectionPolicy` 在 legacy adapter 投影前被静默丢失。
 - 第二轮收口已把显式 `CoreTaskRequest` 的执行路径收紧为 fail-closed：`#87` 只负责 shared model 受理与校验，不提前开放 adapter admission / execution happy path。
 - 第三轮实现收口已把 legacy `TaskRequest(input.url)` 路径纳入 shared-axis admission：adapter 现在必须显式声明 `supported_targets` 包含 `url` 且 `supported_collection_modes` 包含 `hybrid`，否则 legacy URL 流量在进入 adapter 前 fail-closed。
-- 最近一次行为 checkpoint 固定为 `3ff22df48d7a3f710c4eba67cf37437dd7f145e1`；其后若只追加 PR / exec-plan 审查态元数据，不改写运行时行为。当前受审 head 以 PR `#90` 与 guardian state 绑定为准。
+- 第四轮实现收口已把 native `CoreTaskRequest` 的 fail-closed 重新前置到 adapter lookup / shared-axis admission 之前，保持 `#87` 的边界为“显式受理 + 校验”，不提前吞并 `#89` 的 adapter admission 责任。
+- 最近一次行为 checkpoint 固定为 `3f8444d342298193c63518725edcb74ecdff1418`；其后若只追加 PR / exec-plan 审查态元数据，不改写运行时行为。当前受审 head 以 PR `#90` 与 guardian state 绑定为准。
 
 ## 下一步动作
 
@@ -70,7 +71,7 @@
 - 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 已核对：当前 `FR-0004` formal spec 已合入主干，而 `#87` 仍为 `OPEN`
 - `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter`
-  - 结果：在最近一次行为 checkpoint `3ff22df48d7a3f710c4eba67cf37437dd7f145e1` 上执行，`Ran 120 tests in 3.877s`，`OK`
+  - 结果：在最近一次行为 checkpoint `3f8444d342298193c63518725edcb74ecdff1418` 上执行，`Ran 120 tests in 4.289s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
@@ -90,6 +91,9 @@
 - guardian 次轮审查：`REQUEST_CHANGES`
   - 阻断项：legacy URL 可执行路径仍绕过 shared-axis admission，且缺少对应回归测试
   - 收口结果：legacy `TaskRequest(input.url)` 现在也必须命中 `supported_targets=url` 与 `supported_collection_modes=hybrid` 检查；真实 adapter、test fixtures 与回归用例已同步补齐
+- guardian 三轮审查：`REQUEST_CHANGES`
+  - 阻断项：native `CoreTaskRequest` 在 fail-closed 前先触发了 adapter admission，越过了 `#87` 的边界
+  - 收口结果：native shared-input 现在在 adapter lookup / shared-axis admission 前直接 fail-close；legacy URL 路径继续承担本回合允许的最小可执行语义
 
 ## 未决风险
 
@@ -103,4 +107,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `3ff22df48d7a3f710c4eba67cf37437dd7f145e1`
+- `3f8444d342298193c63518725edcb74ecdff1418`

--- a/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
+++ b/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
@@ -39,7 +39,7 @@
 - 当前独立 worktree 已建立：`/Users/mc/code/worktrees/syvert/issue-87-fr-0004-core`；实现分支 `issue-87-fr-0004-core` 已推送远端，并打开 implementation PR `#90`。
 - 首轮 guardian 针对 PR `#90` / head `727cf564c58094b99d60d90bf739b39aaf368f6a` 给出 `REQUEST_CHANGES`：指出 `CollectionPolicy` 在 legacy adapter 投影前被静默丢失。
 - 第二轮收口已把显式 `CoreTaskRequest` 的执行路径收紧为 fail-closed：`#87` 只负责 shared model 受理与校验，不提前开放 adapter admission / execution happy path；legacy `TaskRequest(input.url)` 仍保持可运行。
-- 当前停在基于 head `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2` 重新执行 guardian 复审与 merge gate。
+- 最近一次行为 checkpoint 固定为 `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2`；其后提交仅补充 PR 正文与 exec-plan 审查态元数据，不改写运行时行为。当前受审 head 以 PR `#90` 与 guardian state 绑定为准。
 
 ## 下一步动作
 
@@ -69,7 +69,8 @@
 - 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 已核对：当前 `FR-0004` formal spec 已合入主干，而 `#87` 仍为 `OPEN`
 - `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
-  - 结果：在当前 head `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2` 上执行，`Ran 65 tests in 1.936s`，`OK`
+  - 结果：在最近一次行为 checkpoint `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2` 上执行，`Ran 65 tests in 1.936s`，`OK`
+  - 说明：其后提交仅同步 PR / exec-plan 审查态元数据，不改写运行时与测试行为
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`

--- a/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
+++ b/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
@@ -1,0 +1,82 @@
+# CHORE-0087-fr-0004-core-input-admission 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0087-fr-0004-core-input-admission`
+- Issue：`#87`
+- item_type：`CHORE`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0004-input-target-and-collection-policy/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`CHORE-0087-fr-0004-core-input-admission`
+
+## 目标
+
+- 为 `FR-0004` 的首个 implementation Work Item 落地 Core 共享输入模型接入点，使运行时能够显式接收 `InputTarget` 与 `CollectionPolicy`，并完成最小结构校验。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py`
+  - `syvert/cli.py`
+  - `tests/runtime/test_models.py`
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_cli.py`
+  - `docs/releases/v0.2.0.md`
+  - `docs/sprints/2026-S15.md`
+  - 本 exec-plan
+- 本次不纳入：
+  - Core 到 Adapter 的投影与 admission 扩展
+  - `FR-0002` legacy 兼容路径 closeout
+  - adapter registry、错误模型、harness、version gate
+  - 参考适配器内部平台解析逻辑
+
+## 当前停点
+
+- `FR-0004` formal spec 已由 PR `#82` 合入主干，但 `#87` 尚未建立 implementation 回合的 active `exec-plan`、代码实现与验证证据。
+- 当前独立 worktree 已建立：`/Users/mc/code/worktrees/syvert/issue-87-fr-0004-core`。
+- 当前回合从 `origin/main@366f0ac054483a93179eec8dbfac3b2da8a6abfb` 起步，后续仅围绕 Core 输入受理与共享模型接入推进。
+
+## 下一步动作
+
+- 在运行时引入 `InputTarget`、`CollectionPolicy` 与新的 Core 请求对象。
+- 补齐最小结构校验与对应单元测试。
+- 运行 implementation 相关验证、创建 PR，并完成 `#87` closeout。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.2.0` 建立 `FR-0004` 共享输入模型的主干实现起点，使后续 `#89` 投影链路与 `#88` 兼容映射有稳定的 Core 承接面。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0004` implementation 子事项的第一步，负责把 formal spec 落到 Core 输入受理层。
+- 阻塞：
+  - 不得在当前回合引入 adapter-facing request 投影、legacy 映射 closeout 或任何平台特定字段。
+
+## 已验证项
+
+- `gh issue view 87 --repo MC-and-his-Agents/Syvert`
+- `python3 scripts/create_worktree.py --issue 87 --class implementation`
+- 已阅读：`AGENTS.md`
+- 已阅读：`WORKFLOW.md`
+- 已阅读：`docs/AGENTS.md`
+- 已阅读：`docs/process/delivery-funnel.md`
+- 已阅读：`spec_review.md`
+- 已阅读：`code_review.md`
+- 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
+- 已核对：当前 `FR-0004` formal spec 已合入主干，而 `#87` 仍为 `OPEN`
+
+## 未决风险
+
+- 若 Core 输入模型在本回合提前混入平台派生字段，会直接违背 `FR-0004` 的 Core / Adapter 边界。
+- 若在本回合把 `content_detail_by_url -> content_detail` 投影一起落地，会与 `#89` 的责任边界串线。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对运行时代码、测试、release/sprint 索引与本 exec-plan 的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `366f0ac054483a93179eec8dbfac3b2da8a6abfb`

--- a/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
+++ b/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S15`
 - 关联 spec：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#90`
 - active 收口事项：`CHORE-0087-fr-0004-core-input-admission`
 
 ## 目标
@@ -35,15 +35,15 @@
 
 ## 当前停点
 
-- `FR-0004` formal spec 已由 PR `#82` 合入主干，但 `#87` 尚未建立 implementation 回合的 active `exec-plan`、代码实现与验证证据。
-- 当前独立 worktree 已建立：`/Users/mc/code/worktrees/syvert/issue-87-fr-0004-core`。
-- 当前回合从 `origin/main@366f0ac054483a93179eec8dbfac3b2da8a6abfb` 起步，后续仅围绕 Core 输入受理与共享模型接入推进。
+- `FR-0004` formal spec 已由 PR `#82` 合入主干，`#87` 当前已完成 Core 共享输入模型接入、最小结构校验与对应测试补强。
+- 当前独立 worktree 已建立：`/Users/mc/code/worktrees/syvert/issue-87-fr-0004-core`；实现分支 `issue-87-fr-0004-core` 已推送远端，并打开 implementation PR `#90`。
+- 当前停在 review / guardian / merge gate 前的最后一致性校对阶段；后续若仅补 PR 正文、review 元数据或 guardian 收口，不单独改写实现范围。
 
 ## 下一步动作
 
-- 在运行时引入 `InputTarget`、`CollectionPolicy` 与新的 Core 请求对象。
-- 补齐最小结构校验与对应单元测试。
-- 运行 implementation 相关验证、创建 PR，并完成 `#87` closeout。
+- 完善 PR `#90` 的审查输入与验证摘要。
+- 基于当前 head 执行 guardian 审查与受控 merge。
+- 合并后关闭 `#87`，并退役当前 branch / worktree。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -67,11 +67,27 @@
 - 已阅读：`code_review.md`
 - 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 已核对：当前 `FR-0004` formal spec 已合入主干，而 `#87` 仍为 `OPEN`
+- `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
+  - 结果：`Ran 63 tests in 1.913s`，`OK`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/open_pr.py --class implementation --issue 87 --item-key CHORE-0087-fr-0004-core-input-admission --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 接入 FR-0004 Core 共享输入模型' --closing fixes --dry-run`
+  - 结果：通过
+- `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
+  - 结果：已校验 1 条提交信息，全部通过
+- `python3 -m unittest tests.runtime.test_douyin_browser_bridge.DouyinBrowserBridgeTests.test_extract_page_state_falls_back_to_authenticated_detail_request_when_page_state_misses_target`
+  - 结果：在当前分支与 `main` 基线均因本地签名服务未启动而失败，不作为本回合阻断性回归结论
+- 已创建当前受审 PR：`#90 https://github.com/MC-and-his-Agents/Syvert/pull/90`
 
 ## 未决风险
 
 - 若 Core 输入模型在本回合提前混入平台派生字段，会直接违背 `FR-0004` 的 Core / Adapter 边界。
 - 若在本回合把 `content_detail_by_url -> content_detail` 投影一起落地，会与 `#89` 的责任边界串线。
+- 当前实现对非 `url` 的合法 `target_type` 采取“结构上可受理、执行时在 legacy 投影前 fail-closed”的过渡策略；该缺口需由 `#89` 的正式 adapter-facing 契约承接完成收口。
 
 ## 回滚方式
 
@@ -79,4 +95,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `366f0ac054483a93179eec8dbfac3b2da8a6abfb`
+- `30ac9e5d1f7a05c316fd928c6ad689ff8ca56ea7`

--- a/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
+++ b/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
@@ -37,7 +37,9 @@
 
 - `FR-0004` formal spec 已由 PR `#82` 合入主干，`#87` 当前已完成 Core 共享输入模型接入、最小结构校验与对应测试补强。
 - 当前独立 worktree 已建立：`/Users/mc/code/worktrees/syvert/issue-87-fr-0004-core`；实现分支 `issue-87-fr-0004-core` 已推送远端，并打开 implementation PR `#90`。
-- 首轮 guardian 针对 PR `#90` / head `727cf564c58094b99d60d90bf739b39aaf368f6a` 给出 `REQUEST_CHANGES`：指出 `CollectionPolicy` 在 legacy adapter 投影前被静默丢失。当前已按“过渡路径只允许 `collection_mode=hybrid`，`public/authenticated` fail-closed”完成收口，等待第二轮 guardian 复审。
+- 首轮 guardian 针对 PR `#90` / head `727cf564c58094b99d60d90bf739b39aaf368f6a` 给出 `REQUEST_CHANGES`：指出 `CollectionPolicy` 在 legacy adapter 投影前被静默丢失。
+- 第二轮收口已把显式 `CoreTaskRequest` 的执行路径收紧为 fail-closed：`#87` 只负责 shared model 受理与校验，不提前开放 adapter admission / execution happy path；legacy `TaskRequest(input.url)` 仍保持可运行。
+- 当前停在基于 head `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2` 重新执行 guardian 复审与 merge gate。
 
 ## 下一步动作
 
@@ -67,7 +69,7 @@
 - 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 已核对：当前 `FR-0004` formal spec 已合入主干，而 `#87` 仍为 `OPEN`
 - `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
-  - 结果：`Ran 65 tests in 2.171s`，`OK`
+  - 结果：在当前 head `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2` 上执行，`Ran 65 tests in 1.936s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
@@ -83,7 +85,7 @@
 - 已创建当前受审 PR：`#90 https://github.com/MC-and-his-Agents/Syvert/pull/90`
 - guardian 首轮审查：`REQUEST_CHANGES`
   - 阻断项：`CollectionPolicy` 在执行前被 legacy 投影静默丢弃
-  - 收口结果：当前运行时过渡路径仅允许 `collection_mode=hybrid`；`public` / `authenticated` 在进入 adapter 前 fail-closed，并已补定点回归测试
+  - 收口结果：当前运行时过渡路径仅允许 legacy `TaskRequest(input.url)`；显式 shared-input 请求在进入 adapter 前 fail-closed，避免绕过 `#89` 才应落地的 shared-axis admission
 
 ## 未决风险
 
@@ -97,4 +99,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `727cf564c58094b99d60d90bf739b39aaf368f6a`
+- `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2`

--- a/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
+++ b/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
@@ -38,8 +38,9 @@
 - `FR-0004` formal spec 已由 PR `#82` 合入主干，`#87` 当前已完成 Core 共享输入模型接入、最小结构校验与对应测试补强。
 - 当前独立 worktree 已建立：`/Users/mc/code/worktrees/syvert/issue-87-fr-0004-core`；实现分支 `issue-87-fr-0004-core` 已推送远端，并打开 implementation PR `#90`。
 - 首轮 guardian 针对 PR `#90` / head `727cf564c58094b99d60d90bf739b39aaf368f6a` 给出 `REQUEST_CHANGES`：指出 `CollectionPolicy` 在 legacy adapter 投影前被静默丢失。
-- 第二轮收口已把显式 `CoreTaskRequest` 的执行路径收紧为 fail-closed：`#87` 只负责 shared model 受理与校验，不提前开放 adapter admission / execution happy path；legacy `TaskRequest(input.url)` 仍保持可运行。
-- 最近一次行为 checkpoint 固定为 `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2`；其后提交仅补充 PR 正文与 exec-plan 审查态元数据，不改写运行时行为。当前受审 head 以 PR `#90` 与 guardian state 绑定为准。
+- 第二轮收口已把显式 `CoreTaskRequest` 的执行路径收紧为 fail-closed：`#87` 只负责 shared model 受理与校验，不提前开放 adapter admission / execution happy path。
+- 第三轮实现收口已把 legacy `TaskRequest(input.url)` 路径纳入 shared-axis admission：adapter 现在必须显式声明 `supported_targets` 包含 `url` 且 `supported_collection_modes` 包含 `hybrid`，否则 legacy URL 流量在进入 adapter 前 fail-closed。
+- 最近一次行为 checkpoint 固定为 `3ff22df48d7a3f710c4eba67cf37437dd7f145e1`；其后若只追加 PR / exec-plan 审查态元数据，不改写运行时行为。当前受审 head 以 PR `#90` 与 guardian state 绑定为准。
 
 ## 下一步动作
 
@@ -68,9 +69,8 @@
 - 已阅读：`code_review.md`
 - 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 已核对：当前 `FR-0004` formal spec 已合入主干，而 `#87` 仍为 `OPEN`
-- `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
-  - 结果：在最近一次行为 checkpoint `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2` 上执行，`Ran 65 tests in 1.936s`，`OK`
-  - 说明：其后提交仅同步 PR / exec-plan 审查态元数据，不改写运行时与测试行为
+- `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter`
+  - 结果：在最近一次行为 checkpoint `3ff22df48d7a3f710c4eba67cf37437dd7f145e1` 上执行，`Ran 120 tests in 3.877s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
@@ -86,7 +86,10 @@
 - 已创建当前受审 PR：`#90 https://github.com/MC-and-his-Agents/Syvert/pull/90`
 - guardian 首轮审查：`REQUEST_CHANGES`
   - 阻断项：`CollectionPolicy` 在执行前被 legacy 投影静默丢弃
-  - 收口结果：当前运行时过渡路径仅允许 legacy `TaskRequest(input.url)`；显式 shared-input 请求在进入 adapter 前 fail-closed，避免绕过 `#89` 才应落地的 shared-axis admission
+  - 收口结果：显式 shared-input 请求在进入 adapter 前 fail-closed，避免绕过 `#89` 才应落地的 shared-axis admission
+- guardian 次轮审查：`REQUEST_CHANGES`
+  - 阻断项：legacy URL 可执行路径仍绕过 shared-axis admission，且缺少对应回归测试
+  - 收口结果：legacy `TaskRequest(input.url)` 现在也必须命中 `supported_targets=url` 与 `supported_collection_modes=hybrid` 检查；真实 adapter、test fixtures 与回归用例已同步补齐
 
 ## 未决风险
 
@@ -100,4 +103,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `e11e4ec760ebe9fd724b5f7a19b85d99e22e30a2`
+- `3ff22df48d7a3f710c4eba67cf37437dd7f145e1`

--- a/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
+++ b/docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md
@@ -37,12 +37,11 @@
 
 - `FR-0004` formal spec 已由 PR `#82` 合入主干，`#87` 当前已完成 Core 共享输入模型接入、最小结构校验与对应测试补强。
 - 当前独立 worktree 已建立：`/Users/mc/code/worktrees/syvert/issue-87-fr-0004-core`；实现分支 `issue-87-fr-0004-core` 已推送远端，并打开 implementation PR `#90`。
-- 当前停在 review / guardian / merge gate 前的最后一致性校对阶段；后续若仅补 PR 正文、review 元数据或 guardian 收口，不单独改写实现范围。
+- 首轮 guardian 针对 PR `#90` / head `727cf564c58094b99d60d90bf739b39aaf368f6a` 给出 `REQUEST_CHANGES`：指出 `CollectionPolicy` 在 legacy adapter 投影前被静默丢失。当前已按“过渡路径只允许 `collection_mode=hybrid`，`public/authenticated` fail-closed”完成收口，等待第二轮 guardian 复审。
 
 ## 下一步动作
 
-- 完善 PR `#90` 的审查输入与验证摘要。
-- 基于当前 head 执行 guardian 审查与受控 merge。
+- 基于当前 head 重跑 guardian 审查与受控 merge。
 - 合并后关闭 `#87`，并退役当前 branch / worktree。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -68,7 +67,7 @@
 - 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 已核对：当前 `FR-0004` formal spec 已合入主干，而 `#87` 仍为 `OPEN`
 - `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
-  - 结果：`Ran 63 tests in 1.913s`，`OK`
+  - 结果：`Ran 65 tests in 2.171s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
@@ -82,6 +81,9 @@
 - `python3 -m unittest tests.runtime.test_douyin_browser_bridge.DouyinBrowserBridgeTests.test_extract_page_state_falls_back_to_authenticated_detail_request_when_page_state_misses_target`
   - 结果：在当前分支与 `main` 基线均因本地签名服务未启动而失败，不作为本回合阻断性回归结论
 - 已创建当前受审 PR：`#90 https://github.com/MC-and-his-Agents/Syvert/pull/90`
+- guardian 首轮审查：`REQUEST_CHANGES`
+  - 阻断项：`CollectionPolicy` 在执行前被 legacy 投影静默丢弃
+  - 收口结果：当前运行时过渡路径仅允许 `collection_mode=hybrid`；`public` / `authenticated` 在进入 adapter 前 fail-closed，并已补定点回归测试
 
 ## 未决风险
 
@@ -95,4 +97,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `30ac9e5d1f7a05c316fd928c6ad689ff8ca56ea7`
+- `727cf564c58094b99d60d90bf739b39aaf368f6a`

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -26,6 +26,7 @@
 - `FR-0007-release-gate-and-regression-checks`：版本 gate 与回归检查 requirement，对应 Issue `#67`
 - `CHORE-0079-fr-0007-formal-spec-closeout`：`FR-0007` formal spec 收口 Work Item，对应 Issue `#79`
 - `FR-0004-input-target-and-collection-policy`：`v0.2.0` 共享输入模型与采集策略模型，对应 Issue `#64`
+- `CHORE-0087-fr-0004-core-input-admission`：`FR-0004` Core 输入受理与共享模型接入，对应 Issue `#87`
 - `FR-0006-adapter-contract-test-harness`：`v0.2.0` adapter contract test harness formal spec，对应 Issue `#66`
 - `CHORE-0051-fr-0006-formal-spec-closeout`：`FR-0006` formal spec PR closeout Work Item，对应 Issue `#74`
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约主线之一，对应 Issue `#65`
@@ -55,6 +56,7 @@
   - `docs/specs/FR-0007-release-gate-and-regression-checks/`
 - exec-plan：
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md`
   - `docs/exec-plans/CHORE-0051-fr-0005-formal-spec.md`
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -15,6 +15,7 @@
 
 - `FR-0002-content-detail-runtime-v0-1`：`v0.1.0` 业务主线 formal spec，对应 Issue `#38`
 - `FR-0004-input-target-and-collection-policy`：`v0.2.0` 共享输入模型与采集策略 formal spec，对应 FR `#64` 与 spec Work Item `#68`
+- `CHORE-0087-fr-0004-core-input-admission`：`FR-0004` Core 输入受理与共享模型接入，对应 Issue `#87`
 - `FR-0006-adapter-contract-test-harness`：`v0.2.0` adapter contract test harness formal spec，对应 Issue `#66`
 - `CHORE-0051-fr-0006-formal-spec-closeout`：`FR-0006` formal spec PR closeout Work Item，对应 Issue `#74`
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约 formal spec，对应 Phase `#63` 下的 FR `#65`
@@ -68,6 +69,7 @@
 - `FR-0003` / `GOV-0027` 已在当前 sprint 建立治理入口；相关 formal spec、exec-plan、decision 与 release/sprint 索引工件见下方“关联工件”。
 - `FR-0007` 已在当前 sprint 建立版本 gate formal spec 入口，为后续 contract harness / 回归检查实现回合提供 requirement 基线。
 - `FR-0004` / `#68` 已在当前 sprint 建立共享输入模型与采集策略的 formal spec 入口。
+- `CHORE-0087` 已在当前 sprint 建立 `FR-0004` 的首个 implementation 入口，负责把共享输入模型接入 Core 输入受理层。
 - `FR-0006` 已在当前 sprint 建立 `v0.2.0` contract harness formal spec 入口；`CHORE-0051` 负责当前 formal spec PR 的受控 closeout。
 - `FR-0005` 已在当前 sprint 建立错误模型与 adapter registry 的 formal spec 入口；后续实现拆分为 `#69` 与 `#70`。
 - `CHORE-0051` 已为 `FR-0005` 提供独立 Work Item 执行入口，负责 formal spec PR、checks、guardian 与 merge gate。
@@ -76,9 +78,9 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`
+- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`、`#87`
 - `pre-v0.2.0` governance 事项树：`#54`、`#55`、`#56`、`#57`、`#58`
-- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`
+- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`、`#87`
 
 ## 关联工件
 
@@ -103,6 +105,7 @@
   - `docs/exec-plans/CHORE-0041-runtime-cli-skeleton.md`（active，绑定 Issue `#41` / PR `#44`）
   - `docs/exec-plans/CHORE-0050-douyin-reference-adapter.md`
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md`
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`
   - `docs/exec-plans/GOV-0028-harness-compat-migration.md`

--- a/syvert/adapters/douyin.py
+++ b/syvert/adapters/douyin.py
@@ -46,6 +46,8 @@ PageStateTransport = Callable[..., Mapping[str, Any]]
 class DouyinAdapter:
     adapter_key = "douyin"
     supported_capabilities = frozenset({CONTENT_DETAIL_BY_URL})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def __init__(
         self,

--- a/syvert/adapters/xhs.py
+++ b/syvert/adapters/xhs.py
@@ -47,6 +47,8 @@ PageStateTransport = Callable[..., Mapping[str, Any]]
 class XhsAdapter:
     adapter_key = "xhs"
     supported_capabilities = frozenset({CONTENT_DETAIL_BY_URL})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def __init__(
         self,

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -8,21 +8,43 @@ from uuid import uuid4
 
 
 CONTENT_DETAIL_BY_URL = "content_detail_by_url"
+LEGACY_COLLECTION_MODE = "hybrid"
+ALLOWED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
+ALLOWED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
 ALLOWED_CONTENT_TYPES = {"video", "image_post", "mixed_media", "unknown"}
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 MISSING = object()
 
 
 @dataclass(frozen=True)
-class TaskRequest:
-    adapter_key: str
-    capability: str
-    input: "TaskInput"
+class TaskInput:
+    url: str
 
 
 @dataclass(frozen=True)
-class TaskInput:
-    url: str
+class InputTarget:
+    adapter_key: str
+    capability: str
+    target_type: str
+    target_value: str
+
+
+@dataclass(frozen=True)
+class CollectionPolicy:
+    collection_mode: str
+
+
+@dataclass(frozen=True)
+class CoreTaskRequest:
+    target: InputTarget
+    policy: CollectionPolicy
+
+
+@dataclass(frozen=True)
+class TaskRequest:
+    adapter_key: str
+    capability: str
+    input: TaskInput
 
 
 @dataclass
@@ -40,7 +62,7 @@ def default_task_id_factory() -> str:
 
 
 def execute_task(
-    request: TaskRequest,
+    request: TaskRequest | CoreTaskRequest,
     *,
     adapters: Mapping[str, Any],
     task_id_factory: Callable[[], str] | None = None,
@@ -50,9 +72,19 @@ def execute_task(
     if task_id_error is not None:
         return failure_envelope(task_id, adapter_key, capability, task_id_error)
 
-    contract_error = validate_request(request)
+    normalized_request, contract_error = normalize_request(request)
     if contract_error is not None:
         return failure_envelope(task_id, adapter_key, capability, contract_error)
+    if normalized_request is None:
+        return failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error("invalid_task_request", "task_request 顶层形状不合法"),
+        )
+
+    adapter_key = normalized_request.target.adapter_key
+    capability = normalized_request.target.capability
 
     adapter, adapter_error = get_adapter(adapters, adapter_key)
     if adapter_error is not None:
@@ -90,8 +122,12 @@ def execute_task(
             },
         )
 
+    adapter_request, projection_error = project_to_adapter_request(normalized_request)
+    if projection_error is not None:
+        return failure_envelope(task_id, adapter_key, capability, projection_error)
+
     try:
-        payload = adapter.execute(request)
+        payload = adapter.execute(adapter_request)
         payload_error = validate_success_payload(payload)
         if payload_error is not None:
             return failure_envelope(task_id, adapter_key, capability, payload_error)
@@ -129,23 +165,82 @@ def execute_task(
 
 
 def validate_request(request: Any) -> dict[str, Any] | None:
-    if type(request) is not TaskRequest:
-        return runtime_contract_error("invalid_task_request", "task_request 顶层形状不合法")
-    if not isinstance(request.adapter_key, str) or not request.adapter_key:
-        return runtime_contract_error("invalid_task_request", "adapter_key 不能为空")
-    if request.capability != CONTENT_DETAIL_BY_URL:
-        return runtime_contract_error(
+    _, error = normalize_request(request)
+    return error
+
+
+def normalize_request(request: Any) -> tuple[CoreTaskRequest | None, dict[str, Any] | None]:
+    if type(request) is TaskRequest:
+        if not isinstance(request.adapter_key, str) or not request.adapter_key:
+            return None, runtime_contract_error("invalid_task_request", "adapter_key 不能为空")
+        if request.capability != CONTENT_DETAIL_BY_URL:
+            return None, runtime_contract_error(
+                "invalid_capability",
+                f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
+            )
+        if type(request.input) is not TaskInput:
+            return None, runtime_contract_error("invalid_task_request", "input 必须为对象")
+        if not isinstance(request.input.url, str) or not request.input.url:
+            return None, runtime_contract_error("invalid_task_request", "input.url 不能为空")
+        return (
+            CoreTaskRequest(
+                target=InputTarget(
+                    adapter_key=request.adapter_key,
+                    capability=request.capability,
+                    target_type="url",
+                    target_value=request.input.url,
+                ),
+                policy=CollectionPolicy(collection_mode=LEGACY_COLLECTION_MODE),
+            ),
+            None,
+        )
+    if type(request) is not CoreTaskRequest:
+        return None, runtime_contract_error("invalid_task_request", "task_request 顶层形状不合法")
+    if type(request.target) is not InputTarget:
+        return None, runtime_contract_error("invalid_task_request", "target 必须为对象")
+    if type(request.policy) is not CollectionPolicy:
+        return None, runtime_contract_error("invalid_task_request", "policy 必须为对象")
+
+    target = request.target
+    policy = request.policy
+    if not isinstance(target.adapter_key, str) or not target.adapter_key:
+        return None, runtime_contract_error("invalid_task_request", "adapter_key 不能为空")
+    if target.capability != CONTENT_DETAIL_BY_URL:
+        return None, runtime_contract_error(
             "invalid_capability",
             f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
         )
-    if type(request.input) is not TaskInput:
-        return runtime_contract_error("invalid_task_request", "input 必须为对象")
-    if not isinstance(request.input.url, str) or not request.input.url:
-        return runtime_contract_error("invalid_task_request", "input.url 不能为空")
-    return None
+    if not isinstance(target.target_value, str) or not target.target_value:
+        return None, runtime_contract_error("invalid_task_request", "target_value 不能为空")
+    if not isinstance(target.target_type, str) or target.target_type not in ALLOWED_TARGET_TYPES:
+        return None, runtime_contract_error("invalid_task_request", "target_type 不合法")
+    if not isinstance(policy.collection_mode, str) or policy.collection_mode not in ALLOWED_COLLECTION_MODES:
+        return None, runtime_contract_error("invalid_task_request", "collection_mode 不合法")
+    return request, None
+
+
+def project_to_adapter_request(request: CoreTaskRequest) -> tuple[TaskRequest | None, dict[str, Any] | None]:
+    if request.target.target_type != "url":
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_task_request",
+                "当前运行时过渡路径仅支持 target_type=url",
+            ),
+        )
+    return (
+        TaskRequest(
+        adapter_key=request.target.adapter_key,
+        capability=request.target.capability,
+        input=TaskInput(url=request.target.target_value),
+        ),
+        None,
+    )
 
 
 def extract_request_context(request: Any) -> tuple[str, str]:
+    adapter_key: Any = ""
+    capability: Any = ""
     if isinstance(request, Mapping):
         try:
             adapter_key = request.get("adapter_key")
@@ -155,6 +250,20 @@ def extract_request_context(request: Any) -> tuple[str, str]:
             capability = request.get("capability")
         except Exception:
             capability = ""
+        if not isinstance(adapter_key, str) or not adapter_key:
+            try:
+                target = request.get("target")
+            except Exception:
+                target = None
+            if isinstance(target, Mapping):
+                try:
+                    adapter_key = target.get("adapter_key", "")
+                except Exception:
+                    adapter_key = ""
+                try:
+                    capability = target.get("capability", capability)
+                except Exception:
+                    capability = capability
     else:
         try:
             adapter_key = getattr(request, "adapter_key", "")
@@ -164,6 +273,20 @@ def extract_request_context(request: Any) -> tuple[str, str]:
             capability = getattr(request, "capability", "")
         except Exception:
             capability = ""
+        if (not isinstance(adapter_key, str) or not adapter_key) or (not isinstance(capability, str) or not capability):
+            try:
+                target = getattr(request, "target", None)
+            except Exception:
+                target = None
+            if target is not None:
+                try:
+                    adapter_key = getattr(target, "adapter_key", adapter_key)
+                except Exception:
+                    adapter_key = adapter_key
+                try:
+                    capability = getattr(target, "capability", capability)
+                except Exception:
+                    capability = capability
     safe_adapter_key = adapter_key if isinstance(adapter_key, str) else ""
     safe_capability = capability if isinstance(capability, str) else ""
     return safe_adapter_key, safe_capability

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -228,6 +228,14 @@ def project_to_adapter_request(request: CoreTaskRequest) -> tuple[TaskRequest | 
                 "当前运行时过渡路径仅支持 target_type=url",
             ),
         )
+    if request.policy.collection_mode != LEGACY_COLLECTION_MODE:
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_task_request",
+                "当前运行时过渡路径仅支持 collection_mode=hybrid",
+            ),
+        )
     return (
         TaskRequest(
         adapter_key=request.target.adapter_key,

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -85,6 +85,16 @@ def execute_task(
 
     adapter_key = normalized_request.target.adapter_key
     capability = normalized_request.target.capability
+    if type(request) is CoreTaskRequest:
+        return failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error(
+                "invalid_task_request",
+                "当前共享输入执行路径尚未完成 adapter admission 承接",
+            ),
+        )
 
     adapter, adapter_error = get_adapter(adapters, adapter_key)
     if adapter_error is not None:
@@ -154,17 +164,6 @@ def execute_task(
                 "message": f"adapter `{adapter_key}` 不支持 collection_mode `{normalized_request.policy.collection_mode}`",
                 "details": {"supported_collection_modes": sorted(supported_collection_modes)},
             },
-        )
-
-    if type(request) is CoreTaskRequest:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            runtime_contract_error(
-                "invalid_task_request",
-                "当前共享输入执行路径尚未完成 adapter admission 承接",
-            ),
         )
 
     adapter_request, projection_error = project_to_adapter_request(normalized_request)

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -85,6 +85,16 @@ def execute_task(
 
     adapter_key = normalized_request.target.adapter_key
     capability = normalized_request.target.capability
+    if type(request) is CoreTaskRequest:
+        return failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error(
+                "invalid_task_request",
+                "当前共享输入执行路径尚未完成 adapter admission 承接",
+            ),
+        )
 
     adapter, adapter_error = get_adapter(adapters, adapter_key)
     if adapter_error is not None:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -85,16 +85,6 @@ def execute_task(
 
     adapter_key = normalized_request.target.adapter_key
     capability = normalized_request.target.capability
-    if type(request) is CoreTaskRequest:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            runtime_contract_error(
-                "invalid_task_request",
-                "当前共享输入执行路径尚未完成 adapter admission 承接",
-            ),
-        )
 
     adapter, adapter_error = get_adapter(adapters, adapter_key)
     if adapter_error is not None:
@@ -130,6 +120,51 @@ def execute_task(
                     "supported_capabilities": sorted(supported_capabilities),
                 },
             },
+        )
+
+    supported_targets, targets_error = validate_supported_targets(get_adapter_supported_targets(adapter))
+    if targets_error is not None:
+        return failure_envelope(task_id, adapter_key, capability, targets_error)
+    if normalized_request.target.target_type not in supported_targets:
+        return failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            {
+                "category": "runtime_contract",
+                "code": "target_type_not_supported",
+                "message": f"adapter `{adapter_key}` 不支持 target_type `{normalized_request.target.target_type}`",
+                "details": {"supported_targets": sorted(supported_targets)},
+            },
+        )
+
+    supported_collection_modes, collection_modes_error = validate_supported_collection_modes(
+        get_adapter_supported_collection_modes(adapter)
+    )
+    if collection_modes_error is not None:
+        return failure_envelope(task_id, adapter_key, capability, collection_modes_error)
+    if normalized_request.policy.collection_mode not in supported_collection_modes:
+        return failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            {
+                "category": "runtime_contract",
+                "code": "collection_mode_not_supported",
+                "message": f"adapter `{adapter_key}` 不支持 collection_mode `{normalized_request.policy.collection_mode}`",
+                "details": {"supported_collection_modes": sorted(supported_collection_modes)},
+            },
+        )
+
+    if type(request) is CoreTaskRequest:
+        return failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error(
+                "invalid_task_request",
+                "当前共享输入执行路径尚未完成 adapter admission 承接",
+            ),
         )
 
     adapter_request, projection_error = project_to_adapter_request(normalized_request)
@@ -343,6 +378,24 @@ def get_adapter_supported_capabilities(adapter: Any) -> Any:
         return MISSING
 
 
+def get_adapter_supported_targets(adapter: Any) -> Any:
+    try:
+        return getattr(adapter, "supported_targets")
+    except AttributeError:
+        return MISSING
+    except Exception:
+        return MISSING
+
+
+def get_adapter_supported_collection_modes(adapter: Any) -> Any:
+    try:
+        return getattr(adapter, "supported_collection_modes")
+    except AttributeError:
+        return MISSING
+    except Exception:
+        return MISSING
+
+
 def validate_supported_capabilities(raw_capabilities: Any) -> tuple[frozenset[str], dict[str, Any] | None]:
     if raw_capabilities is MISSING:
         return frozenset(), runtime_contract_error(
@@ -384,6 +437,73 @@ def validate_supported_capabilities(raw_capabilities: Any) -> tuple[frozenset[st
         return frozenset(), runtime_contract_error(
             "invalid_adapter_capabilities",
             "supported_capabilities 必须为字符串集合",
+            details={"error_type": error.__class__.__name__},
+        )
+    return frozenset(validated), None
+
+
+def validate_supported_targets(raw_targets: Any) -> tuple[frozenset[str], dict[str, Any] | None]:
+    return validate_supported_axis(
+        raw_targets,
+        missing_code="invalid_adapter_targets",
+        message="supported_targets 必须为字符串集合",
+    )
+
+
+def validate_supported_collection_modes(raw_modes: Any) -> tuple[frozenset[str], dict[str, Any] | None]:
+    return validate_supported_axis(
+        raw_modes,
+        missing_code="invalid_adapter_collection_modes",
+        message="supported_collection_modes 必须为字符串集合",
+    )
+
+
+def validate_supported_axis(
+    raw_values: Any,
+    *,
+    missing_code: str,
+    message: str,
+) -> tuple[frozenset[str], dict[str, Any] | None]:
+    if raw_values is MISSING:
+        return frozenset(), runtime_contract_error(
+            missing_code,
+            message,
+            details={"reason": "missing"},
+        )
+    if raw_values is None:
+        return frozenset(), runtime_contract_error(
+            missing_code,
+            message,
+            details={"actual_type": "NoneType"},
+        )
+    if isinstance(raw_values, (str, bytes)):
+        return frozenset(), runtime_contract_error(
+            missing_code,
+            message,
+            details={"actual_type": type(raw_values).__name__},
+        )
+    try:
+        iterator = iter(raw_values)
+    except TypeError:
+        return frozenset(), runtime_contract_error(
+            missing_code,
+            message,
+            details={"actual_type": type(raw_values).__name__},
+        )
+    validated: list[str] = []
+    try:
+        for value in iterator:
+            if not isinstance(value, str):
+                return frozenset(), runtime_contract_error(
+                    missing_code,
+                    message,
+                    details={"invalid_value_type": type(value).__name__},
+                )
+            validated.append(value)
+    except Exception as error:
+        return frozenset(), runtime_contract_error(
+            missing_code,
+            message,
             details={"error_type": error.__class__.__name__},
         )
     return frozenset(validated), None

--- a/tests/runtime/adapter_fixtures.py
+++ b/tests/runtime/adapter_fixtures.py
@@ -6,6 +6,8 @@ from syvert.runtime import TaskRequest
 class SuccessfulAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {
@@ -41,6 +43,8 @@ class SuccessfulAdapter:
 class UnserializableSuccessAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -16,6 +16,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 class SuccessfulAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request):
         url = request.input.url

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -8,6 +8,8 @@ from syvert.runtime import TaskInput, TaskRequest, execute_task
 class SuccessfulAdapter:
     adapter_key = "xhs"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {
@@ -43,6 +45,8 @@ class SuccessfulAdapter:
 class UnsupportedCapabilityAdapter:
     adapter_key = "xhs"
     supported_capabilities = frozenset({"creator_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         raise AssertionError("execute should not be called")

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import unittest
 
-from syvert.runtime import TaskInput, TaskRequest, validate_request, validate_success_payload
+from syvert.runtime import (
+    CollectionPolicy,
+    CoreTaskRequest,
+    InputTarget,
+    TaskInput,
+    TaskRequest,
+    validate_request,
+    validate_success_payload,
+)
+
+
+@dataclass(frozen=True)
+class ExtendedInputTarget(InputTarget):
+    note_id: str
 
 
 class TaskRequestValidationTests(unittest.TestCase):
@@ -56,6 +70,84 @@ class TaskRequestValidationTests(unittest.TestCase):
             adapter_key="xhs",
             capability="content_detail_by_url",
             input=TaskInput(url=""),
+        )
+
+        error = validate_request(request)
+
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "invalid_task_request")
+
+    def test_accepts_core_request_model(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://www.xiaohongshu.com/explore/abc123",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        self.assertIsNone(validate_request(request))
+
+    def test_rejects_empty_target_value(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        error = validate_request(request)
+
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "invalid_task_request")
+
+    def test_rejects_unknown_target_type(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                target_type="unknown_type",
+                target_value="https://www.xiaohongshu.com/explore/abc123",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        error = validate_request(request)
+
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "invalid_task_request")
+
+    def test_rejects_unknown_collection_mode(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://www.xiaohongshu.com/explore/abc123",
+            ),
+            policy=CollectionPolicy(collection_mode="private"),
+        )
+
+        error = validate_request(request)
+
+        self.assertIsNotNone(error)
+        self.assertEqual(error["code"], "invalid_task_request")
+
+    def test_rejects_extended_target_shape_with_platform_specific_fields(self) -> None:
+        request = CoreTaskRequest(
+            target=ExtendedInputTarget(
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://www.xiaohongshu.com/explore/abc123",
+                note_id="66fad51c000000001b0224b8",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
         )
 
         error = validate_request(request)

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -27,6 +27,8 @@ class ExtendedTaskRequest(TaskRequest):
 class SuccessfulAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         self.last_request = request
@@ -66,6 +68,8 @@ class SuccessfulAdapter:
 class MissingRawAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {
@@ -100,6 +104,8 @@ class MissingRawAdapter:
 class NonePayloadAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest):
         return None
@@ -108,6 +114,8 @@ class NonePayloadAdapter:
 class ListPayloadAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest):
         return []
@@ -116,6 +124,8 @@ class ListPayloadAdapter:
 class CrashingAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest):
         raise RuntimeError("boom")
@@ -124,6 +134,8 @@ class CrashingAdapter:
 class PlatformErrorWithBadDetailsAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest):
         from syvert.runtime import PlatformAdapterError
@@ -134,6 +146,8 @@ class PlatformErrorWithBadDetailsAdapter:
 class PlatformFailureAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         raise PlatformAdapterError(
@@ -196,6 +210,25 @@ class ExplodingAdapterRegistry(dict):
 class ExplodingRequestMapping(dict):
     def get(self, key, default=None):
         raise RuntimeError("boom")
+
+
+class MissingTargetsAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
+class UnsupportedHybridCollectionModeAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"authenticated"})
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
 
 
 class RuntimeExecutionTests(unittest.TestCase):
@@ -305,7 +338,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+        self.assertEqual(envelope["error"]["code"], "target_type_not_supported")
 
     def test_execute_task_rejects_public_collection_mode_before_legacy_projection(self) -> None:
         request = CoreTaskRequest(
@@ -326,7 +359,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
 
     def test_execute_task_rejects_authenticated_collection_mode_before_legacy_projection(self) -> None:
         request = CoreTaskRequest(
@@ -347,7 +380,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
 
     def test_execute_task_rejects_unknown_adapter_as_runtime_contract_failure(self) -> None:
         request = TaskRequest(
@@ -366,6 +399,40 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "adapter_not_found")
+
+    def test_execute_task_rejects_legacy_request_when_adapter_lacks_supported_targets(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/1"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": MissingTargetsAdapter()},
+            task_id_factory=lambda: "task-missing-targets",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_adapter_targets")
+
+    def test_execute_task_rejects_legacy_request_when_adapter_does_not_declare_hybrid_mode(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/1"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": UnsupportedHybridCollectionModeAdapter()},
+            task_id_factory=lambda: "task-unsupported-hybrid",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
 
     def test_execute_task_rejects_unsupported_capability(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -308,6 +308,48 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
+    def test_execute_task_rejects_public_collection_mode_before_legacy_projection(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/2",
+            ),
+            policy=CollectionPolicy(collection_mode="public"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-public-mode",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+
+    def test_execute_task_rejects_authenticated_collection_mode_before_legacy_projection(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/2",
+            ),
+            policy=CollectionPolicy(collection_mode="authenticated"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-authenticated-mode",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+
     def test_execute_task_rejects_unknown_adapter_as_runtime_contract_failure(self) -> None:
         request = TaskRequest(
             adapter_key="missing",

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 import unittest
 
-from syvert.runtime import PlatformAdapterError, TaskInput, TaskRequest, execute_task
+from syvert.runtime import (
+    CollectionPolicy,
+    CoreTaskRequest,
+    InputTarget,
+    PlatformAdapterError,
+    TaskInput,
+    TaskRequest,
+    execute_task,
+)
 
 
 @dataclass(frozen=True)
@@ -212,6 +220,93 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertIn("raw", envelope)
         self.assertEqual(envelope["normalized"]["canonical_url"], request.input.url)
         self.assertEqual(adapter.last_request.input.url, request.input.url)
+
+    def test_execute_task_accepts_core_request_shape(self) -> None:
+        adapter = SuccessfulAdapter()
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/2",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": adapter},
+            task_id_factory=lambda: "task-001b",
+        )
+
+        self.assertEqual(envelope["task_id"], "task-001b")
+        self.assertEqual(envelope["status"], "success")
+        self.assertEqual(envelope["adapter_key"], "stub")
+        self.assertEqual(envelope["normalized"]["canonical_url"], "https://example.com/posts/2")
+        self.assertEqual(adapter.last_request.input.url, "https://example.com/posts/2")
+
+    def test_execute_task_rejects_unknown_target_type(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="unknown_type",
+                target_value="https://example.com/posts/2",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-invalid-target-type",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+
+    def test_execute_task_rejects_unknown_collection_mode(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/2",
+            ),
+            policy=CollectionPolicy(collection_mode="private"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-invalid-collection-mode",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+
+    def test_execute_task_rejects_non_url_target_before_legacy_projection(self) -> None:
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="content_id",
+                target_value="abc123",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-non-url-target",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_unknown_adapter_as_runtime_contract_failure(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -338,7 +338,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "target_type_not_supported")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_public_collection_mode_before_legacy_projection(self) -> None:
         request = CoreTaskRequest(
@@ -359,7 +359,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_authenticated_collection_mode_before_legacy_projection(self) -> None:
         request = CoreTaskRequest(
@@ -380,7 +380,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_unknown_adapter_as_runtime_contract_failure(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -221,8 +221,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["normalized"]["canonical_url"], request.input.url)
         self.assertEqual(adapter.last_request.input.url, request.input.url)
 
-    def test_execute_task_accepts_core_request_shape(self) -> None:
-        adapter = SuccessfulAdapter()
+    def test_execute_task_fails_closed_for_core_request_shape_before_shared_axis_admission(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -235,15 +234,15 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": adapter},
+            adapters={"stub": SuccessfulAdapter()},
             task_id_factory=lambda: "task-001b",
         )
 
         self.assertEqual(envelope["task_id"], "task-001b")
-        self.assertEqual(envelope["status"], "success")
+        self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["adapter_key"], "stub")
-        self.assertEqual(envelope["normalized"]["canonical_url"], "https://example.com/posts/2")
-        self.assertEqual(adapter.last_request.input.url, "https://example.com/posts/2")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_unknown_target_type(self) -> None:
         request = CoreTaskRequest(

--- a/tests/runtime/test_xhs_adapter.py
+++ b/tests/runtime/test_xhs_adapter.py
@@ -1632,6 +1632,8 @@ class XhsAdapterTests(unittest.TestCase):
         class BrokenXhsAdapter:
             adapter_key = "xhs"
             supported_capabilities = frozenset({"content_detail_by_url"})
+            supported_targets = frozenset({"url"})
+            supported_collection_modes = frozenset({"hybrid"})
 
             def execute(self, request: TaskRequest) -> dict[str, Any]:
                 return {


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：为 `FR-0004` 的 `#87` 落地 Core 共享输入模型接入点，使运行时能够显式接收 `InputTarget` 与 `CollectionPolicy`，并完成最小结构校验。
- 主要改动：
  - 在 `syvert.runtime` 引入 `InputTarget`、`CollectionPolicy`、`CoreTaskRequest`
  - `validate_request` / `execute_task` 统一走共享输入归一化路径
  - 对空 `target_value`、未知 `target_type`、未知 `collection_mode` 做 fail-closed 校验
  - 保留 legacy `TaskRequest(input.url)` 路径，但在 Core 内部归一化为 `target_type=url` + `collection_mode=hybrid`
  - 显式 `CoreTaskRequest` 在本回合只做到“受理 + 校验”，执行路径继续 fail-closed，避免提前打开 `#89` 的 adapter admission happy path
  - legacy `TaskRequest(input.url)` 路径已补齐 shared-axis admission：adapter 必须显式声明 `supported_targets` 包含 `url` 且 `supported_collection_modes` 包含 `hybrid`
  - 真实 adapter、runtime fixtures、CLI/executor/runtime/xhs/douyin 测试已同步到新声明

## Issue 摘要

## Goal

在 `FR-0004` 范围内，为 Core 建立 `InputTarget` 与 `CollectionPolicy` 的最小输入受理路径与共享模型接入点。

## Out of Scope

- 错误模型与失败分类细化（属于 `FR-0005`）
- adapter registry（属于 `FR-0005`）
- harness / gate / regression（属于 `FR-0006` / `FR-0007`）
- 真实平台特定解析逻辑

## Acceptance Criteria

- Core 已能显式接收 `InputTarget` 与 `CollectionPolicy`
- 最小结构校验已落地，不接受空 `target_value`、未知 `target_type`、未知 `collection_mode`
- 对应测试、门禁与 closeout 已与 `FR-0004` 对齐

## 关联事项

- Issue: #87
- item_key: `CHORE-0087-fr-0004-core-input-admission`
- item_type: `CHORE`
- release: `v0.2.0`
- sprint: `2026-S15`
- Closing: Fixes #87

## 风险

- 风险级别：`normal`
- 审查关注：
  - 本回合不能把平台派生字段提升到 Core
  - 本回合不能提前实现 `#89` 的 adapter-facing 契约投影
  - 当前边界是“显式受理 + legacy 路径共享轴准入 + 显式 shared-input fail-closed 执行”，不是 shared-input happy path；后者必须等 `#89`

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/open_pr.py --class implementation --issue 87 --item-key CHORE-0087-fr-0004-core-input-admission --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 接入 FR-0004 Core 共享输入模型' --closing fixes --dry-run`
  - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
- 未执行：
  - `python3 -m unittest discover -s tests/runtime -p 'test_*.py'`
    - 原因：其中 `test_douyin_browser_bridge...authenticated_detail_request...` 在当前分支与 `main` 基线均因本地签名服务未启动失败，不作为本回合阻断性回归结论

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次对 `syvert.runtime`、adapter 声明、相关测试、`docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md` 与 `v0.2.0/2026-S15` 索引的增量修改。
