### PR TITLE
feat(runtime): 承接 FR-0004 adapter-facing 请求投影

### DIFF
--- a/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
+++ b/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
@@ -1,0 +1,95 @@
+# CHORE-0089-fr-0004-core-adapter-projection 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0089-fr-0004-core-adapter-projection`
+- Issue：`#89`
+- item_type：`CHORE`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0004-input-target-and-collection-policy/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`CHORE-0089-fr-0004-core-adapter-projection`
+
+## 目标
+
+- 在 `#87` 已合入的 Core 共享输入模型之上，打通 Core 到 adapter-facing contract 的正式投影链路，使 adapter request 显式承接 `target_type`、`target_value`、`collection_mode`，并把调用侧 operation `content_detail_by_url` 投影为 adapter-facing capability family `content_detail`。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py`
+  - `syvert/adapters/xhs.py`
+  - `syvert/adapters/douyin.py`
+  - `tests/runtime/test_models.py`
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_executor.py`
+  - `tests/runtime/adapter_fixtures.py`
+  - 受影响的 adapter 单测
+  - `docs/releases/v0.2.0.md`
+  - `docs/sprints/2026-S15.md`
+  - 本 exec-plan
+- 本次不纳入：
+  - `FR-0002` 兼容路径的 closeout 证据收口
+  - 错误模型、registry、harness、version gate
+  - 平台特定签名、cookie、headers、fallback 或派生字段上浮到 Core
+
+## 当前停点
+
+- `FR-0004` formal spec 已由 PR `#82` 合入主干，`#87` 已由 PR `#90` 合入并关闭。
+- 当前 `main` / 本 worktree 仍处于 `#87` 结束时的过渡态：
+  - `CoreTaskRequest` 已可显式受理，但 native 路径在 adapter admission 前 fail-closed
+  - legacy `TaskRequest(input.url)` 已统一归一到 shared input 并命中 `supported_targets` / `supported_collection_modes`
+  - `project_to_adapter_request()` 仍投影回 legacy `TaskRequest(adapter_key, capability, input.url)` 形状
+  - in-tree adapters 仍以 `request.input.url` 与 `supported_capabilities={content_detail_by_url}` 工作
+- 当前独立 worktree：`/Users/mc/code/worktrees/syvert/issue-89-fr-0004-core-adapter`
+- 当前执行分支：`issue-89-fr-0004-core-adapter`
+
+## 下一步动作
+
+- 引入最小 adapter-facing request 形状，并把 runtime admission / projection 顺序调整为“共享轴校验 -> capability family 投影 -> adapter 执行”。
+- 同步参考 adapter、fixtures 与回归测试到新请求契约。
+- 通过实现门禁后打开 implementation PR，完成 guardian / merge / closeout。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.2.0` 收口 `FR-0004` 的第二个实现子事项，保证主干上的 Core 与 adapter 之间围绕同一组 shared input / adapter-facing contract 运行。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0004` implementation 第二步，负责 shared input 到 adapter-facing contract 的承接。
+- 阻塞：
+  - 不得在本回合吞并 `#88` 的 closeout 证据职责。
+  - 不得把平台派生字段或 `FR-0005` 的错误/registry 语义混入 runtime Core 层。
+
+## 已验证项
+
+- 已阅读：`AGENTS.md`
+- 已阅读：`WORKFLOW.md`
+- 已阅读：`docs/AGENTS.md`
+- 已阅读：`docs/process/delivery-funnel.md`
+- 已阅读：`spec_review.md`
+- 已阅读：`code_review.md`
+- 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
+- `gh issue view 64 --repo MC-and-his-Agents/Syvert`
+- `gh issue view 68 --repo MC-and-his-Agents/Syvert`
+- `gh issue view 87 --repo MC-and-his-Agents/Syvert`
+- `gh issue view 88 --repo MC-and-his-Agents/Syvert`
+- `gh issue view 89 --repo MC-and-his-Agents/Syvert`
+- 已核对：`#87` 已关闭，`#89/#88/#68/#64` 仍为 `OPEN`
+- 已核对：`#64` 正文仍保留过期的 `formal spec：待创建`
+
+## 未决风险
+
+- 若 capability projection 与 adapter 支持声明顺序处理不当，可能把调用侧 operation 与 adapter-facing family 混为一层，导致 admission 语义漂移。
+- 若直接把 legacy `TaskRequest` 升格为 adapter-facing request，容易把 `adapter_key` Core 路由语义继续带入 adapter contract。
+- 直接改写 adapter 单测时需防止把 `#88` 的兼容证据与 `#89` 的契约承接混成一次 closeout。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对 runtime、adapter、tests、release/sprint 索引与本 exec-plan 的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `c4df7d26893f86771285e98314ec0df29b75921b`

--- a/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
+++ b/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
@@ -38,19 +38,20 @@
 ## 当前停点
 
 - `FR-0004` formal spec 已由 PR `#82` 合入主干，`#87` 已由 PR `#90` 合入并关闭。
