### PR TITLE
feat(runtime): 落地 FR-0005 标准化错误模型

### DIFF
--- a/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
+++ b/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
@@ -1,0 +1,82 @@
+# CHORE-0069-fr-0005-standardized-error-model 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0069-fr-0005-standardized-error-model`
+- Issue：`#69`
+- item_type：`CHORE`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
+- 关联 decision：
+- 关联 PR：
+
+## 目标
+
+- 在 `FR-0005` 范围内落地标准化错误模型，把 Core / Adapter 的失败路径统一映射到 `invalid_input`、`unsupported`、`runtime_contract`、`platform` 四类运行时语义。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py`
+  - `syvert/cli.py`
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_executor.py`
+  - `tests/runtime/test_cli.py`
+  - `docs/releases/v0.2.0.md`
+  - `docs/sprints/2026-S15.md`
+  - 本 exec-plan
+- 本次不纳入：
+  - adapter registry materialization / discovery / registration
+  - fake adapter、harness、validator、version gate
+  - `FR-0004` 的输入建模语义改写
+  - 平台适配器内部平台逻辑
+
+## 当前停点
+
+- `FR-0005` formal spec 已由 PR `#78` 合入主干，`#69` 仍为 open Work Item，尚无 implementation PR。
+- 当前主干运行时仅实做 `runtime_contract` / `platform` 两类失败分类，`invalid_input` / `unsupported` 尚未进入统一实现路径。
+- 当前 `execute_task()` 仍把 adapter 不存在、capability 不支持、非法请求形状等路径大多打成 `runtime_contract`，与 `FR-0005` formal spec 不一致。
+
+## 下一步动作
+
+- 为 runtime / CLI 新增 `invalid_input` 与 `unsupported` 错误 helper，并把现有失败分支重映射到 formal spec 指定分类。
+- 补齐并更新 runtime / executor / CLI 回归测试。
+- 运行 implementation 门禁，创建 `#69` 对应 PR。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.2.0` 把共享错误分类从“能跑即可”推进到“契约可验证”，为后续 `#70` registry contract 与 `FR-0006/#0007` 的上层复用提供稳定失败语义。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0005` 的第一个 implementation Work Item，负责先把错误模型从 formal spec 落到主干运行时。
+- 阻塞：
+  - 不得把 adapter registry、harness、gate、fake adapter 或额外 FR 范围并入当前回合。
+
+## 已验证项
+
+- 已阅读：`AGENTS.md`
+- 已阅读：`WORKFLOW.md`
+- 已阅读：`docs/AGENTS.md`
+- 已阅读：`docs/process/delivery-funnel.md`
+- 已阅读：`spec_review.md`
+- 已阅读：`code_review.md`
+- 已阅读：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
+- `gh issue view 69 --repo MC-and-his-Agents/Syvert`
+- `python3 scripts/create_worktree.py --issue 69 --class implementation`
+  - 结果：已创建 worktree `/Users/mc/code/worktrees/syvert/issue-69-task`
+
+## 未决风险
+
+- 若把 adapter target / collection admission 的失败误判为 `unsupported`，会模糊 `invalid_input` 与 “adapter 前置输入约束不满足” 的 spec 边界。
+- 若在本回合顺手引入 registry 结构，会与 `#70` 的职责切分串线。
+- 若 CLI 参数错误仍保留为 `runtime_contract`，则主干 CLI 与 formal spec 的 `invalid_input` 边界不一致。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对 runtime、CLI、tests、release/sprint 索引与本 exec-plan 的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `bb0f4af77f8ba54fff43290ff8c98a903d35a4ed`

--- a/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
+++ b/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S15`
 - 关联 spec：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#97`
 
 ## 目标
 
@@ -34,15 +34,16 @@
 
 ## 当前停点
 
-- `FR-0005` formal spec 已由 PR `#78` 合入主干，`#69` 仍为 open Work Item，尚无 implementation PR。
+- `FR-0005` formal spec 已由 PR `#78` 合入主干，`#69` 当前通过 PR `#97` 进入 implementation review / guardian 回合。
 - 当前主干运行时仅实做 `runtime_contract` / `platform` 两类失败分类，`invalid_input` / `unsupported` 尚未进入统一实现路径。
 - 当前 `execute_task()` 仍把 adapter 不存在、capability 不支持、非法请求形状等路径大多打成 `runtime_contract`，与 `FR-0005` formal spec 不一致。
+- 当前分支 `issue-69-task` 已把 runtime / CLI 错误分类重映射到四类语义，并同步更新 release / sprint / exec-plan 索引与回归测试。
 
 ## 下一步动作
 
-- 为 runtime / CLI 新增 `invalid_input` 与 `unsupported` 错误 helper，并把现有失败分支重映射到 formal spec 指定分类。
-- 补齐并更新 runtime / executor / CLI 回归测试。
-- 运行 implementation 门禁，创建 `#69` 对应 PR。
+- 消化 guardian 结论并保持 active exec-plan、PR、GitHub checks 与当前 head 一致。
+- 在 guardian `APPROVE` 且 checks 全绿后，通过受控 merge 入口完成合并与 closeout。
+- 合并后关闭 `#69`，退役分支 / worktree，并切换到 `#70` 的独立执行回合。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -66,6 +67,27 @@
 - `gh issue view 69 --repo MC-and-his-Agents/Syvert`
 - `python3 scripts/create_worktree.py --issue 69 --class implementation`
   - 结果：已创建 worktree `/Users/mc/code/worktrees/syvert/issue-69-task`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
