### PR TITLE
test(runtime): 补齐 FR-0004 的 FR-0002 兼容证据

### DIFF
--- a/docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md
+++ b/docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md
@@ -1,0 +1,98 @@
+# CHORE-0088-fr-0004-fr-0002-compat-closeout 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0088-fr-0004-fr-0002-compat-closeout`
+- Issue：`#88`
+- item_type：`CHORE`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0004-input-target-and-collection-policy/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`CHORE-0088-fr-0004-fr-0002-compat-closeout`
+
+## 目标
+
+- 在 `#87` 与 `#89` 已合入的主干实现之上，完成 `FR-0002` legacy URL 入口到 `InputTarget / CollectionPolicy` 的兼容路径 closeout，补齐 legacy/native 不分叉的 admission 证据、反例证据与 release / sprint / GitHub 回链。
+
+## 范围
+
+- 本次纳入：
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_cli.py`（如需补兼容回归）
+  - `docs/releases/v0.2.0.md`
+  - `docs/sprints/2026-S15.md`
+  - 本 exec-plan（兼作 closeout 证据入口）
+- 本次不纳入：
+  - 新的 shared input / adapter-facing contract 语义
+  - 错误模型、registry、harness、version gate
+  - 平台特定签名、cookie、headers、fallback 逻辑
+
+## 当前停点
+
+- `#87` 已完成 legacy `TaskRequest(adapter_key, capability, input.url)` 到 shared input 的基础归一。
+- `#89` 已通过 PR `#91` 合入主干，完成 `content_detail_by_url -> content_detail` capability family 投影，以及 legacy/native 共用 `AdapterTaskRequest` 的执行链。
+- 当前回合已补齐 runtime 回归测试草案：
+  - legacy URL 请求与 native `CoreTaskRequest(url + hybrid)` 命中同一 `AdapterTaskRequest(url + hybrid)` 投影，并返回等价结果
+  - adapter 未声明 `hybrid` 时，legacy/native 命中同一 `collection_mode_not_supported` 失败
+  - release / sprint 已登记 `#88` 的兼容证据入口，待 PR / closeout 回链
+- 当前独立 worktree：`/Users/mc/code/worktrees/syvert/issue-88-fr-0004-fr-0002`
+- 当前执行分支：`issue-88-fr-0004-fr-0002`
+
+## 下一步动作
+
+- 为 legacy/native 等价性与统一 `hybrid` admission 失败补充回归测试。
+- 把 `#88` 作为 `v0.2.0 / 2026-S15` 的兼容证据入口登记到 release / sprint 索引。
+- 通过实现门禁后打开 PR，完成 guardian / merge / issue closeout。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.2.0` 收口 `FR-0004` 的第三个 implementation 子事项，使 `FR-0002` 旧入口仍可被主干实现和验证证据直接追溯。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0004` implementation 第三步，负责 legacy `FR-0002` 入口的兼容证据与反例收口。
+- 阻塞：
+  - 不得把 `#68` / `#64` 的聚合 closeout 提前混入本回合。
+  - 不得借兼容证据之名扩写新的 shared input 语义。
+
+## 已验证项
+
+- 已阅读：`AGENTS.md`
+- 已阅读：`WORKFLOW.md`
+- 已阅读：`docs/AGENTS.md`
+- 已阅读：`docs/process/delivery-funnel.md`
+- 已阅读：`spec_review.md`
+- 已阅读：`code_review.md`
+- 已阅读：`docs/specs/FR-0004-input-target-and-collection-policy/`
+- 已核对：`#88` 仍为 `OPEN`，`#89` 已关闭，`#68/#64` 仍为 `OPEN`
+- 已核对：当前 `#88` worktree 基于 `main@e2b6b53d9a73f22b8e2f36ba9c4069a79ae45a08`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor tests.runtime.test_models`
+  - 结果：`Ran 69 tests in 2.412s`，`OK`
+
+## 兼容 closeout 证据
+
+- legacy success 证据：
+  - `tests.runtime.test_runtime.RuntimeExecutionTests.test_execute_task_maps_legacy_and_native_requests_to_same_adapter_projection`
+  - 证明 `TaskRequest(adapter_key, capability, input.url)` 与 native `CoreTaskRequest(target_type=url, target_value=input.url, collection_mode=hybrid)` 命中同一 adapter-facing request，并返回等价结果
+- admission 统一反例：
+  - `tests.runtime.test_runtime.RuntimeExecutionTests.test_execute_task_rejects_legacy_and_native_requests_with_same_hybrid_admission_error`
+  - 证明 adapter 未声明 `hybrid` 时，legacy/native 都返回同一 `collection_mode_not_supported`
+- old entry 仍可用：
+  - `tests.runtime.test_cli.CliTests.test_cli_module_path_can_load_adapter_source`
+  - `tests.runtime.test_cli.CliTests.test_cli_module_path_can_load_shared_adapter_registry`
+  - 证明 CLI 旧入口 `--adapter + --capability + --url` 仍能驱动当前主干实现路径
+
+## 未决风险
+
+- 若只补 success path 而不补反例证据，`#88` 的 closeout 仍无法证明 legacy/native admission 不分叉。
+- 若在本回合再次改 runtime 共享语义，容易与已关闭的 `#87/#89` 责任边界串线。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项新增的兼容回归测试、索引与 closeout 工件。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `e2b6b53d9a73f22b8e2f36ba9c4069a79ae45a08`