-- 当前 `main` / 本 worktree 仍处于 `#87` 结束时的过渡态：
-  - `CoreTaskRequest` 已可显式受理，但 native 路径在 adapter admission 前 fail-closed
-  - legacy `TaskRequest(input.url)` 已统一归一到 shared input 并命中 `supported_targets` / `supported_collection_modes`
-  - `project_to_adapter_request()` 仍投影回 legacy `TaskRequest(adapter_key, capability, input.url)` 形状
-  - in-tree adapters 仍以 `request.input.url` 与 `supported_capabilities={content_detail_by_url}` 工作
+- 当前行为 checkpoint 已落盘到 `72858bfc4c14e7d763b47c1c37c784aee8d4dbf8`：
+  - Runtime 新增 `AdapterTaskRequest(capability, target_type, target_value, collection_mode)`，由 Core 统一把 legacy `TaskRequest` 与 native `CoreTaskRequest` 投影到 adapter-facing request
+  - 调用侧 operation `content_detail_by_url` 已在进入 adapter 前投影为 capability family `content_detail`
+  - native `CoreTaskRequest` 不再在 `#87` 的 fail-closed 位置提前返回，而是与 legacy 路径一起命中 shared admission 与 adapter projection
+  - unsupported `target_type` / `collection_mode` 现在统一在 shared admission 层失败
+  - in-tree adapters 与 runtime fixtures 已把 `supported_capabilities` 同步到 `content_detail`，并承接显式 `target_type` / `target_value` / `collection_mode`
 - 当前独立 worktree：`/Users/mc/code/worktrees/syvert/issue-89-fr-0004-core-adapter`
 - 当前执行分支：`issue-89-fr-0004-core-adapter`
 
 ## 下一步动作
 
-- 引入最小 adapter-facing request 形状，并把 runtime admission / projection 顺序调整为“共享轴校验 -> capability family 投影 -> adapter 执行”。
-- 同步参考 adapter、fixtures 与回归测试到新请求契约。
-- 通过实现门禁后打开 implementation PR，完成 guardian / merge / closeout。
+- 运行 `pr_scope_guard`、`open_pr --dry-run` 与 `commit_check`，补齐进入 PR 的受控门禁记录。
+- 打开 implementation PR，完成 guardian / merge gate。
+- 合并后关闭 `#89`，并把 release / sprint / closeout 工件回链到该 PR。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -79,6 +80,12 @@
 - `gh issue view 89 --repo MC-and-his-Agents/Syvert`
 - 已核对：`#87` 已关闭，`#89/#88/#68/#64` 仍为 `OPEN`
 - 已核对：`#64` 正文仍保留过期的 `formal spec：待创建`
+- `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_cli tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter`
+  - 结果：`Ran 120 tests in 3.315s`，`OK`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
 
 ## 未决风险
 
@@ -92,4 +99,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `c4df7d26893f86771285e98314ec0df29b75921b`
+- `72858bfc4c14e7d763b47c1c37c784aee8d4dbf8`

--- a/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
+++ b/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
@@ -44,12 +44,19 @@
   - native `CoreTaskRequest` 不再在 `#87` 的 fail-closed 位置提前返回，而是与 legacy 路径一起命中 shared admission 与 adapter projection
   - unsupported `target_type` / `collection_mode` 现在统一在 shared admission 层失败
   - in-tree adapters 与 runtime fixtures 已把 `supported_capabilities` 同步到 `content_detail`，并承接显式 `target_type` / `target_value` / `collection_mode`
+- guardian 首轮针对 PR `#91` / head `9e9b45e3472e1acad3b8c97538fd57829cf5e179` 返回 `REQUEST_CHANGES`：
+  - 阻断 1：shared admission 保护不足，若未来 adapter 声明更宽 target / collection 轴，`content_id`、`public`、`authenticated` 会错误进入执行链
+  - 阻断 2：xhs / douyin adapter 对 `AdapterTaskRequest` 的 direct invocation 接受了其未声明支持的 `public` / `authenticated`
+- 当前收口：
+  - Runtime 重新前置 shared projection guard，保持当前执行边界仍为 `target_type=url` 与 `collection_mode=hybrid`
+  - xhs / douyin adapter 自身对 `AdapterTaskRequest` 也回到 fail-closed，只接受 `collection_mode=hybrid`
+  - 回归测试新增“broad declared axes 仍被 shared projection guard 拦截”和“reference adapter direct invocation 拒绝非 hybrid”的覆盖
 - 当前独立 worktree：`/Users/mc/code/worktrees/syvert/issue-89-fr-0004-core-adapter`
 - 当前执行分支：`issue-89-fr-0004-core-adapter`
 
 ## 下一步动作
 
-- 等待 PR `#91` 的 GitHub checks 全绿，并对当前 head 运行 guardian 审查。
+- 重新运行实现门禁与 guardian，确认 `REQUEST_CHANGES` 已收口。
 - 若 guardian `APPROVE` 且 `safe_to_merge=true`，通过受控入口合并 PR。
 - 合并后关闭 `#89`，并把 release / sprint / closeout 工件回链到该 PR。
 
@@ -93,6 +100,11 @@
 - `python3 scripts/open_pr.py --class implementation --issue 89 --item-key CHORE-0089-fr-0004-core-adapter-projection --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 承接 FR-0004 adapter-facing 请求投影' --closing fixes --dry-run`
   - 结果：通过
 - 已创建当前受审 PR：`#91 https://github.com/MC-and-his-Agents/Syvert/pull/91`
+- guardian 首轮审查：`REQUEST_CHANGES`
+  - 阻断项：shared projection guard 被放宽，且 adapter direct invocation 接受了未声明支持的 `public` / `authenticated`
+  - 收口动作：恢复 shared projection guard 到 `url + hybrid`，并让 xhs / douyin adapter 对 `AdapterTaskRequest` 的 collection_mode 回到 fail-closed
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_models tests.runtime.test_executor tests.runtime.test_cli`
+  - 结果：`Ran 122 tests in 3.821s`，`OK`
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
+++ b/docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S15`
 - 关联 spec：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#91`
 - active 收口事项：`CHORE-0089-fr-0004-core-adapter-projection`
 
 ## 目标