+  - 结果：`Ran 48 tests in 1.726s`，`OK`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
+  - 结果：已校验 1 条提交信息，全部通过
+- `python3 scripts/open_pr.py --class implementation --issue 69 --item-key CHORE-0069-fr-0005-standardized-error-model --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 落地 FR-0005 标准化错误模型' --closing fixes --dry-run`
+  - 结果：通过
+- 已创建当前受审 PR：`#97 https://github.com/MC-and-his-Agents/Syvert/pull/97`
+- GitHub checks：
+  - `Validate Commit Messages`：通过
+  - `Validate Docs And Guard Scripts`：通过
+  - `Validate Governance Tooling`：通过
+  - `Validate Spec Review Boundaries`：通过
+- guardian 首轮审查：`REQUEST_CHANGES`
+  - 阻断项：active exec-plan 仍停留在 pre-PR 状态，`关联 PR` 为空，且“下一步动作”仍写着创建 PR，导致仓内执行上下文与当前受审 PR `#97` 不一致
+  - 收口动作：更新 active exec-plan，使其与当前 PR / head / merge gate 状态对齐
 
 ## 未决风险
 
@@ -79,4 +101,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `bb0f4af77f8ba54fff43290ff8c98a903d35a4ed`
+- `06682d32357b5301acee500239301af86b33c56d`

--- a/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
+++ b/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
@@ -38,7 +38,7 @@
 - 当前主干运行时仅实做 `runtime_contract` / `platform` 两类失败分类，`invalid_input` / `unsupported` 尚未进入统一实现路径。
 - 当前 `execute_task()` 仍把 adapter 不存在、capability 不支持、非法请求形状等路径大多打成 `runtime_contract`，与 `FR-0005` formal spec 不一致。
 - 当前分支 `issue-69-task` 已把 runtime / CLI 错误分类重映射到四类语义，并同步更新 release / sprint / exec-plan 索引与回归测试。
-- guardian 第二轮指出：真实 xhs / douyin adapter 在进入平台前因 invalid URL / invalid request 抛出的 `PlatformAdapterError` 仍被 blanket 映射到 `platform`；当前 head 已补上 runtime 分类逻辑与真实 adapter 回归测试，待重新受审。
+- guardian 第三轮指出：Core 仍靠 `invalid_*_url` / `invalid_*_request` 这类 code 命名启发式识别 adapter pre-platform invalid input，缺少显式 contract；当前 head 已将该边界改为 `PlatformAdapterError(category=\"invalid_input\")` 的显式 adapter-side 信号，并补上真实 adapter 与非命名启发式回归测试，待重新受审。
 
 ## 下一步动作
 
@@ -72,6 +72,8 @@
   - 结果：`Ran 48 tests in 1.726s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
   - 结果：在修正真实 adapter pre-platform 输入分类后重跑，`Ran 50 tests in 1.729s`，`OK`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter`
+  - 结果：在引入 `PlatformAdapterError(category=\"invalid_input\")` 显式 contract 后重跑，`Ran 106 tests in 3.291s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
@@ -94,6 +96,9 @@
 - guardian 次轮审查：`REQUEST_CHANGES`
   - 阻断项：真实 adapter 在 pre-platform 输入失败时抛出的 `invalid_xhs_url` / `invalid_douyin_url` 仍被 runtime 映射到 `platform`
   - 收口动作：runtime 新增 adapter pre-platform invalid-input 分类逻辑，并补充真实 xhs / douyin invalid URL 回归测试
+- guardian 三轮审查：`REQUEST_CHANGES`
+  - 阻断项：Core 仍依赖 error code 后缀启发式识别 adapter pre-platform invalid input，未形成显式 Core / Adapter contract
+  - 收口动作：为 `PlatformAdapterError` 增加显式 `category` 字段，并在 xhs / douyin 的 pre-platform request/url 校验路径上标记 `invalid_input`；同时补充一条不依赖 `*_request` / `*_url` 命名的回归测试
 
 ## 未决风险
 
@@ -107,4 +112,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `984ae6176d8a37853bf696176372b9d946c8d5cb`
+- `491fe7e81c50b2f7d8cb4b51cbcab9cb1e7f72f8`

--- a/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
+++ b/docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md
@@ -38,6 +38,7 @@
 - 当前主干运行时仅实做 `runtime_contract` / `platform` 两类失败分类，`invalid_input` / `unsupported` 尚未进入统一实现路径。
 - 当前 `execute_task()` 仍把 adapter 不存在、capability 不支持、非法请求形状等路径大多打成 `runtime_contract`，与 `FR-0005` formal spec 不一致。
 - 当前分支 `issue-69-task` 已把 runtime / CLI 错误分类重映射到四类语义，并同步更新 release / sprint / exec-plan 索引与回归测试。
+- guardian 第二轮指出：真实 xhs / douyin adapter 在进入平台前因 invalid URL / invalid request 抛出的 `PlatformAdapterError` 仍被 blanket 映射到 `platform`；当前 head 已补上 runtime 分类逻辑与真实 adapter 回归测试，待重新受审。
 
 ## 下一步动作
 
@@ -69,6 +70,8 @@
   - 结果：已创建 worktree `/Users/mc/code/worktrees/syvert/issue-69-task`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
   - 结果：`Ran 48 tests in 1.726s`，`OK`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
+  - 结果：在修正真实 adapter pre-platform 输入分类后重跑，`Ran 50 tests in 1.729s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
@@ -88,6 +91,9 @@
 - guardian 首轮审查：`REQUEST_CHANGES`
   - 阻断项：active exec-plan 仍停留在 pre-PR 状态，`关联 PR` 为空，且“下一步动作”仍写着创建 PR，导致仓内执行上下文与当前受审 PR `#97` 不一致
   - 收口动作：更新 active exec-plan，使其与当前 PR / head / merge gate 状态对齐