--- a/docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md
+++ b/docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S15`
 - 关联 spec：`docs/specs/FR-0004-input-target-and-collection-policy/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#92`
 - active 收口事项：`CHORE-0088-fr-0004-fr-0002-compat-closeout`
 
 ## 目标
@@ -42,9 +42,9 @@
 
 ## 下一步动作
 
-- 为 legacy/native 等价性与统一 `hybrid` admission 失败补充回归测试。
-- 把 `#88` 作为 `v0.2.0 / 2026-S15` 的兼容证据入口登记到 release / sprint 索引。
-- 通过实现门禁后打开 PR，完成 guardian / merge / issue closeout。
+- 等待 PR `#92` 的 GitHub checks 全绿，并对当前 head 运行 guardian 审查。
+- 若 guardian `APPROVE` 且 `safe_to_merge=true`，通过受控入口合并 PR。
+- 合并后关闭 `#88`，并把 closeout 证据回链到 `#68 / #64` 聚合收口。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -74,6 +74,13 @@
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
   - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
+  - 结果：已校验 2 条提交信息，全部通过
+- `python3 scripts/open_pr.py --class implementation --issue 88 --item-key CHORE-0088-fr-0004-fr-0002-compat-closeout --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'test(runtime): 补齐 FR-0004 的 FR-0002 兼容证据' --closing fixes --dry-run`
+  - 结果：通过
+- 已创建当前受审 PR：`#92 https://github.com/MC-and-his-Agents/Syvert/pull/92`
 
 ## 兼容 closeout 证据
 

--- a/docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md
+++ b/docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md
@@ -33,7 +33,7 @@
 
 - `#87` 已完成 legacy `TaskRequest(adapter_key, capability, input.url)` 到 shared input 的基础归一。
 - `#89` 已通过 PR `#91` 合入主干，完成 `content_detail_by_url -> content_detail` capability family 投影，以及 legacy/native 共用 `AdapterTaskRequest` 的执行链。
-- 当前回合已补齐 runtime 回归测试草案：
+- 当前行为 checkpoint 已落盘到 `10f5b5a5bfdcb1913ace9b5eb8c1985e90e44045`：
   - legacy URL 请求与 native `CoreTaskRequest(url + hybrid)` 命中同一 `AdapterTaskRequest(url + hybrid)` 投影，并返回等价结果
   - adapter 未声明 `hybrid` 时，legacy/native 命中同一 `collection_mode_not_supported` 失败
   - release / sprint 已登记 `#88` 的兼容证据入口，待 PR / closeout 回链
@@ -69,7 +69,11 @@
 - 已核对：`#88` 仍为 `OPEN`，`#89` 已关闭，`#68/#64` 仍为 `OPEN`
 - 已核对：当前 `#88` worktree 基于 `main@e2b6b53d9a73f22b8e2f36ba9c4069a79ae45a08`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor tests.runtime.test_models`
-  - 结果：`Ran 69 tests in 2.412s`，`OK`
+  - 结果：`Ran 69 tests in 1.779s`，`OK`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
 
 ## 兼容 closeout 证据
 
@@ -95,4 +99,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `e2b6b53d9a73f22b8e2f36ba9c4069a79ae45a08`
+- `10f5b5a5bfdcb1913ace9b5eb8c1985e90e44045`

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -28,6 +28,7 @@
 - `FR-0004-input-target-and-collection-policy`：`v0.2.0` 共享输入模型与采集策略模型，对应 Issue `#64`
 - `CHORE-0087-fr-0004-core-input-admission`：`FR-0004` Core 输入受理与共享模型接入，对应 Issue `#87`
 - `CHORE-0089-fr-0004-core-adapter-projection`：`FR-0004` Core 到 adapter-facing request 的投影与共享 admission 承接，对应 Issue `#89`