@@ -49,8 +49,8 @@
 
 ## 下一步动作
 
-- 运行 `pr_scope_guard`、`open_pr --dry-run` 与 `commit_check`，补齐进入 PR 的受控门禁记录。
-- 打开 implementation PR，完成 guardian / merge gate。
+- 等待 PR `#91` 的 GitHub checks 全绿，并对当前 head 运行 guardian 审查。
+- 若 guardian `APPROVE` 且 `safe_to_merge=true`，通过受控入口合并 PR。
 - 合并后关闭 `#89`，并把 release / sprint / closeout 工件回链到该 PR。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -86,6 +86,13 @@
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
   - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
+  - 结果：已校验 2 条提交信息，全部通过
+- `python3 scripts/open_pr.py --class implementation --issue 89 --item-key CHORE-0089-fr-0004-core-adapter-projection --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 承接 FR-0004 adapter-facing 请求投影' --closing fixes --dry-run`
+  - 结果：通过
+- 已创建当前受审 PR：`#91 https://github.com/MC-and-his-Agents/Syvert/pull/91`
 
 ## 未决风险
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -27,6 +27,7 @@
 - `CHORE-0079-fr-0007-formal-spec-closeout`：`FR-0007` formal spec 收口 Work Item，对应 Issue `#79`
 - `FR-0004-input-target-and-collection-policy`：`v0.2.0` 共享输入模型与采集策略模型，对应 Issue `#64`
 - `CHORE-0087-fr-0004-core-input-admission`：`FR-0004` Core 输入受理与共享模型接入，对应 Issue `#87`
+- `CHORE-0089-fr-0004-core-adapter-projection`：`FR-0004` Core 到 adapter-facing request 的投影与共享 admission 承接，对应 Issue `#89`
 - `FR-0006-adapter-contract-test-harness`：`v0.2.0` adapter contract test harness formal spec，对应 Issue `#66`
 - `CHORE-0051-fr-0006-formal-spec-closeout`：`FR-0006` formal spec PR closeout Work Item，对应 Issue `#74`
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约主线之一，对应 Issue `#65`
@@ -57,6 +58,7 @@
 - exec-plan：
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md`
+  - `docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md`
   - `docs/exec-plans/CHORE-0051-fr-0005-formal-spec.md`
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -16,6 +16,7 @@
 - `FR-0002-content-detail-runtime-v0-1`：`v0.1.0` 业务主线 formal spec，对应 Issue `#38`
 - `FR-0004-input-target-and-collection-policy`：`v0.2.0` 共享输入模型与采集策略 formal spec，对应 FR `#64` 与 spec Work Item `#68`
 - `CHORE-0087-fr-0004-core-input-admission`：`FR-0004` Core 输入受理与共享模型接入，对应 Issue `#87`
+- `CHORE-0089-fr-0004-core-adapter-projection`：`FR-0004` adapter-facing request 投影与共享 admission 承接，对应 Issue `#89`
 - `FR-0006-adapter-contract-test-harness`：`v0.2.0` adapter contract test harness formal spec，对应 Issue `#66`
 - `CHORE-0051-fr-0006-formal-spec-closeout`：`FR-0006` formal spec PR closeout Work Item，对应 Issue `#74`
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约 formal spec，对应 Phase `#63` 下的 FR `#65`
@@ -70,6 +71,7 @@
 - `FR-0007` 已在当前 sprint 建立版本 gate formal spec 入口，为后续 contract harness / 回归检查实现回合提供 requirement 基线。
 - `FR-0004` / `#68` 已在当前 sprint 建立共享输入模型与采集策略的 formal spec 入口。
 - `CHORE-0087` 已在当前 sprint 建立 `FR-0004` 的首个 implementation 入口，负责把共享输入模型接入 Core 输入受理层。
+- `CHORE-0089` 已在当前 sprint 建立 `FR-0004` 的第二个 implementation 入口，负责把共享输入模型投影到 adapter-facing request，并让 unsupported `target_type` / `collection_mode` 统一停留在共享 admission 层失败。
 - `FR-0006` 已在当前 sprint 建立 `v0.2.0` contract harness formal spec 入口；`CHORE-0051` 负责当前 formal spec PR 的受控 closeout。
 - `FR-0005` 已在当前 sprint 建立错误模型与 adapter registry 的 formal spec 入口；后续实现拆分为 `#69` 与 `#70`。
 - `CHORE-0051` 已为 `FR-0005` 提供独立 Work Item 执行入口，负责 formal spec PR、checks、guardian 与 merge gate。
@@ -78,9 +80,9 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`、`#87`
+- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`、`#87`、`#89`
 - `pre-v0.2.0` governance 事项树：`#54`、`#55`、`#56`、`#57`、`#58`
-- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`、`#87`
+- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`、`#87`、`#89`
 
 ## 关联工件
 
@@ -106,6 +108,7 @@
   - `docs/exec-plans/CHORE-0050-douyin-reference-adapter.md`
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md`
+  - `docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md`
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`
   - `docs/exec-plans/GOV-0028-harness-compat-migration.md`

--- a/syvert/adapters/douyin.py
+++ b/syvert/adapters/douyin.py
@@ -10,7 +10,7 @@ from urllib import error, parse, request
 
 from syvert.adapters.douyin_browser_bridge import extract_aweme_detail_from_page_state
 from syvert.adapters.douyin_browser_bridge import DouyinAuthenticatedBrowserBridge
-from syvert.runtime import CONTENT_DETAIL_BY_URL, PlatformAdapterError, TaskRequest
+from syvert.runtime import AdapterTaskRequest, CONTENT_DETAIL, PlatformAdapterError, TaskRequest
 
 
 DOUYIN_API_BASE_URL = "https://www.douyin.com"