+- guardian 次轮审查：`REQUEST_CHANGES`
+  - 阻断项：真实 adapter 在 pre-platform 输入失败时抛出的 `invalid_xhs_url` / `invalid_douyin_url` 仍被 runtime 映射到 `platform`
+  - 收口动作：runtime 新增 adapter pre-platform invalid-input 分类逻辑，并补充真实 xhs / douyin invalid URL 回归测试
 
 ## 未决风险
 
@@ -101,4 +107,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `06682d32357b5301acee500239301af86b33c56d`
+- `984ae6176d8a37853bf696176372b9d946c8d5cb`

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -34,7 +34,7 @@
 - `CHORE-0051-fr-0006-formal-spec-closeout`：`FR-0006` formal spec PR closeout Work Item，对应 Issue `#74`
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约主线之一，对应 Issue `#65`
 - `CHORE-0051-fr-0005-formal-spec`：`FR-0005` 的 formal spec Work Item，对应 Issue `#77`
-- `#69`：`FR-0005` 下的“实现标准化错误模型” Work Item
+- `CHORE-0069-fr-0005-standardized-error-model`：`FR-0005` 的错误模型实现 Work Item，对应 Issue `#69`
 - `#70`：`FR-0005` 下的“实现适配器注册表” Work Item
 - `GOV-0027-governance-contract-rewrite`：治理契约重写与口径收敛，对应 Issue `#56`
 - `GOV-0028-harness-compat-migration`：后续 harness 兼容迁移，对应 Issue `#57`
@@ -52,6 +52,7 @@
 - `FR-0004` 的 implementation 子事项 `#87/#89/#88` 已分别由 PR `#90/#91/#92` 合入主干
 - `#68` implementation 聚合 closeout 已由 PR `#93` 收口并关闭，formal spec、实现子事项与 release / sprint / exec-plan 的引用链已统一
 - 当前仅剩父 FR `#64` closeout，由 Work Item `#95` / PR `#96` 把以上主干事实与 GitHub 关闭语义完成最终对齐
+- `FR-0005` 的 formal spec 已由 PR `#78` 合入主干；`#69` 当前为 active implementation 回合，负责把四类错误分类落到 runtime / CLI 的统一失败路径
 
 ## 关联工件
 
@@ -73,6 +74,7 @@
   - `docs/exec-plans/CHORE-0089-fr-0004-core-adapter-projection.md`
   - `docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md`
   - `docs/exec-plans/CHORE-0051-fr-0005-formal-spec.md`
+  - `docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md`（current active；绑定 Issue `#69`）
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -34,7 +34,7 @@
 - `GOV-0027-governance-contract-rewrite`：`FR-0003` 首个治理 Work Item，对应 Issue `#56`
 - `GOV-0028-harness-compat-migration`：后续 harness 兼容迁移 Work Item，对应 Issue `#57`
 - `GOV-0029-remove-legacy-todo-md`：移除 legacy `TODO.md` 的正式治理流入口，对应 Issue `#58`
-- `#69`：`FR-0005` 下的“实现标准化错误模型” Work Item
+- `CHORE-0069-fr-0005-standardized-error-model`：`FR-0005` 的错误模型实现 Work Item，对应 Issue `#69`
 - `#70`：`FR-0005` 下的“实现适配器注册表” Work Item
 
 ## 进入前依赖
@@ -82,6 +82,7 @@
 - `FR-0006` 已在当前 sprint 建立 `v0.2.0` contract harness formal spec 入口；`CHORE-0051` 负责当前 formal spec PR 的受控 closeout。
 - `FR-0005` 已在当前 sprint 建立错误模型与 adapter registry 的 formal spec 入口；后续实现拆分为 `#69` 与 `#70`。
 - `CHORE-0051` 已为 `FR-0005` 提供独立 Work Item 执行入口，负责 formal spec PR、checks、guardian 与 merge gate。
+- `CHORE-0069` 已在当前 sprint 建立 `FR-0005` 的第一个 implementation 入口，负责把四类错误分类落到 runtime / CLI 的统一失败路径。
 - `CHORE-0051-fr-0006-formal-spec-closeout` 已为 `FR-0006` 提供独立 Work Item 执行入口，负责当前 formal spec PR 的受控 closeout。
 
 ## 协作入口