+- `CHORE-0088-fr-0004-fr-0002-compat-closeout`：`FR-0004` 下 `FR-0002` legacy URL 入口的兼容路径、反例与 closeout 证据收口，对应 Issue `#88`
 - `FR-0006-adapter-contract-test-harness`：`v0.2.0` adapter contract test harness formal spec，对应 Issue `#66`
 - `CHORE-0051-fr-0006-formal-spec-closeout`：`FR-0006` formal spec PR closeout Work Item，对应 Issue `#74`
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约主线之一，对应 Issue `#65`
@@ -59,6 +60,7 @@
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md`
   - `docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md`
+  - `docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md`
   - `docs/exec-plans/CHORE-0051-fr-0005-formal-spec.md`
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -17,6 +17,7 @@
 - `FR-0004-input-target-and-collection-policy`：`v0.2.0` 共享输入模型与采集策略 formal spec，对应 FR `#64` 与 spec Work Item `#68`
 - `CHORE-0087-fr-0004-core-input-admission`：`FR-0004` Core 输入受理与共享模型接入，对应 Issue `#87`
 - `CHORE-0089-fr-0004-core-adapter-projection`：`FR-0004` adapter-facing request 投影与共享 admission 承接，对应 Issue `#89`
+- `CHORE-0088-fr-0004-fr-0002-compat-closeout`：`FR-0004` 下 `FR-0002` legacy URL 入口的兼容路径与验证证据，对应 Issue `#88`
 - `FR-0006-adapter-contract-test-harness`：`v0.2.0` adapter contract test harness formal spec，对应 Issue `#66`
 - `CHORE-0051-fr-0006-formal-spec-closeout`：`FR-0006` formal spec PR closeout Work Item，对应 Issue `#74`
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约 formal spec，对应 Phase `#63` 下的 FR `#65`
@@ -72,6 +73,7 @@
 - `FR-0004` / `#68` 已在当前 sprint 建立共享输入模型与采集策略的 formal spec 入口。
 - `CHORE-0087` 已在当前 sprint 建立 `FR-0004` 的首个 implementation 入口，负责把共享输入模型接入 Core 输入受理层。
 - `CHORE-0089` 已在当前 sprint 建立 `FR-0004` 的第二个 implementation 入口，负责把共享输入模型投影到 adapter-facing request，并让 unsupported `target_type` / `collection_mode` 统一停留在共享 admission 层失败。
+- `CHORE-0088` 已在当前 sprint 建立 `FR-0004` 的第三个 implementation 入口，负责把 legacy `FR-0002` URL 入口的等价性、反例与 closeout 证据回链到主干实现。
 - `FR-0006` 已在当前 sprint 建立 `v0.2.0` contract harness formal spec 入口；`CHORE-0051` 负责当前 formal spec PR 的受控 closeout。
 - `FR-0005` 已在当前 sprint 建立错误模型与 adapter registry 的 formal spec 入口；后续实现拆分为 `#69` 与 `#70`。
 - `CHORE-0051` 已为 `FR-0005` 提供独立 Work Item 执行入口，负责 formal spec PR、checks、guardian 与 merge gate。
@@ -80,9 +82,9 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`、`#87`、`#89`
+- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`、`#87`、`#88`、`#89`
 - `pre-v0.2.0` governance 事项树：`#54`、`#55`、`#56`、`#57`、`#58`
-- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`、`#87`、`#89`
+- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`、`#87`、`#88`、`#89`
 
 ## 关联工件
 