@@ -45,7 +45,7 @@ PageStateTransport = Callable[..., Mapping[str, Any]]
 
 class DouyinAdapter:
     adapter_key = "douyin"
-    supported_capabilities = frozenset({CONTENT_DETAIL_BY_URL})
+    supported_capabilities = frozenset({CONTENT_DETAIL})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -64,8 +64,9 @@ class DouyinAdapter:
         self._detail_transport = detail_transport or default_detail_transport
         self._page_state_transport = page_state_transport or default_page_state_transport
 
-    def execute(self, request: TaskRequest) -> dict[str, Any]:
-        url_info = parse_douyin_detail_url(request.input.url)
+    def execute(self, request: TaskRequest | AdapterTaskRequest) -> dict[str, Any]:
+        input_url = resolve_input_url(request=request, adapter_key=self.adapter_key)
+        url_info = parse_douyin_detail_url(input_url)
         session = self._session_provider(self._session_path)
         try:
             params = self._build_detail_params(session, url_info)
@@ -75,7 +76,7 @@ class DouyinAdapter:
             raw_response, aweme_detail = self._recover_aweme_detail_from_page_state(
                 exc,
                 session=session,
-                input_url=request.input.url,
+                input_url=input_url,
                 source_aweme_id=url_info.aweme_id,
             )
         normalized = normalize_aweme_detail(aweme_detail, canonical_url=url_info.canonical_url)
@@ -180,6 +181,36 @@ class DouyinAdapter:
 
 def build_adapters() -> dict[str, object]:
     return {"douyin": DouyinAdapter()}
+
+
+def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest, adapter_key: str) -> str:
+    if type(request) is AdapterTaskRequest:
+        if request.capability != CONTENT_DETAIL:
+            raise PlatformAdapterError(
+                code="invalid_douyin_request",
+                message="douyin adapter 不支持该 capability family",
+                details={"capability": request.capability},
+            )
+        if request.target_type != "url":
+            raise PlatformAdapterError(
+                code="invalid_douyin_request",
+                message="douyin adapter 仅支持 target_type=url",
+                details={"target_type": request.target_type},
+            )
+        if request.collection_mode not in {"hybrid", "authenticated", "public"}:
+            raise PlatformAdapterError(
+                code="invalid_douyin_request",
+                message="douyin adapter 收到未知 collection_mode",
+                details={"collection_mode": request.collection_mode},
+            )
+        return request.target_value
+    if type(request) is TaskRequest:
+        return request.input.url
+    raise PlatformAdapterError(
+        code="invalid_douyin_request",
+        message="douyin adapter request 顶层形状不合法",
+        details={"request_type": type(request).__name__},
+    )
 
 
 def parse_douyin_detail_url(url: str) -> DouyinUrlInfo:

--- a/syvert/adapters/douyin.py
+++ b/syvert/adapters/douyin.py
@@ -65,7 +65,7 @@ class DouyinAdapter:
         self._page_state_transport = page_state_transport or default_page_state_transport
 
     def execute(self, request: TaskRequest | AdapterTaskRequest) -> dict[str, Any]:
-        input_url = resolve_input_url(request=request, adapter_key=self.adapter_key)
+        input_url = resolve_input_url(request=request)
         url_info = parse_douyin_detail_url(input_url)
         session = self._session_provider(self._session_path)
         try:
@@ -183,7 +183,7 @@ def build_adapters() -> dict[str, object]:
     return {"douyin": DouyinAdapter()}
 
 
-def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest, adapter_key: str) -> str:
+def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
     if type(request) is AdapterTaskRequest:
         if request.capability != CONTENT_DETAIL:
             raise PlatformAdapterError(
@@ -197,10 +197,10 @@ def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest, adapter_key:
                 message="douyin adapter 仅支持 target_type=url",
                 details={"target_type": request.target_type},
             )
-        if request.collection_mode not in {"hybrid", "authenticated", "public"}:
+        if request.collection_mode != "hybrid":
             raise PlatformAdapterError(
                 code="invalid_douyin_request",
-                message="douyin adapter 收到未知 collection_mode",
+                message="douyin adapter 仅支持 collection_mode=hybrid",
                 details={"collection_mode": request.collection_mode},
             )
         return request.target_value

--- a/syvert/adapters/xhs.py
+++ b/syvert/adapters/xhs.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Mapping
 from urllib import error, parse, request
 
 from syvert.adapters.xhs_browser_bridge import XhsAuthenticatedBrowserBridge
-from syvert.runtime import CONTENT_DETAIL_BY_URL, PlatformAdapterError, TaskRequest
+from syvert.runtime import AdapterTaskRequest, CONTENT_DETAIL, PlatformAdapterError, TaskRequest
 
 
 XHS_API_BASE_URL = "https://edith.xiaohongshu.com"
@@ -46,7 +46,7 @@ PageStateTransport = Callable[..., Mapping[str, Any]]
 
 class XhsAdapter:
     adapter_key = "xhs"
-    supported_capabilities = frozenset({CONTENT_DETAIL_BY_URL})
+    supported_capabilities = frozenset({CONTENT_DETAIL})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -67,8 +67,9 @@ class XhsAdapter:
         self._page_transport = page_transport or default_page_transport
         self._page_state_transport = page_state_transport or default_page_state_transport
 