@@ -113,6 +114,7 @@
   - `docs/exec-plans/FR-0004-input-target-and-collection-policy.md`（inactive requirement container；绑定 FR `#64`）
   - `docs/exec-plans/CHORE-0095-fr-0004-parent-closeout.md`（current active；绑定 Issue `#95` / PR `#96`）
   - `docs/exec-plans/CHORE-0051-fr-0005-formal-spec.md`
+  - `docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md`（current active；绑定 Issue `#69`）
   - `docs/exec-plans/CHORE-0041-runtime-cli-skeleton.md`（active，绑定 Issue `#41` / PR `#44`）
   - `docs/exec-plans/CHORE-0050-douyin-reference-adapter.md`
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`（historical / inactive；formal spec 已由 PR `#82` 收口）

--- a/syvert/adapters/douyin.py
+++ b/syvert/adapters/douyin.py
@@ -190,18 +190,21 @@ def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
                 code="invalid_douyin_request",
                 message="douyin adapter 不支持该 capability family",
                 details={"capability": request.capability},
+                category="invalid_input",
             )
         if request.target_type != "url":
             raise PlatformAdapterError(
                 code="invalid_douyin_request",
                 message="douyin adapter 仅支持 target_type=url",
                 details={"target_type": request.target_type},
+                category="invalid_input",
             )
         if request.collection_mode != "hybrid":
             raise PlatformAdapterError(
                 code="invalid_douyin_request",
                 message="douyin adapter 仅支持 collection_mode=hybrid",
                 details={"collection_mode": request.collection_mode},
+                category="invalid_input",
             )
         return request.target_value
     if type(request) is TaskRequest:
@@ -210,6 +213,7 @@ def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
         code="invalid_douyin_request",
         message="douyin adapter request 顶层形状不合法",
         details={"request_type": type(request).__name__},
+        category="invalid_input",
     )
 
 
@@ -228,12 +232,14 @@ def parse_douyin_detail_url(url: str) -> DouyinUrlInfo:
             code="invalid_douyin_url",
             message="暂不支持抖音短链，需先解析到详情 URL",
             details={"url": url},
+            category="invalid_input",
         )
     else:
         raise PlatformAdapterError(
             code="invalid_douyin_url",
             message="不是支持的抖音详情 URL",
             details={"url": url},
+            category="invalid_input",
         )
 
     if not aweme_id.isdigit():
@@ -241,6 +247,7 @@ def parse_douyin_detail_url(url: str) -> DouyinUrlInfo:
             code="invalid_douyin_url",
             message="无法从 URL 中解析 aweme_id",
             details={"url": url},
+            category="invalid_input",
         )
     return DouyinUrlInfo(
         aweme_id=aweme_id,

--- a/syvert/adapters/xhs.py
+++ b/syvert/adapters/xhs.py
@@ -232,18 +232,21 @@ def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
                 code="invalid_xhs_request",
                 message="xhs adapter 不支持该 capability family",
                 details={"capability": request.capability},
+                category="invalid_input",
             )
         if request.target_type != "url":
             raise PlatformAdapterError(
                 code="invalid_xhs_request",
                 message="xhs adapter 仅支持 target_type=url",
                 details={"target_type": request.target_type},
+                category="invalid_input",
             )
         if request.collection_mode != "hybrid":
             raise PlatformAdapterError(
                 code="invalid_xhs_request",
                 message="xhs adapter 仅支持 collection_mode=hybrid",
                 details={"collection_mode": request.collection_mode},
+                category="invalid_input",
             )
         return request.target_value
     if type(request) is TaskRequest:
@@ -252,6 +255,7 @@ def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
         code="invalid_xhs_request",
         message="xhs adapter request 顶层形状不合法",
         details={"request_type": type(request).__name__},
+        category="invalid_input",
     )
 
 
@@ -263,6 +267,7 @@ def parse_xhs_detail_url(url: str) -> XhsUrlInfo:
             code="invalid_xhs_url",
             message="不是支持的小红书详情 URL",
             details={"url": url},
+            category="invalid_input",
         )
 
     path_parts = [part for part in parsed.path.split("/") if part]
@@ -274,6 +279,7 @@ def parse_xhs_detail_url(url: str) -> XhsUrlInfo:
             code="invalid_xhs_url",
             message="无法从 URL 中解析 note_id",
             details={"url": url},
+            category="invalid_input",
         )
 
     query = parse.parse_qs(parsed.query, keep_blank_values=True)

--- a/syvert/cli.py
+++ b/syvert/cli.py
@@ -6,7 +6,15 @@ import json
 import sys
 from typing import Any, Callable, Mapping, TextIO
 
-from syvert.runtime import TaskInput, TaskRequest, execute_task, failure_envelope, resolve_task_id
+from syvert.runtime import (
+    TaskInput,
+    TaskRequest,
+    execute_task,
+    failure_envelope,
+    invalid_input_error,
+    resolve_task_id,
+    runtime_contract_error,
+)
 
 
 class CliArgumentError(ValueError):