@@ -108,6 +110,7 @@
   - `docs/exec-plans/CHORE-0050-douyin-reference-adapter.md`
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0087-fr-0004-core-input-admission.md`
+  - `docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md`
   - `docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md`
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -299,6 +299,44 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(adapter.last_request.collection_mode, "hybrid")
         self.assertFalse(hasattr(adapter.last_request, "adapter_key"))
 
+    def test_execute_task_maps_legacy_and_native_requests_to_same_adapter_projection(self) -> None:
+        legacy_adapter = SuccessfulAdapter()
+        native_adapter = SuccessfulAdapter()
+        legacy_request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/legacy-native"),
+        )
+        native_request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/legacy-native",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        legacy_envelope = execute_task(
+            legacy_request,
+            adapters={"stub": legacy_adapter},
+            task_id_factory=lambda: "task-legacy-map",
+        )
+        native_envelope = execute_task(
+            native_request,
+            adapters={"stub": native_adapter},
+            task_id_factory=lambda: "task-native-map",
+        )
+
+        self.assertEqual(legacy_envelope["status"], "success")
+        self.assertEqual(native_envelope["status"], "success")
+        self.assertEqual(legacy_envelope["raw"], native_envelope["raw"])
+        self.assertEqual(legacy_envelope["normalized"], native_envelope["normalized"])
+        self.assertEqual(legacy_adapter.last_request, native_adapter.last_request)
+        self.assertEqual(legacy_adapter.last_request.target_type, "url")
+        self.assertEqual(legacy_adapter.last_request.target_value, legacy_request.input.url)
+        self.assertEqual(legacy_adapter.last_request.collection_mode, "hybrid")
+
     def test_execute_task_rejects_unknown_target_type(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
@@ -455,6 +493,41 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
+
+    def test_execute_task_rejects_legacy_and_native_requests_with_same_hybrid_admission_error(self) -> None:
+        legacy_request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/no-hybrid"),
+        )
+        native_request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/no-hybrid",
+            ),
+            policy=CollectionPolicy(collection_mode="hybrid"),
+        )
+
+        legacy_envelope = execute_task(
+            legacy_request,
+            adapters={"stub": UnsupportedHybridCollectionModeAdapter()},
+            task_id_factory=lambda: "task-legacy-no-hybrid",
+        )
+        native_envelope = execute_task(
+            native_request,
+            adapters={"stub": UnsupportedHybridCollectionModeAdapter()},
+            task_id_factory=lambda: "task-native-no-hybrid",
+        )
+
+        self.assertEqual(legacy_envelope["status"], "failed")
+        self.assertEqual(native_envelope["status"], "failed")
+        self.assertEqual(legacy_envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(native_envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(legacy_envelope["error"]["code"], "collection_mode_not_supported")
+        self.assertEqual(native_envelope["error"]["code"], "collection_mode_not_supported")
+        self.assertEqual(legacy_envelope["error"]["details"], native_envelope["error"]["details"])
 
     def test_execute_task_rejects_unsupported_capability(self) -> None:
         request = TaskRequest(


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：完成 `#88`，为 `FR-0004` 下的 `FR-0002` legacy URL 入口补齐兼容路径、反例与 closeout 证据。
- 主要改动：
  - 在 `tests/runtime/test_runtime.py` 新增 legacy/native 等价性回归，证明旧入口与 native `CoreTaskRequest(url + hybrid)` 命中同一 `AdapterTaskRequest` 投影并返回等价结果。
  - 新增 legacy/native 统一 `hybrid` admission 失败回归，证明 adapter 未声明 `hybrid` 时两条入口都返回同一 `collection_mode_not_supported`。
  - 将 `#88` 的兼容证据登记到 `docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md`，并同步 `docs/releases/v0.2.0.md` 与 `docs/sprints/2026-S15.md`。
  - 复用既有 CLI regression 作为 old entry 仍可用的证据，不扩写新的 runtime 语义。

## Issue 摘要

- `#88` 不负责新建 shared input 语义；本 PR 只收口 `FR-0002` 旧入口已经在主干上的兼容实现与验证证据。
- 当前兼容结论是：legacy `adapter_key + capability + input.url` 无损映射到 `target_type=url`、`target_value=input.url`、`collection_mode=hybrid`，且 legacy/native 在 admission 语义上不分叉。

## 关联事项

- Issue: #88
- item_key: `CHORE-0088-fr-0004-fr-0002-compat-closeout`
- item_type: `CHORE`
- release: `v0.2.0`
- sprint: `2026-S15`
- Closing: Fixes #88

## 风险

- 风险级别：`normal`
- 审查关注：
  - legacy/native 等价性是否真的落到同一 `AdapterTaskRequest(url + hybrid)`，而不是只在 envelope 层看起来一样。
  - adapter 未声明 `hybrid` 时，legacy/native 是否都命中相同 admission 失败，不会因为来源不同而分叉。
  - 本 PR 是否只补兼容证据，而没有偷偷改写 `#87/#89` 已冻结的 shared input / adapter-facing contract 语义。

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor tests.runtime.test_models`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/open_pr.py --class implementation --issue 88 --item-key CHORE-0088-fr-0004-fr-0002-compat-closeout --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'test(runtime): 补齐 FR-0004 的 FR-0002 兼容证据' --closing fixes --dry-run`
- 未执行：
  - guardian 审查与受控 merge（待当前 PR head checks 通过后执行）

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次新增的兼容回归测试、release/sprint 索引与 closeout 工件。