-    def execute(self, request: TaskRequest) -> dict[str, Any]:
-        url_info = parse_xhs_detail_url(request.input.url)
+    def execute(self, request: TaskRequest | AdapterTaskRequest) -> dict[str, Any]:
+        input_url = resolve_input_url(request=request, adapter_key=self.adapter_key)
+        url_info = parse_xhs_detail_url(input_url)
         session = self._session_provider(self._session_path)
         body = build_detail_body(url_info)
         try:
@@ -80,10 +81,10 @@ class XhsAdapter:
             raw_response, note_card = self._recover_note_card_from_html(
                 exc,
                 session=session,
-                input_url=request.input.url,
+                input_url=input_url,
                 source_note_id=url_info.note_id,
             )
-        normalized = normalize_note_card(note_card, request.input.url)
+        normalized = normalize_note_card(note_card, input_url)
         return {"raw": raw_response, "normalized": normalized}
 
     def _build_headers(self, session: XhsSessionConfig, body: dict[str, Any]) -> dict[str, str]:
@@ -222,6 +223,36 @@ class XhsAdapter:
 
 def build_adapters() -> dict[str, object]:
     return {"xhs": XhsAdapter()}
+
+
+def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest, adapter_key: str) -> str:
+    if type(request) is AdapterTaskRequest:
+        if request.capability != CONTENT_DETAIL:
+            raise PlatformAdapterError(
+                code="invalid_xhs_request",
+                message="xhs adapter 不支持该 capability family",
+                details={"capability": request.capability},
+            )
+        if request.target_type != "url":
+            raise PlatformAdapterError(
+                code="invalid_xhs_request",
+                message="xhs adapter 仅支持 target_type=url",
+                details={"target_type": request.target_type},
+            )
+        if request.collection_mode not in {"hybrid", "authenticated", "public"}:
+            raise PlatformAdapterError(
+                code="invalid_xhs_request",
+                message="xhs adapter 收到未知 collection_mode",
+                details={"collection_mode": request.collection_mode},
+            )
+        return request.target_value
+    if type(request) is TaskRequest:
+        return request.input.url
+    raise PlatformAdapterError(
+        code="invalid_xhs_request",
+        message="xhs adapter request 顶层形状不合法",
+        details={"request_type": type(request).__name__},
+    )
 
 
 def parse_xhs_detail_url(url: str) -> XhsUrlInfo:

--- a/syvert/adapters/xhs.py
+++ b/syvert/adapters/xhs.py
@@ -68,7 +68,7 @@ class XhsAdapter:
         self._page_state_transport = page_state_transport or default_page_state_transport
 
     def execute(self, request: TaskRequest | AdapterTaskRequest) -> dict[str, Any]:
-        input_url = resolve_input_url(request=request, adapter_key=self.adapter_key)
+        input_url = resolve_input_url(request=request)
         url_info = parse_xhs_detail_url(input_url)
         session = self._session_provider(self._session_path)
         body = build_detail_body(url_info)
@@ -225,7 +225,7 @@ def build_adapters() -> dict[str, object]:
     return {"xhs": XhsAdapter()}
 
 
-def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest, adapter_key: str) -> str:
+def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
     if type(request) is AdapterTaskRequest:
         if request.capability != CONTENT_DETAIL:
             raise PlatformAdapterError(
@@ -239,10 +239,10 @@ def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest, adapter_key:
                 message="xhs adapter 仅支持 target_type=url",
                 details={"target_type": request.target_type},
             )
-        if request.collection_mode not in {"hybrid", "authenticated", "public"}:
+        if request.collection_mode != "hybrid":
             raise PlatformAdapterError(
                 code="invalid_xhs_request",
-                message="xhs adapter 收到未知 collection_mode",
+                message="xhs adapter 仅支持 collection_mode=hybrid",
                 details={"collection_mode": request.collection_mode},
             )
         return request.target_value

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -8,9 +8,11 @@ from uuid import uuid4
 
 
 CONTENT_DETAIL_BY_URL = "content_detail_by_url"
+CONTENT_DETAIL = "content_detail"
 LEGACY_COLLECTION_MODE = "hybrid"
 ALLOWED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
 ALLOWED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
+CAPABILITY_FAMILY_BY_OPERATION = {CONTENT_DETAIL_BY_URL: CONTENT_DETAIL}
 ALLOWED_CONTENT_TYPES = {"video", "image_post", "mixed_media", "unknown"}
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 MISSING = object()
@@ -45,6 +47,18 @@ class TaskRequest:
     adapter_key: str
     capability: str
     input: TaskInput
+
+
+@dataclass(frozen=True)
+class AdapterTaskRequest:
+    capability: str
+    target_type: str
+    target_value: str
+    collection_mode: str
+
+    @property
+    def input(self) -> TaskInput:
+        return TaskInput(url=self.target_value)
 
 
 @dataclass