@@ -45,12 +53,7 @@ def main(
     except CliArgumentError as error:
         task_id, task_id_error = resolve_task_id(task_id_factory)
         adapter_key, capability = extract_cli_context(argv)
-        envelope_error = task_id_error or {
-            "category": "runtime_contract",
-            "code": "invalid_cli_arguments",
-            "message": str(error),
-            "details": {},
-        }
+        envelope_error = task_id_error or invalid_input_error("invalid_cli_arguments", str(error))
         envelope = failure_envelope(task_id, adapter_key, capability, envelope_error)
         err.write(json.dumps(envelope, ensure_ascii=False) + "\n")
         return 1
@@ -76,12 +79,10 @@ def main(
             task_id,
             request.adapter_key,
             request.capability,
-            {
-                "category": "runtime_contract",
-                "code": "adapter_loader_error",
-                "message": str(error) or error.__class__.__name__,
-                "details": {},
-            },
+            runtime_contract_error(
+                "adapter_loader_error",
+                str(error) or error.__class__.__name__,
+            ),
         )
         err.write(json.dumps(envelope, ensure_ascii=False) + "\n")
         return 1
@@ -101,14 +102,11 @@ def main(
             fallback_task_id,
             request.adapter_key,
             request.capability,
-            {
-                "category": "runtime_contract",
-                "code": "envelope_not_json_serializable",
-                "message": "CLI 输出结果无法序列化为 JSON",
-                "details": {
-                    "error_type": error.__class__.__name__,
-                },
-            },
+            runtime_contract_error(
+                "envelope_not_json_serializable",
+                "CLI 输出结果无法序列化为 JSON",
+                details={"error_type": error.__class__.__name__},
+            ),
         )
         payload = json.dumps(envelope, ensure_ascii=False)
         stream = err

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -187,17 +187,7 @@ def execute_task(
         if payload_error is not None:
             return failure_envelope(task_id, adapter_key, capability, payload_error)
     except PlatformAdapterError as error:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            {
-                "category": "platform",
-                "code": error.code,
-                "message": error.message,
-                "details": error.details,
-            },
-        )
+        return failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error))
     except Exception as error:
         return failure_envelope(
             task_id,
@@ -724,6 +714,24 @@ def runtime_contract_error(code: str, message: str, *, details: Mapping[str, Any
         "message": message,
         "details": dict(details or {}),
     }
+
+
+def classify_adapter_error(error: PlatformAdapterError) -> dict[str, Any]:
+    details = error.details if isinstance(error.details, Mapping) else {}
+    if is_pre_platform_invalid_input_error(error.code):
+        return invalid_input_error(error.code, error.message, details=details)
+    return {
+        "category": "platform",
+        "code": error.code,
+        "message": error.message,
+        "details": dict(details),
+    }
+
+
+def is_pre_platform_invalid_input_error(code: str) -> bool:
+    if not isinstance(code, str):
+        return False
+    return code.startswith("invalid_") and (code.endswith("_request") or code.endswith("_url"))
 
 
 def invalid_input_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -66,6 +66,7 @@ class PlatformAdapterError(Exception):
     code: str
     message: str
     details: dict[str, Any] = field(default_factory=dict)
+    category: str = "platform"
 
     def __post_init__(self) -> None:
         super().__init__(self.message)
@@ -718,7 +719,7 @@ def runtime_contract_error(code: str, message: str, *, details: Mapping[str, Any
 
 def classify_adapter_error(error: PlatformAdapterError) -> dict[str, Any]:
     details = error.details if isinstance(error.details, Mapping) else {}
-    if is_pre_platform_invalid_input_error(error.code):
+    if error.category == "invalid_input":
         return invalid_input_error(error.code, error.message, details=details)
     return {
         "category": "platform",
@@ -726,12 +727,6 @@ def classify_adapter_error(error: PlatformAdapterError) -> dict[str, Any]:
         "message": error.message,
         "details": dict(details),
     }
-
-
-def is_pre_platform_invalid_input_error(code: str) -> bool:
-    if not isinstance(code, str):
-        return False
-    return code.startswith("invalid_") and (code.endswith("_request") or code.endswith("_url"))
 
 
 def invalid_input_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -94,7 +94,7 @@ def execute_task(
             task_id,
             adapter_key,
             capability,
-            runtime_contract_error("invalid_task_request", "task_request 顶层形状不合法"),
+            invalid_input_error("invalid_task_request", "task_request 顶层形状不合法"),
         )
 
     adapter_key = normalized_request.target.adapter_key
@@ -107,7 +107,7 @@ def execute_task(
             task_id,
             adapter_key,
             capability,
-            runtime_contract_error("invalid_capability", "capability 无法投影到 adapter-facing family"),
+            invalid_input_error("invalid_capability", "capability 无法投影到 adapter-facing family"),
         )
 
     projection_axis_error = validate_projection_axes_for_current_runtime(normalized_request)
@@ -122,12 +122,7 @@ def execute_task(
             task_id,
             adapter_key,
             capability,
-            {
-                "category": "runtime_contract",
-                "code": "adapter_not_found",
-                "message": f"adapter `{adapter_key}` 不存在",
-                "details": {},
-            },
+            unsupported_error("adapter_not_found", f"adapter `{adapter_key}` 不存在"),
         )
 
     supported_capabilities, capability_error = validate_supported_capabilities(
@@ -140,15 +135,14 @@ def execute_task(
             task_id,
             adapter_key,
             capability,
-            {
-                "category": "runtime_contract",
-                "code": "capability_not_supported",
-                "message": f"adapter `{adapter_key}` 不支持 `{capability_family}`",
-                "details": {
+            unsupported_error(
+                "capability_not_supported",
+                f"adapter `{adapter_key}` 不支持 `{capability_family}`",
+                details={
                     "supported_capabilities": sorted(supported_capabilities),
                     "capability_family": capability_family,
                 },
-            },
+            ),
         )
 
     supported_targets, targets_error = validate_supported_targets(get_adapter_supported_targets(adapter))
@@ -159,12 +153,11 @@ def execute_task(
             task_id,
             adapter_key,
             capability,
-            {
-                "category": "runtime_contract",
-                "code": "target_type_not_supported",
-                "message": f"adapter `{adapter_key}` 不支持 target_type `{normalized_request.target.target_type}`",
-                "details": {"supported_targets": sorted(supported_targets)},
-            },
+            invalid_input_error(
+                "target_type_not_supported",
+                f"adapter `{adapter_key}` 不支持 target_type `{normalized_request.target.target_type}`",
+                details={"supported_targets": sorted(supported_targets)},
+            ),
         )
 
     supported_collection_modes, collection_modes_error = validate_supported_collection_modes(
@@ -177,12 +170,11 @@ def execute_task(
             task_id,
             adapter_key,
             capability,
-            {
-                "category": "runtime_contract",
-                "code": "collection_mode_not_supported",
-                "message": f"adapter `{adapter_key}` 不支持 collection_mode `{normalized_request.policy.collection_mode}`",
-                "details": {"supported_collection_modes": sorted(supported_collection_modes)},
-            },
+            invalid_input_error(
+                "collection_mode_not_supported",
+                f"adapter `{adapter_key}` 不支持 collection_mode `{normalized_request.policy.collection_mode}`",
+                details={"supported_collection_modes": sorted(supported_collection_modes)},
+            ),
         )
 
     adapter_request, projection_error = project_to_adapter_request(normalized_request, capability_family)
@@ -235,16 +227,16 @@ def validate_request(request: Any) -> dict[str, Any] | None:
 def normalize_request(request: Any) -> tuple[CoreTaskRequest | None, dict[str, Any] | None]:
     if type(request) is TaskRequest:
         if not isinstance(request.adapter_key, str) or not request.adapter_key:
-            return None, runtime_contract_error("invalid_task_request", "adapter_key 不能为空")
+            return None, invalid_input_error("invalid_task_request", "adapter_key 不能为空")
         if request.capability != CONTENT_DETAIL_BY_URL:
-            return None, runtime_contract_error(
+            return None, invalid_input_error(
                 "invalid_capability",
                 f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
             )
         if type(request.input) is not TaskInput:
-            return None, runtime_contract_error("invalid_task_request", "input 必须为对象")
+            return None, invalid_input_error("invalid_task_request", "input 必须为对象")
         if not isinstance(request.input.url, str) or not request.input.url:
-            return None, runtime_contract_error("invalid_task_request", "input.url 不能为空")
+            return None, invalid_input_error("invalid_task_request", "input.url 不能为空")
         return (
             CoreTaskRequest(
                 target=InputTarget(
@@ -258,27 +250,27 @@ def normalize_request(request: Any) -> tuple[CoreTaskRequest | None, dict[str, A
             None,
         )
     if type(request) is not CoreTaskRequest:
-        return None, runtime_contract_error("invalid_task_request", "task_request 顶层形状不合法")
+        return None, invalid_input_error("invalid_task_request", "task_request 顶层形状不合法")
     if type(request.target) is not InputTarget:
-        return None, runtime_contract_error("invalid_task_request", "target 必须为对象")
+        return None, invalid_input_error("invalid_task_request", "target 必须为对象")
     if type(request.policy) is not CollectionPolicy:
-        return None, runtime_contract_error("invalid_task_request", "policy 必须为对象")
+        return None, invalid_input_error("invalid_task_request", "policy 必须为对象")
 
     target = request.target
     policy = request.policy
     if not isinstance(target.adapter_key, str) or not target.adapter_key:
-        return None, runtime_contract_error("invalid_task_request", "adapter_key 不能为空")
+        return None, invalid_input_error("invalid_task_request", "adapter_key 不能为空")
     if target.capability != CONTENT_DETAIL_BY_URL:
-        return None, runtime_contract_error(
+        return None, invalid_input_error(
             "invalid_capability",
             f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
         )
     if not isinstance(target.target_value, str) or not target.target_value:
-        return None, runtime_contract_error("invalid_task_request", "target_value 不能为空")
+        return None, invalid_input_error("invalid_task_request", "target_value 不能为空")
     if not isinstance(target.target_type, str) or target.target_type not in ALLOWED_TARGET_TYPES:
-        return None, runtime_contract_error("invalid_task_request", "target_type 不合法")
+        return None, invalid_input_error("invalid_task_request", "target_type 不合法")
     if not isinstance(policy.collection_mode, str) or policy.collection_mode not in ALLOWED_COLLECTION_MODES:
-        return None, runtime_contract_error("invalid_task_request", "collection_mode 不合法")
+        return None, invalid_input_error("invalid_task_request", "collection_mode 不合法")
     return request, None
 
 
@@ -287,7 +279,7 @@ def resolve_capability_family(capability: str) -> tuple[str | None, dict[str, An
     if mapped is None:
         return (
             None,
-            runtime_contract_error(
+            invalid_input_error(
                 "invalid_capability",
                 f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
             ),
@@ -312,12 +304,12 @@ def project_to_adapter_request(
 
 def validate_projection_axes_for_current_runtime(request: CoreTaskRequest) -> dict[str, Any] | None:
     if request.target.target_type != "url":
-        return runtime_contract_error(
+        return invalid_input_error(
             "invalid_task_request",
             "当前运行时执行路径仅支持 target_type=url",
         )
     if request.policy.collection_mode != LEGACY_COLLECTION_MODE:
-        return runtime_contract_error(
+        return invalid_input_error(
             "invalid_task_request",
             "当前运行时执行路径仅支持 collection_mode=hybrid",
         )
@@ -728,6 +720,24 @@ def failure_envelope(task_id: str, adapter_key: str, capability: str, error: Map
 def runtime_contract_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
     return {
         "category": "runtime_contract",
+        "code": code,
+        "message": message,
+        "details": dict(details or {}),
+    }
+
+
+def invalid_input_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "category": "invalid_input",
+        "code": code,
+        "message": message,
+        "details": dict(details or {}),
+    }
+
+
+def unsupported_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "category": "unsupported",
         "code": code,
         "message": message,
         "details": dict(details or {}),

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -86,7 +86,7 @@ class CliTests(unittest.TestCase):
         payload = json.loads(result.stderr)
         self.assertEqual(payload["status"], "failed")
         self.assertEqual(payload["adapter_key"], "stub")
-        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["category"], "invalid_input")
         self.assertEqual(payload["error"]["code"], "invalid_cli_arguments")
 
     def test_cli_parse_failure_preserves_adapter_key_from_equals_syntax(self) -> None:
@@ -312,7 +312,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "")
         payload = json.loads(stderr.getvalue())
         self.assertEqual(payload["status"], "failed")
-        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["category"], "unsupported")
 
     def test_injected_empty_adapter_registry_is_authoritative(self) -> None:
         stdout = io.StringIO()
@@ -338,6 +338,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), "")
         payload = json.loads(stderr.getvalue())
         self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["error"]["category"], "unsupported")
         self.assertEqual(payload["error"]["code"], "adapter_not_found")
 
     def test_cli_loader_failure_returns_machine_readable_failure(self) -> None:

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -53,7 +53,7 @@ class UnsupportedCapabilityAdapter:
 
 
 class ExecutorTests(unittest.TestCase):
-    def test_returns_runtime_contract_failure_when_adapter_is_missing(self) -> None:
+    def test_returns_unsupported_failure_when_adapter_is_missing(self) -> None:
         request = TaskRequest(
             adapter_key="missing",
             capability="content_detail_by_url",
@@ -63,10 +63,10 @@ class ExecutorTests(unittest.TestCase):
         result = execute_task(request, adapters={})
 
         self.assertEqual(result["status"], "failed")
-        self.assertEqual(result["error"]["category"], "runtime_contract")
+        self.assertEqual(result["error"]["category"], "unsupported")
         self.assertEqual(result["error"]["code"], "adapter_not_found")
 
-    def test_returns_runtime_contract_failure_when_capability_is_unsupported(self) -> None:
+    def test_returns_unsupported_failure_when_adapter_capability_is_unsupported(self) -> None:
         request = TaskRequest(
             adapter_key="xhs",
             capability="content_detail_by_url",
@@ -76,7 +76,7 @@ class ExecutorTests(unittest.TestCase):
         result = execute_task(request, adapters={"xhs": UnsupportedCapabilityAdapter()})
 
         self.assertEqual(result["status"], "failed")
-        self.assertEqual(result["error"]["category"], "runtime_contract")
+        self.assertEqual(result["error"]["category"], "unsupported")
         self.assertEqual(result["error"]["code"], "capability_not_supported")
 
     def test_returns_success_envelope_for_valid_adapter_result(self) -> None:

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -355,7 +355,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_unknown_collection_mode(self) -> None:
@@ -376,7 +376,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_non_url_target_at_shared_projection_guard(self) -> None:
@@ -397,7 +397,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_public_collection_mode_at_shared_projection_guard(self) -> None:
@@ -418,7 +418,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_authenticated_collection_mode_at_shared_projection_guard(self) -> None:
@@ -439,10 +439,10 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
-    def test_execute_task_rejects_unknown_adapter_as_runtime_contract_failure(self) -> None:
+    def test_execute_task_rejects_unknown_adapter_as_unsupported_failure(self) -> None:
         request = TaskRequest(
             adapter_key="missing",
             capability="content_detail_by_url",
@@ -457,7 +457,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["task_id"], "task-002")
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "unsupported")
         self.assertEqual(envelope["error"]["code"], "adapter_not_found")
 
     def test_execute_task_rejects_legacy_request_when_adapter_lacks_supported_targets(self) -> None:
@@ -491,7 +491,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
 
     def test_execute_task_rejects_legacy_and_native_requests_with_same_hybrid_admission_error(self) -> None:
@@ -523,8 +523,8 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(legacy_envelope["status"], "failed")
         self.assertEqual(native_envelope["status"], "failed")
-        self.assertEqual(legacy_envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(native_envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(legacy_envelope["error"]["category"], "invalid_input")
+        self.assertEqual(native_envelope["error"]["category"], "invalid_input")
         self.assertEqual(legacy_envelope["error"]["code"], "collection_mode_not_supported")
         self.assertEqual(native_envelope["error"]["code"], "collection_mode_not_supported")
         self.assertEqual(legacy_envelope["error"]["details"], native_envelope["error"]["details"])
@@ -543,7 +543,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_capability")
 
     def test_execute_task_rejects_success_without_raw_payload(self) -> None:
@@ -724,7 +724,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_rejects_extended_task_request_shape(self) -> None:
@@ -742,7 +742,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_fails_closed_for_malformed_request_mapping(self) -> None:
@@ -758,7 +758,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["task_id"], "task-malformed-request")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_fails_closed_for_request_mapping_that_raises_on_get(self) -> None:
@@ -770,7 +770,7 @@ class RuntimeExecutionTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["task_id"], "task-exploding-request")
-        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_fails_closed_for_none_supported_capabilities(self) -> None:

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -160,6 +160,21 @@ class PlatformFailureAdapter:
         )
 
 
+class PrePlatformValidationAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request: TaskRequest):
+        raise PlatformAdapterError(
+            code="adapter_precheck_failed",
+            message="adapter pre-platform validation failed",
+            details={"reason": "precheck"},
+            category="invalid_input",
+        )
+
+
 class NoneCapabilitiesAdapter:
     adapter_key = "stub"
     supported_capabilities = None
@@ -685,6 +700,23 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_douyin_url")
+
+    def test_execute_task_maps_explicit_pre_platform_adapter_error_to_invalid_input(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/1"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": PrePlatformValidationAdapter()},
+            task_id_factory=lambda: "task-preplatform-invalid-input",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
+        self.assertEqual(envelope["error"]["code"], "adapter_precheck_failed")
 
     def test_execute_task_rejects_empty_task_id_from_factory(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 import unittest
 
+from syvert.adapters.douyin import DouyinAdapter
+from syvert.adapters.xhs import XhsAdapter
 from syvert.runtime import (
     AdapterTaskRequest,
     CollectionPolicy,
@@ -649,6 +651,40 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["error"]["category"], "platform")
         self.assertEqual(envelope["error"]["code"], "content_not_found")
         self.assertEqual(envelope["error"]["details"]["reason"], "missing")
+
+    def test_execute_task_maps_real_xhs_invalid_url_to_invalid_input(self) -> None:
+        request = TaskRequest(
+            adapter_key="xhs",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/not-xhs"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"xhs": XhsAdapter()},
+            task_id_factory=lambda: "task-xhs-invalid-url",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
+        self.assertEqual(envelope["error"]["code"], "invalid_xhs_url")
+
+    def test_execute_task_maps_real_douyin_invalid_url_to_invalid_input(self) -> None:
+        request = TaskRequest(
+            adapter_key="douyin",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/not-douyin"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"douyin": DouyinAdapter()},
+            task_id_factory=lambda: "task-douyin-invalid-url",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
+        self.assertEqual(envelope["error"]["code"], "invalid_douyin_url")
 
     def test_execute_task_rejects_empty_task_id_from_factory(self) -> None:
         request = TaskRequest(


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：把 `FR-0005` 的标准化错误模型从 formal spec 落到 runtime / CLI 实现，补齐 `invalid_input`、`unsupported`、`runtime_contract`、`platform` 四类失败语义。
- 主要改动：
  - 在 `syvert/runtime.py` 新增 `invalid_input` / `unsupported` helper，并将非法请求、adapter 不存在、adapter capability 不支持、adapter pre-platform 输入不满足等路径重新映射到 formal spec 指定分类。
  - 在 `syvert/cli.py` 将 CLI 参数解析失败改为 `invalid_input`，保留 loader / serialization fail-closed 为 `runtime_contract`。
  - 更新 runtime / executor / CLI 回归测试断言，并为 `#69` 新建 active exec-plan，同步 release / sprint 最小索引入口。

## 关联事项

- Issue: #69
- Parent FR: #65
- item_key: `CHORE-0069-fr-0005-standardized-error-model`
- item_type: `CHORE`
- release: `v0.2.0`
- sprint: `2026-S15`
- Closing: Fixes #69

## 风险

- 风险级别：`normal`
- 审查关注：
  - `invalid_input` 与 `unsupported` 的边界是否符合 `FR-0005` formal spec，尤其是 adapter pre-platform admission。
  - `runtime_contract` 是否仅保留 registry / metadata / payload / host-side fail-closed 路径。
  - 本 PR 是否保持在错误模型范围内，没有提前引入 adapter registry 或 harness / gate 语义。

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_cli tests.runtime.test_executor`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/open_pr.py --class implementation --issue 69 --item-key CHORE-0069-fr-0005-standardized-error-model --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 落地 FR-0005 标准化错误模型' --closing fixes --dry-run`
- 未执行：
  - guardian
  - `python3 scripts/merge_pr.py merge-if-safe 97`

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