@@ -85,15 +99,15 @@ def execute_task(
 
     adapter_key = normalized_request.target.adapter_key
     capability = normalized_request.target.capability
-    if type(request) is CoreTaskRequest:
+    capability_family, capability_family_error = resolve_capability_family(capability)
+    if capability_family_error is not None:
+        return failure_envelope(task_id, adapter_key, capability, capability_family_error)
+    if capability_family is None:
         return failure_envelope(
             task_id,
             adapter_key,
             capability,
-            runtime_contract_error(
-                "invalid_task_request",
-                "当前共享输入执行路径尚未完成 adapter admission 承接",
-            ),
+            runtime_contract_error("invalid_capability", "capability 无法投影到 adapter-facing family"),
         )
 
     adapter, adapter_error = get_adapter(adapters, adapter_key)
@@ -117,7 +131,7 @@ def execute_task(
     )
     if capability_error is not None:
         return failure_envelope(task_id, adapter_key, capability, capability_error)
-    if capability not in supported_capabilities:
+    if capability_family not in supported_capabilities:
         return failure_envelope(
             task_id,
             adapter_key,
@@ -125,9 +139,10 @@ def execute_task(
             {
                 "category": "runtime_contract",
                 "code": "capability_not_supported",
-                "message": f"adapter `{adapter_key}` 不支持 `{capability}`",
+                "message": f"adapter `{adapter_key}` 不支持 `{capability_family}`",
                 "details": {
                     "supported_capabilities": sorted(supported_capabilities),
+                    "capability_family": capability_family,
                 },
             },
         )
@@ -166,7 +181,7 @@ def execute_task(
             },
         )
 
-    adapter_request, projection_error = project_to_adapter_request(normalized_request)
+    adapter_request, projection_error = project_to_adapter_request(normalized_request, capability_family)
     if projection_error is not None:
         return failure_envelope(task_id, adapter_key, capability, projection_error)
 
@@ -263,28 +278,29 @@ def normalize_request(request: Any) -> tuple[CoreTaskRequest | None, dict[str, A
     return request, None
 
 
-def project_to_adapter_request(request: CoreTaskRequest) -> tuple[TaskRequest | None, dict[str, Any] | None]:
-    if request.target.target_type != "url":
+def resolve_capability_family(capability: str) -> tuple[str | None, dict[str, Any] | None]:
+    mapped = CAPABILITY_FAMILY_BY_OPERATION.get(capability)
+    if mapped is None:
         return (
             None,
             runtime_contract_error(
-                "invalid_task_request",
-                "当前运行时过渡路径仅支持 target_type=url",
+                "invalid_capability",
+                f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
             ),
         )
-    if request.policy.collection_mode != LEGACY_COLLECTION_MODE:
-        return (
-            None,
-            runtime_contract_error(
-                "invalid_task_request",
-                "当前运行时过渡路径仅支持 collection_mode=hybrid",
-            ),
-        )
+    return mapped, None
+
+
+def project_to_adapter_request(
+    request: CoreTaskRequest,
+    capability_family: str,
+) -> tuple[AdapterTaskRequest | None, dict[str, Any] | None]:
     return (
-        TaskRequest(
-        adapter_key=request.target.adapter_key,
-        capability=request.target.capability,
-        input=TaskInput(url=request.target.target_value),
+        AdapterTaskRequest(
+            capability=capability_family,
+            target_type=request.target.target_type,
+            target_value=request.target.target_value,
+            collection_mode=request.policy.collection_mode,
         ),
         None,
     )

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -110,6 +110,10 @@ def execute_task(
             runtime_contract_error("invalid_capability", "capability 无法投影到 adapter-facing family"),
         )
 
+    projection_axis_error = validate_projection_axes_for_current_runtime(normalized_request)
+    if projection_axis_error is not None:
+        return failure_envelope(task_id, adapter_key, capability, projection_axis_error)
+
     adapter, adapter_error = get_adapter(adapters, adapter_key)
     if adapter_error is not None:
         return failure_envelope(task_id, adapter_key, capability, adapter_error)
@@ -304,6 +308,20 @@ def project_to_adapter_request(
         ),
         None,
     )
+
+
+def validate_projection_axes_for_current_runtime(request: CoreTaskRequest) -> dict[str, Any] | None:
+    if request.target.target_type != "url":
+        return runtime_contract_error(
+            "invalid_task_request",
+            "当前运行时执行路径仅支持 target_type=url",
+        )
+    if request.policy.collection_mode != LEGACY_COLLECTION_MODE:
+        return runtime_contract_error(
+            "invalid_task_request",
+            "当前运行时执行路径仅支持 collection_mode=hybrid",
+        )
+    return None
 
 
 def extract_request_context(request: Any) -> tuple[str, str]:

--- a/tests/runtime/adapter_fixtures.py
+++ b/tests/runtime/adapter_fixtures.py
@@ -5,7 +5,7 @@ from syvert.runtime import TaskRequest
 
 class SuccessfulAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -42,7 +42,7 @@ class SuccessfulAdapter:
 
 class UnserializableSuccessAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 class SuccessfulAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 

--- a/tests/runtime/test_douyin_adapter.py
+++ b/tests/runtime/test_douyin_adapter.py
@@ -10,7 +10,7 @@ from typing import Any
 import unittest
 from unittest import mock
 
-from syvert.runtime import PlatformAdapterError, TaskInput, TaskRequest, execute_task
+from syvert.runtime import AdapterTaskRequest, PlatformAdapterError, TaskInput, TaskRequest, execute_task
 
 
 def build_douyin_aweme_detail(
@@ -53,6 +53,23 @@ def build_douyin_aweme_detail(
 
 
 class DouyinAdapterTests(unittest.TestCase):
+    def test_douyin_adapter_rejects_non_hybrid_adapter_task_request_before_session_lookup(self) -> None:
+        from syvert.adapters.douyin import DouyinAdapter
+
+        adapter = DouyinAdapter()
+
+        with self.assertRaises(PlatformAdapterError) as raised:
+            adapter.execute(
+                AdapterTaskRequest(
+                    capability="content_detail",
+                    target_type="url",
+                    target_value="https://www.douyin.com/video/7580570616932224282",
+                    collection_mode="authenticated",
+                )
+            )
+
+        self.assertEqual(raised.exception.code, "invalid_douyin_request")
+
     def test_parse_douyin_detail_url_extracts_aweme_id_from_canonical_url(self) -> None:
         from syvert.adapters.douyin import parse_douyin_detail_url
 

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -7,7 +7,7 @@ from syvert.runtime import TaskInput, TaskRequest, execute_task
 
 class SuccessfulAdapter:
     adapter_key = "xhs"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -44,7 +44,7 @@ class SuccessfulAdapter:
 
 class UnsupportedCapabilityAdapter:
     adapter_key = "xhs"
-    supported_capabilities = frozenset({"creator_detail_by_url"})
+    supported_capabilities = frozenset({"creator_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -232,6 +232,16 @@ class UnsupportedHybridCollectionModeAdapter:
         raise AssertionError("execute should not be called")
 
 
+class BroadAxesAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url", "content_id", "creator_id", "keyword"})
+    supported_collection_modes = frozenset({"public", "authenticated", "hybrid"})
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("shared admission should fail before adapter execution")
+
+
 class RuntimeExecutionTests(unittest.TestCase):
     def test_execute_task_builds_success_envelope_from_adapter_payload(self) -> None:
         adapter = SuccessfulAdapter()
@@ -331,7 +341,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
-    def test_execute_task_rejects_unsupported_target_type_at_shared_admission(self) -> None:
+    def test_execute_task_rejects_non_url_target_at_shared_projection_guard(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -344,15 +354,15 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={"stub": BroadAxesAdapter()},
             task_id_factory=lambda: "task-non-url-target",
         )
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "target_type_not_supported")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
-    def test_execute_task_rejects_unsupported_public_collection_mode_at_shared_admission(self) -> None:
+    def test_execute_task_rejects_public_collection_mode_at_shared_projection_guard(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -365,15 +375,15 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={"stub": BroadAxesAdapter()},
             task_id_factory=lambda: "task-public-mode",
         )
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
-    def test_execute_task_rejects_unsupported_authenticated_collection_mode_at_shared_admission(self) -> None:
+    def test_execute_task_rejects_authenticated_collection_mode_at_shared_projection_guard(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -386,13 +396,13 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={"stub": BroadAxesAdapter()},
             task_id_factory=lambda: "task-authenticated-mode",
         )
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
+        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_unknown_adapter_as_runtime_contract_failure(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import unittest
 
 from syvert.runtime import (
+    AdapterTaskRequest,
     CollectionPolicy,
     CoreTaskRequest,
     InputTarget,
@@ -26,7 +27,7 @@ class ExtendedTaskRequest(TaskRequest):
 
 class SuccessfulAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -67,7 +68,7 @@ class SuccessfulAdapter:
 
 class MissingRawAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -103,7 +104,7 @@ class MissingRawAdapter:
 
 class NonePayloadAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -113,7 +114,7 @@ class NonePayloadAdapter:
 
 class ListPayloadAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -123,7 +124,7 @@ class ListPayloadAdapter:
 
 class CrashingAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -133,7 +134,7 @@ class CrashingAdapter:
 
 class PlatformErrorWithBadDetailsAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -145,7 +146,7 @@ class PlatformErrorWithBadDetailsAdapter:
 
 class PlatformFailureAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -175,7 +176,7 @@ class NonContainerCapabilitiesAdapter:
 
 class NonStringCapabilitiesAdapter:
     adapter_key = "stub"
-    supported_capabilities = ("content_detail_by_url", 1)
+    supported_capabilities = ("content_detail", 1)
 
     def execute(self, request: TaskRequest):
         raise AssertionError("execute should not be called")
@@ -190,7 +191,7 @@ class MissingCapabilitiesAdapter:
 
 class BrokenCapabilitiesIterable:
     def __iter__(self):
-        yield "content_detail_by_url"
+        yield "content_detail"
         raise RuntimeError("broken-iterator")
 
 
@@ -214,7 +215,7 @@ class ExplodingRequestMapping(dict):
 
 class MissingTargetsAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_collection_modes = frozenset({"hybrid"})
 
     def execute(self, request: TaskRequest):
@@ -223,7 +224,7 @@ class MissingTargetsAdapter:
 
 class UnsupportedHybridCollectionModeAdapter:
     adapter_key = "stub"
-    supported_capabilities = frozenset({"content_detail_by_url"})
+    supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"authenticated"})
 
@@ -252,9 +253,15 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["status"], "success")
         self.assertIn("raw", envelope)
         self.assertEqual(envelope["normalized"]["canonical_url"], request.input.url)
-        self.assertEqual(adapter.last_request.input.url, request.input.url)
+        self.assertIsInstance(adapter.last_request, AdapterTaskRequest)
+        self.assertEqual(adapter.last_request.capability, "content_detail")
+        self.assertEqual(adapter.last_request.target_type, "url")
+        self.assertEqual(adapter.last_request.target_value, request.input.url)
+        self.assertEqual(adapter.last_request.collection_mode, "hybrid")
+        self.assertFalse(hasattr(adapter.last_request, "adapter_key"))
 
-    def test_execute_task_fails_closed_for_core_request_shape_before_shared_axis_admission(self) -> None:
+    def test_execute_task_executes_core_request_through_adapter_projection(self) -> None:
+        adapter = SuccessfulAdapter()
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -267,15 +274,20 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={"stub": adapter},
             task_id_factory=lambda: "task-001b",
         )
 
         self.assertEqual(envelope["task_id"], "task-001b")
-        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["status"], "success")
         self.assertEqual(envelope["adapter_key"], "stub")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+        self.assertEqual(envelope["normalized"]["canonical_url"], request.target.target_value)
+        self.assertIsInstance(adapter.last_request, AdapterTaskRequest)
+        self.assertEqual(adapter.last_request.capability, "content_detail")
+        self.assertEqual(adapter.last_request.target_type, "url")
+        self.assertEqual(adapter.last_request.target_value, request.target.target_value)
+        self.assertEqual(adapter.last_request.collection_mode, "hybrid")
+        self.assertFalse(hasattr(adapter.last_request, "adapter_key"))
 
     def test_execute_task_rejects_unknown_target_type(self) -> None:
         request = CoreTaskRequest(
@@ -319,7 +331,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
-    def test_execute_task_rejects_non_url_target_before_legacy_projection(self) -> None:
+    def test_execute_task_rejects_unsupported_target_type_at_shared_admission(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -338,9 +350,9 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+        self.assertEqual(envelope["error"]["code"], "target_type_not_supported")
 
-    def test_execute_task_rejects_public_collection_mode_before_legacy_projection(self) -> None:
+    def test_execute_task_rejects_unsupported_public_collection_mode_at_shared_admission(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -359,9 +371,9 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
 
-    def test_execute_task_rejects_authenticated_collection_mode_before_legacy_projection(self) -> None:
+    def test_execute_task_rejects_unsupported_authenticated_collection_mode_at_shared_admission(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
                 adapter_key="stub",
@@ -380,7 +392,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(envelope["error"]["code"], "invalid_task_request")
+        self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
 
     def test_execute_task_rejects_unknown_adapter_as_runtime_contract_failure(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_xhs_adapter.py
+++ b/tests/runtime/test_xhs_adapter.py
@@ -11,7 +11,7 @@ import unittest
 from unittest import mock
 
 from syvert.cli import main
-from syvert.runtime import PlatformAdapterError, TaskInput, TaskRequest, execute_task
+from syvert.runtime import AdapterTaskRequest, PlatformAdapterError, TaskInput, TaskRequest, execute_task
 
 from syvert.adapters.xhs import (
     XhsAdapter,
@@ -68,6 +68,21 @@ class FakeHttpResponse:
 
 
 class XhsAdapterTests(unittest.TestCase):
+    def test_xhs_adapter_rejects_non_hybrid_adapter_task_request_before_session_lookup(self) -> None:
+        adapter = XhsAdapter()
+
+        with self.assertRaises(PlatformAdapterError) as raised:
+            adapter.execute(
+                AdapterTaskRequest(
+                    capability="content_detail",
+                    target_type="url",
+                    target_value="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8",
+                    collection_mode="public",
+                )
+            )
+
+        self.assertEqual(raised.exception.code, "invalid_xhs_request")
+
     def test_default_page_state_transport_returns_browser_bridge_page_state_without_rewrapping(self) -> None:
         note_id = "69d33f6a000000001f0078b3"
         raw_state = {

--- a/tests/runtime/test_xhs_adapter.py
+++ b/tests/runtime/test_xhs_adapter.py
@@ -1631,7 +1631,7 @@ class XhsAdapterTests(unittest.TestCase):
     def test_runtime_rejects_incomplete_normalized_payload(self) -> None:
         class BrokenXhsAdapter:
             adapter_key = "xhs"
-            supported_capabilities = frozenset({"content_detail_by_url"})
+            supported_capabilities = frozenset({"content_detail"})
             supported_targets = frozenset({"url"})
             supported_collection_modes = frozenset({"hybrid"})
 


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：完成 `#89`，把 `FR-0004` 的 shared input 从 Core 正式投影到 adapter-facing request，并让 unsupported `target_type` / `collection_mode` 统一停留在共享 admission 层失败。
- 主要改动：
  - 在 `syvert/runtime.py` 新增 `AdapterTaskRequest` 与 `content_detail_by_url -> content_detail` capability family 投影。
  - 打开 native `CoreTaskRequest` 执行路径，使 legacy / native 都先归一到 shared input，再进入 shared admission 与 adapter projection。
  - 将小红书、抖音参考 adapter 的 `supported_capabilities` 切到 `content_detail`，并承接显式 `target_type` / `target_value` / `collection_mode`。
  - 补齐 runtime/CLI/fixture/adapter 回归测试，验证 adapter 收到的请求形状和 shared-axis admission 失败语义。
  - 更新 `docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md`、`docs/releases/v0.2.0.md`、`docs/sprints/2026-S15.md`。

## Issue 摘要

- `#89` 是 `FR-0004` 在 `#87` 之后的第二个 implementation 子事项，职责是承接 Core 到 Adapter 的请求契约，而不是处理 `#88` 的兼容证据 closeout。
- 本 PR 保持 Core 边界不变：不把签名、cookie、headers、fallback 或平台派生字段提升到 Core。
- `adapter_key` 继续只作为 Core 路由输入，不进入 adapter-facing request。

## 关联事项

- Issue: #89
- item_key: `CHORE-0089-fr-0004-core-adapter-projection`
- item_type: `CHORE`
- release: `v0.2.0`
- sprint: `2026-S15`
- Closing: Fixes #89

## 风险

- 风险级别：`normal`
- 审查关注：
  - capability family 投影是否保持 `content_detail_by_url -> content_detail`，且不把调用侧 operation 误带入 adapter 支持声明。
  - unsupported `target_type` / `collection_mode` 是否仍在 shared admission 层失败，而不是下沉为平台执行错误。
  - native / legacy 路径是否都统一走 `AdapterTaskRequest`，且未把 `adapter_key` 或平台派生字段泄漏到 adapter request。

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_models tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_cli tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/open_pr.py --class implementation --issue 89 --item-key CHORE-0089-fr-0004-core-adapter-projection --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 承接 FR-0004 adapter-facing 请求投影' --closing fixes --dry-run`
- 未执行：
  - guardian 审查与受控 merge（待当前 PR head checks 通过后执行）

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
