### PR TITLE
feat(runtime): 落地 FR-0005 适配器注册表

### DIFF
--- a/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
+++ b/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
@@ -39,7 +39,8 @@
 - 已新增 `syvert/registry.py` 并在 `execute_task()` 中接入 registry materialization / lookup / discovery。
 - 已补齐 registry / runtime 相关测试并更新 release / sprint 索引。
 - 当前受审 PR 为 `#98`，绑定 `Issue #70` / `item_key=CHORE-0070-fr-0005-adapter-registry`。
-- 当前停在 guardian 前的最后审查补件：已完成实现提交、PR scope 校验、commit check 与受控 `open_pr` 创建。
+- guardian 首轮审查已给出两个阻断：无效 adapter 声明未在 materialization 阶段 fail-close，以及默认 shared builder 路径会吞掉 duplicate key。
+- 当前停在 guardian 阻断收口后的待提交状态：已补齐 adapter `execute` 最小宿主契约校验、shared builder duplicate-key 保留语义，以及对应 runtime / registry / CLI 回归测试。
 
 ## 下一步动作
 
@@ -67,7 +68,7 @@
 - 已阅读：`code_review.md`
 - 已阅读：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_cli tests.runtime.test_registry`
-  - 结果：`Ran 58 tests in 1.765s`，`OK`
+  - 结果：`Ran 62 tests in 1.703s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
@@ -75,10 +76,12 @@
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - 结果：通过
 - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
-  - 结果：已校验 2 条提交信息，全部通过
+  - 结果：已校验 3 条提交信息，全部通过
 - `python3 scripts/open_pr.py --class implementation --issue 70 --item-key CHORE-0070-fr-0005-adapter-registry --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 落地 FR-0005 适配器注册表' --closing fixes --dry-run`
   - 结果：通过
 - 已创建当前受审 PR：`#98 https://github.com/MC-and-his-Agents/Syvert/pull/98`
+- `SYVERT_GUARDIAN_TIMEOUT_SECONDS=36000 python3 scripts/pr_guardian.py review 98 --post-review`
+  - 结果：首轮 `REQUEST_CHANGES`；阻断项已定位为“无效 adapter 声明未在 materialization 阶段 fail-close”和“默认 shared builder 路径吞掉 duplicate key”
 
 ## 未决风险
 
@@ -92,4 +95,4 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - `37d6b835f01867ac99e307a46016498f5f9e5af9`
-- 说明：该 checkpoint 已包含 registry 实现、测试与索引更新；当前增量只补充 PR / 门禁元数据，可由 guardian state 继续绑定当前受审 head。
+- 说明：该 checkpoint 已包含 registry 实现、测试与索引更新；后续 guardian 阻断收口提交仅补充 fail-closed 与 duplicate-key 保真，不改写 `FR-0005` contract 边界。

--- a/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
+++ b/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
@@ -9,7 +9,8 @@
 - sprint：`2026-S15`
 - 关联 spec：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#98`
+- 状态：`active`
 
 ## 目标
 
@@ -36,12 +37,15 @@
 
 - `FR-0005` formal spec 已由 PR `#78` 合入主干。
 - 已新增 `syvert/registry.py` 并在 `execute_task()` 中接入 registry materialization / lookup / discovery。
-- 已补齐 registry / runtime 相关测试并更新 release / sprint 索引；当前待进入提交、PR、guardian 与 merge gate。
+- 已补齐 registry / runtime 相关测试并更新 release / sprint 索引。
+- 当前受审 PR 为 `#98`，绑定 `Issue #70` / `item_key=CHORE-0070-fr-0005-adapter-registry`。
+- 当前停在 guardian 前的最后审查补件：已完成实现提交、PR scope 校验、commit check 与受控 `open_pr` 创建。
 
 ## 下一步动作
 
-- 提交改动并完成 `pr_scope_guard` / `commit_check` / `open_pr --dry-run`。
-- 进入 review / guardian / merge gate 后按流程完成 PR 与 closeout。
+- 在当前 head 上完成 guardian 审查。
+- 若 guardian 给出新的阻断，只修当前 head 的最新阻断。
+- guardian 通过后使用受控 `merge_pr` 合并，并同步 closeout `#70`。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -63,17 +67,18 @@
 - 已阅读：`code_review.md`
 - 已阅读：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_cli tests.runtime.test_registry`
-  - 结果：`Ran 58 tests in 1.769s`，`OK`
+  - 结果：`Ran 58 tests in 1.765s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
   - 结果：通过
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
-  - 结果：待在当前实现提交形成后执行
+  - 结果：通过
 - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
-  - 结果：待在当前实现提交形成后执行
+  - 结果：已校验 1 条提交信息，全部通过
 - `python3 scripts/open_pr.py --class implementation --issue 70 --item-key CHORE-0070-fr-0005-adapter-registry --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 落地 FR-0005 适配器注册表' --closing fixes --dry-run`
-  - 结果：待在当前实现提交形成后执行
+  - 结果：通过
+- 已创建当前受审 PR：`#98 https://github.com/MC-and-his-Agents/Syvert/pull/98`
 
 ## 未决风险
 
@@ -86,4 +91,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `94a90f13b78e0af20fed3939397b674d5a20ad3a`
+- `37d6b835f01867ac99e307a46016498f5f9e5af9`
+- 说明：该 checkpoint 已包含 registry 实现、测试与索引更新；当前增量只补充 PR / 门禁元数据，可由 guardian state 继续绑定当前受审 head。

--- a/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
+++ b/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
@@ -1,0 +1,89 @@
+# CHORE-0070-fr-0005-adapter-registry 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0070-fr-0005-adapter-registry`
+- Issue：`#70`
+- item_type：`CHORE`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
+- 关联 decision：
+- 关联 PR：
+
+## 目标
+
+- 在 `FR-0005` 范围内落地 adapter registry，把 materialize、lookup、capability discovery 与 fail-closed 语义固化到运行时主路径。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/registry.py`
+  - `syvert/runtime.py`
+  - `syvert/adapters/__init__.py`
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_executor.py`
+  - `tests/runtime/test_registry.py`
+  - `docs/releases/v0.2.0.md`
+  - `docs/sprints/2026-S15.md`
+  - 本 exec-plan
+- 本次不纳入：
+  - fake adapter、harness、validator、version gate
+  - `FR-0004` 的输入建模语义改写
+  - 平台适配器内部平台逻辑
+
+## 当前停点
+
+- `FR-0005` formal spec 已由 PR `#78` 合入主干。
+- 已新增 `syvert/registry.py` 并在 `execute_task()` 中接入 registry materialization / lookup / discovery。
+- 已补齐 registry / runtime 相关测试并更新 release / sprint 索引；当前待进入提交、PR、guardian 与 merge gate。
+
+## 下一步动作
+
+- 提交改动并完成 `pr_scope_guard` / `commit_check` / `open_pr --dry-run`。
+- 进入 review / guardian / merge gate 后按流程完成 PR 与 closeout。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.2.0` 把 adapter registry contract 从 formal spec 落到 runtime，实现可验证的 registry materialization 与 discovery 语义。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0005` 的第二个 implementation Work Item，负责把 adapter registry contract 落到 Core。
+- 阻塞：
+  - 不得把 harness、fake adapter、gate 或额外 FR 范围并入当前回合。
+
+## 已验证项
+
+- 已阅读：`AGENTS.md`
+- 已阅读：`WORKFLOW.md`
+- 已阅读：`docs/AGENTS.md`
+- 已阅读：`docs/process/delivery-funnel.md`
+- 已阅读：`spec_review.md`
+- 已阅读：`code_review.md`
+- 已阅读：`docs/specs/FR-0005-standardized-error-model-and-adapter-registry/`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_cli tests.runtime.test_registry`
+  - 结果：`Ran 58 tests in 1.769s`，`OK`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：待在当前实现提交形成后执行
+- `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
+  - 结果：待在当前实现提交形成后执行
+- `python3 scripts/open_pr.py --class implementation --issue 70 --item-key CHORE-0070-fr-0005-adapter-registry --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 落地 FR-0005 适配器注册表' --closing fixes --dry-run`
+  - 结果：待在当前实现提交形成后执行
+
+## 未决风险
+
+- registry discovery 若引入真实平台副作用，将破坏 `FR-0005` 的 discovery 约束并影响后续 `FR-0006` harness。
+- 若把 registry 失配误判为 `unsupported`，会破坏 `runtime_contract` 的 fail-closed 边界。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对 registry、runtime、tests 与索引工件的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `94a90f13b78e0af20fed3939397b674d5a20ad3a`

--- a/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
+++ b/docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md
@@ -75,7 +75,7 @@
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - 结果：通过
 - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
-  - 结果：已校验 1 条提交信息，全部通过
+  - 结果：已校验 2 条提交信息，全部通过
 - `python3 scripts/open_pr.py --class implementation --issue 70 --item-key CHORE-0070-fr-0005-adapter-registry --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 落地 FR-0005 适配器注册表' --closing fixes --dry-run`
   - 结果：通过
 - 已创建当前受审 PR：`#98 https://github.com/MC-and-his-Agents/Syvert/pull/98`

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -35,7 +35,7 @@
 - `FR-0005-standardized-error-model-and-adapter-registry`：`v0.2.0` 共享运行时契约主线之一，对应 Issue `#65`
 - `CHORE-0051-fr-0005-formal-spec`：`FR-0005` 的 formal spec Work Item，对应 Issue `#77`
 - `CHORE-0069-fr-0005-standardized-error-model`：`FR-0005` 的错误模型实现 Work Item，对应 Issue `#69`
-- `#70`：`FR-0005` 下的“实现适配器注册表” Work Item
+- `CHORE-0070-fr-0005-adapter-registry`：`FR-0005` 的 adapter registry 实现 Work Item，对应 Issue `#70`
 - `GOV-0027-governance-contract-rewrite`：治理契约重写与口径收敛，对应 Issue `#56`
 - `GOV-0028-harness-compat-migration`：后续 harness 兼容迁移，对应 Issue `#57`
 - `GOV-0029-remove-legacy-todo-md`：移除 legacy `TODO.md` 的正式治理流入口与存量 compat 残留，对应 Issue `#58`
@@ -52,7 +52,7 @@
 - `FR-0004` 的 implementation 子事项 `#87/#89/#88` 已分别由 PR `#90/#91/#92` 合入主干
 - `#68` implementation 聚合 closeout 已由 PR `#93` 收口并关闭，formal spec、实现子事项与 release / sprint / exec-plan 的引用链已统一
 - 当前仅剩父 FR `#64` closeout，由 Work Item `#95` / PR `#96` 把以上主干事实与 GitHub 关闭语义完成最终对齐
-- `FR-0005` 的 formal spec 已由 PR `#78` 合入主干；`#69` 当前为 active implementation 回合，负责把四类错误分类落到 runtime / CLI 的统一失败路径
+- `FR-0005` 的 formal spec 已由 PR `#78` 合入主干；`#69` 负责把四类错误分类落到 runtime / CLI 的统一失败路径；`#70` 已建立 adapter registry implementation exec-plan 入口
 
 ## 关联工件
 
@@ -75,6 +75,7 @@
   - `docs/exec-plans/CHORE-0088-fr-0004-fr-0002-compat-closeout.md`
   - `docs/exec-plans/CHORE-0051-fr-0005-formal-spec.md`
   - `docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md`（current active；绑定 Issue `#69`）
+  - `docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md`（current active；绑定 Issue `#70`）
   - `docs/exec-plans/CHORE-0051-fr-0006-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -35,7 +35,7 @@
 - `GOV-0028-harness-compat-migration`：后续 harness 兼容迁移 Work Item，对应 Issue `#57`
 - `GOV-0029-remove-legacy-todo-md`：移除 legacy `TODO.md` 的正式治理流入口，对应 Issue `#58`
 - `CHORE-0069-fr-0005-standardized-error-model`：`FR-0005` 的错误模型实现 Work Item，对应 Issue `#69`
-- `#70`：`FR-0005` 下的“实现适配器注册表” Work Item
+- `CHORE-0070-fr-0005-adapter-registry`：`FR-0005` 的 adapter registry 实现 Work Item，对应 Issue `#70`
 
 ## 进入前依赖
 
@@ -83,6 +83,7 @@
 - `FR-0005` 已在当前 sprint 建立错误模型与 adapter registry 的 formal spec 入口；后续实现拆分为 `#69` 与 `#70`。
 - `CHORE-0051` 已为 `FR-0005` 提供独立 Work Item 执行入口，负责 formal spec PR、checks、guardian 与 merge gate。
 - `CHORE-0069` 已在当前 sprint 建立 `FR-0005` 的第一个 implementation 入口，负责把四类错误分类落到 runtime / CLI 的统一失败路径。
+- `CHORE-0070` 已在当前 sprint 建立 `FR-0005` 的第二个 implementation 入口，负责把 adapter registry contract 落到 runtime。
 - `CHORE-0051-fr-0006-formal-spec-closeout` 已为 `FR-0006` 提供独立 Work Item 执行入口，负责当前 formal spec PR 的受控 closeout。
 
 ## 协作入口
@@ -115,6 +116,7 @@
   - `docs/exec-plans/CHORE-0095-fr-0004-parent-closeout.md`（current active；绑定 Issue `#95` / PR `#96`）
   - `docs/exec-plans/CHORE-0051-fr-0005-formal-spec.md`
   - `docs/exec-plans/CHORE-0069-fr-0005-standardized-error-model.md`（current active；绑定 Issue `#69`）
+  - `docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md`（current active；绑定 Issue `#70`）
   - `docs/exec-plans/CHORE-0041-runtime-cli-skeleton.md`（active，绑定 Issue `#41` / PR `#44`）
   - `docs/exec-plans/CHORE-0050-douyin-reference-adapter.md`
   - `docs/exec-plans/CHORE-0068-fr-0004-formal-spec-closeout.md`（historical / inactive；formal spec 已由 PR `#82` 收口）

--- a/syvert/adapters/__init__.py
+++ b/syvert/adapters/__init__.py
@@ -3,6 +3,7 @@ from syvert.adapters.xhs import XhsAdapter, build_adapters as build_xhs_adapters
 
 
 def build_adapters() -> dict[str, object]:
+    """Return adapter bindings for registry materialization."""
     adapters: dict[str, object] = {}
     adapters.update(build_xhs_adapters())
     adapters.update(build_douyin_adapters())

--- a/syvert/adapters/__init__.py
+++ b/syvert/adapters/__init__.py
@@ -1,13 +1,42 @@
+from collections.abc import Iterator, Mapping
+
 from syvert.adapters.douyin import DouyinAdapter, build_adapters as build_douyin_adapters
 from syvert.adapters.xhs import XhsAdapter, build_adapters as build_xhs_adapters
 
 
-def build_adapters() -> dict[str, object]:
+class AdapterBindingSources(Mapping[str, object]):
+    def __init__(self, *sources: Mapping[str, object]) -> None:
+        self._items: list[tuple[str, object]] = []
+        for source in sources:
+            self._items.extend(source.items())
+
+    def __iter__(self) -> Iterator[str]:
+        yielded: set[str] = set()
+        for adapter_key, _adapter in self._items:
+            if adapter_key in yielded:
+                continue
+            yielded.add(adapter_key)
+            yield adapter_key
+
+    def __len__(self) -> int:
+        return len({adapter_key for adapter_key, _adapter in self._items})
+
+    def __getitem__(self, key: str) -> object:
+        for adapter_key, adapter in self._items:
+            if adapter_key == key:
+                return adapter
+        raise KeyError(key)
+
+    def items(self) -> Iterator[tuple[str, object]]:
+        return iter(self._items)
+
+
+def build_adapters() -> Mapping[str, object]:
     """Return adapter bindings for registry materialization."""
-    adapters: dict[str, object] = {}
-    adapters.update(build_xhs_adapters())
-    adapters.update(build_douyin_adapters())
-    return adapters
+    return AdapterBindingSources(
+        build_xhs_adapters(),
+        build_douyin_adapters(),
+    )
 
 
 __all__ = ["XhsAdapter", "DouyinAdapter", "build_adapters"]

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+MISSING = object()
+
+
+class RegistryError(Exception):
+    def __init__(self, code: str, message: str, *, details: Mapping[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = dict(details or {})
+
+
+@dataclass(frozen=True)
+class AdapterDeclaration:
+    adapter_key: str
+    adapter: Any
+    supported_capabilities: frozenset[str]
+    supported_targets: frozenset[str]
+    supported_collection_modes: frozenset[str]
+
+
+class AdapterRegistry:
+    def __init__(self, entries: Mapping[str, AdapterDeclaration]) -> None:
+        self._entries = dict(entries)
+
+    @classmethod
+    def from_mapping(cls, adapters: Mapping[str, Any]) -> AdapterRegistry:
+        if not isinstance(adapters, Mapping):
+            raise RegistryError(
+                "invalid_adapter_registry",
+                "adapters 必须是 mapping",
+                details={"actual_type": type(adapters).__name__},
+            )
+        try:
+            items = adapters.items()
+        except Exception as error:
+            raise RegistryError(
+                "invalid_adapter_registry",
+                "adapters 无法遍历",
+                details={"error_type": error.__class__.__name__},
+            ) from error
+
+        entries: dict[str, AdapterDeclaration] = {}
+        seen: set[str] = set()
+        try:
+            for adapter_key, adapter in items:
+                if not isinstance(adapter_key, str) or not adapter_key:
+                    raise RegistryError(
+                        "invalid_adapter_registry",
+                        "adapter_key 必须为非空字符串",
+                        details={"adapter_key": adapter_key},
+                    )
+                if adapter_key in seen:
+                    raise RegistryError(
+                        "invalid_adapter_registry",
+                        "adapter registry 存在重复 adapter_key",
+                        details={"adapter_key": adapter_key},
+                    )
+                seen.add(adapter_key)
+                declaration = _build_adapter_declaration(adapter_key, adapter)
+                entries[adapter_key] = declaration
+        except RegistryError:
+            raise
+        except Exception as error:
+            raise RegistryError(
+                "invalid_adapter_registry",
+                "adapters 无法遍历",
+                details={"error_type": error.__class__.__name__},
+            ) from error
+
+        return cls(entries)
+
+    def lookup(self, adapter_key: str) -> AdapterDeclaration | None:
+        return self._entries.get(adapter_key)
+
+    def discover_capabilities(self, adapter_key: str) -> frozenset[str] | None:
+        declaration = self.lookup(adapter_key)
+        if declaration is None:
+            return None
+        return declaration.supported_capabilities
+
+    def discover_targets(self, adapter_key: str) -> frozenset[str] | None:
+        declaration = self.lookup(adapter_key)
+        if declaration is None:
+            return None
+        return declaration.supported_targets
+
+    def discover_collection_modes(self, adapter_key: str) -> frozenset[str] | None:
+        declaration = self.lookup(adapter_key)
+        if declaration is None:
+            return None
+        return declaration.supported_collection_modes
+
+
+def _build_adapter_declaration(adapter_key: str, adapter: Any) -> AdapterDeclaration:
+    capabilities = _get_adapter_attribute(adapter, "supported_capabilities")
+    targets = _get_adapter_attribute(adapter, "supported_targets")
+    collection_modes = _get_adapter_attribute(adapter, "supported_collection_modes")
+
+    supported_capabilities = _validate_supported_capabilities(capabilities)
+    supported_targets = _validate_supported_targets(targets)
+    supported_collection_modes = _validate_supported_collection_modes(collection_modes)
+
+    return AdapterDeclaration(
+        adapter_key=adapter_key,
+        adapter=adapter,
+        supported_capabilities=supported_capabilities,
+        supported_targets=supported_targets,
+        supported_collection_modes=supported_collection_modes,
+    )
+
+
+def _get_adapter_attribute(adapter: Any, name: str) -> Any:
+    try:
+        return getattr(adapter, name)
+    except AttributeError:
+        return MISSING
+    except Exception:
+        return MISSING
+
+
+def _validate_supported_capabilities(raw_capabilities: Any) -> frozenset[str]:
+    return _validate_supported_axis(
+        raw_capabilities,
+        missing_code="invalid_adapter_capabilities",
+        message="supported_capabilities 必须为字符串集合",
+    )
+
+
+def _validate_supported_targets(raw_targets: Any) -> frozenset[str]:
+    return _validate_supported_axis(
+        raw_targets,
+        missing_code="invalid_adapter_targets",
+        message="supported_targets 必须为字符串集合",
+    )
+
+
+def _validate_supported_collection_modes(raw_modes: Any) -> frozenset[str]:
+    return _validate_supported_axis(
+        raw_modes,
+        missing_code="invalid_adapter_collection_modes",
+        message="supported_collection_modes 必须为字符串集合",
+    )
+
+
+def _validate_supported_axis(
+    raw_values: Any,
+    *,
+    missing_code: str,
+    message: str,
+) -> frozenset[str]:
+    if raw_values is MISSING:
+        raise RegistryError(
+            missing_code,
+            message,
+            details={"reason": "missing"},
+        )
+    if raw_values is None:
+        raise RegistryError(
+            missing_code,
+            message,
+            details={"actual_type": "NoneType"},
+        )
+    if isinstance(raw_values, (str, bytes)):
+        raise RegistryError(
+            missing_code,
+            message,
+            details={"actual_type": type(raw_values).__name__},
+        )
+    try:
+        iterator = iter(raw_values)
+    except TypeError:
+        raise RegistryError(
+            missing_code,
+            message,
+            details={"actual_type": type(raw_values).__name__},
+        )
+    validated: list[str] = []
+    try:
+        for value in iterator:
+            if not isinstance(value, str):
+                raise RegistryError(
+                    missing_code,
+                    message,
+                    details={"invalid_value_type": type(value).__name__},
+                )
+            validated.append(value)
+    except RegistryError:
+        raise
+    except Exception as error:
+        raise RegistryError(
+            missing_code,
+            message,
+            details={"error_type": error.__class__.__name__},
+        ) from error
+    return frozenset(validated)

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 
 MISSING = object()
@@ -98,6 +99,7 @@ class AdapterRegistry:
 
 
 def _build_adapter_declaration(adapter_key: str, adapter: Any) -> AdapterDeclaration:
+    _validate_adapter_execute(adapter_key, adapter)
     capabilities = _get_adapter_attribute(adapter, "supported_capabilities")
     targets = _get_adapter_attribute(adapter, "supported_targets")
     collection_modes = _get_adapter_attribute(adapter, "supported_collection_modes")
@@ -122,6 +124,22 @@ def _get_adapter_attribute(adapter: Any, name: str) -> Any:
         return MISSING
     except Exception:
         return MISSING
+
+
+def _validate_adapter_execute(adapter_key: str, adapter: Any) -> None:
+    execute = _get_adapter_attribute(adapter, "execute")
+    if execute is MISSING:
+        raise RegistryError(
+            "invalid_adapter_declaration",
+            "adapter 必须提供可调用的 execute",
+            details={"adapter_key": adapter_key, "reason": "missing_execute"},
+        )
+    if not callable(execute):
+        raise RegistryError(
+            "invalid_adapter_declaration",
+            "adapter 必须提供可调用的 execute",
+            details={"adapter_key": adapter_key, "reason": "non_callable_execute"},
+        )
 
 
 def _validate_supported_capabilities(raw_capabilities: Any) -> frozenset[str]:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, Callable, Mapping
 from uuid import uuid4
 
+from syvert.registry import AdapterRegistry, RegistryError
 
 CONTENT_DETAIL_BY_URL = "content_detail_by_url"
 CONTENT_DETAIL = "content_detail"
@@ -15,7 +16,6 @@ ALLOWED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
 CAPABILITY_FAMILY_BY_OPERATION = {CONTENT_DETAIL_BY_URL: CONTENT_DETAIL}
 ALLOWED_CONTENT_TYPES = {"video", "image_post", "mixed_media", "unknown"}
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
-MISSING = object()
 
 
 @dataclass(frozen=True)
@@ -115,10 +115,22 @@ def execute_task(
     if projection_axis_error is not None:
         return failure_envelope(task_id, adapter_key, capability, projection_axis_error)
 
-    adapter, adapter_error = get_adapter(adapters, adapter_key)
-    if adapter_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, adapter_error)
-    if adapter is None:
+    try:
+        registry = AdapterRegistry.from_mapping(adapters)
+    except RegistryError as error:
+        return failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error(
+                error.code,
+                error.message,
+                details=error.details,
+            ),
+        )
+
+    declaration = registry.lookup(adapter_key)
+    if declaration is None:
         return failure_envelope(
             task_id,
             adapter_key,
@@ -126,11 +138,7 @@ def execute_task(
             unsupported_error("adapter_not_found", f"adapter `{adapter_key}` 不存在"),
         )
 
-    supported_capabilities, capability_error = validate_supported_capabilities(
-        get_adapter_supported_capabilities(adapter)
-    )
-    if capability_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, capability_error)
+    supported_capabilities = declaration.supported_capabilities
     if capability_family not in supported_capabilities:
         return failure_envelope(
             task_id,
@@ -146,9 +154,7 @@ def execute_task(
             ),
         )
 
-    supported_targets, targets_error = validate_supported_targets(get_adapter_supported_targets(adapter))
-    if targets_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, targets_error)
+    supported_targets = declaration.supported_targets
     if normalized_request.target.target_type not in supported_targets:
         return failure_envelope(
             task_id,
@@ -161,11 +167,7 @@ def execute_task(
             ),
         )
 
-    supported_collection_modes, collection_modes_error = validate_supported_collection_modes(
-        get_adapter_supported_collection_modes(adapter)
-    )
-    if collection_modes_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, collection_modes_error)
+    supported_collection_modes = declaration.supported_collection_modes
     if normalized_request.policy.collection_mode not in supported_collection_modes:
         return failure_envelope(
             task_id,
@@ -183,7 +185,7 @@ def execute_task(
         return failure_envelope(task_id, adapter_key, capability, projection_error)
 
     try:
-        payload = adapter.execute(adapter_request)
+        payload = declaration.adapter.execute(adapter_request)
         payload_error = validate_success_payload(payload)
         if payload_error is not None:
             return failure_envelope(task_id, adapter_key, capability, payload_error)
@@ -361,168 +363,6 @@ def extract_request_context(request: Any) -> tuple[str, str]:
     return safe_adapter_key, safe_capability
 
 
-def get_adapter(adapters: Mapping[str, Any], adapter_key: str) -> tuple[Any, dict[str, Any] | None]:
-    try:
-        getter = getattr(adapters, "get")
-    except Exception as error:
-        return None, runtime_contract_error(
-            "invalid_adapter_registry",
-            "adapters 必须是支持 get() 的映射对象",
-            details={"error_type": error.__class__.__name__},
-        )
-    if not callable(getter):
-        return None, runtime_contract_error(
-            "invalid_adapter_registry",
-            "adapters 必须是支持 get() 的映射对象",
-        )
-    try:
-        return getter(adapter_key), None
-    except Exception as error:
-        return None, runtime_contract_error(
-            "invalid_adapter_registry",
-            "adapters.get() 执行失败",
-            details={"error_type": error.__class__.__name__},
-        )
-
-
-def get_adapter_supported_capabilities(adapter: Any) -> Any:
-    try:
-        return getattr(adapter, "supported_capabilities")
-    except AttributeError:
-        return MISSING
-    except Exception:
-        return MISSING
-
-
-def get_adapter_supported_targets(adapter: Any) -> Any:
-    try:
-        return getattr(adapter, "supported_targets")
-    except AttributeError:
-        return MISSING
-    except Exception:
-        return MISSING
-
-
-def get_adapter_supported_collection_modes(adapter: Any) -> Any:
-    try:
-        return getattr(adapter, "supported_collection_modes")
-    except AttributeError:
-        return MISSING
-    except Exception:
-        return MISSING
-
-
-def validate_supported_capabilities(raw_capabilities: Any) -> tuple[frozenset[str], dict[str, Any] | None]:
-    if raw_capabilities is MISSING:
-        return frozenset(), runtime_contract_error(
-            "invalid_adapter_capabilities",
-            "supported_capabilities 必须为字符串集合",
-            details={"reason": "missing"},
-        )
-    if raw_capabilities is None:
-        return frozenset(), runtime_contract_error(
-            "invalid_adapter_capabilities",
-            "supported_capabilities 必须为字符串集合",
-            details={"actual_type": "NoneType"},
-        )
-    if isinstance(raw_capabilities, (str, bytes)):
-        return frozenset(), runtime_contract_error(
-            "invalid_adapter_capabilities",
-            "supported_capabilities 必须为字符串集合",
-            details={"actual_type": type(raw_capabilities).__name__},
-        )
-    try:
-        iterator = iter(raw_capabilities)
-    except TypeError:
-        return frozenset(), runtime_contract_error(
-            "invalid_adapter_capabilities",
-            "supported_capabilities 必须为字符串集合",
-            details={"actual_type": type(raw_capabilities).__name__},
-        )
-    validated: list[str] = []
-    try:
-        for value in iterator:
-            if not isinstance(value, str):
-                return frozenset(), runtime_contract_error(
-                    "invalid_adapter_capabilities",
-                    "supported_capabilities 必须为字符串集合",
-                    details={"invalid_value_type": type(value).__name__},
-                )
-            validated.append(value)
-    except Exception as error:
-        return frozenset(), runtime_contract_error(
-            "invalid_adapter_capabilities",
-            "supported_capabilities 必须为字符串集合",
-            details={"error_type": error.__class__.__name__},
-        )
-    return frozenset(validated), None
-
-
-def validate_supported_targets(raw_targets: Any) -> tuple[frozenset[str], dict[str, Any] | None]:
-    return validate_supported_axis(
-        raw_targets,
-        missing_code="invalid_adapter_targets",
-        message="supported_targets 必须为字符串集合",
-    )
-
-
-def validate_supported_collection_modes(raw_modes: Any) -> tuple[frozenset[str], dict[str, Any] | None]:
-    return validate_supported_axis(
-        raw_modes,
-        missing_code="invalid_adapter_collection_modes",
-        message="supported_collection_modes 必须为字符串集合",
-    )
-
-
-def validate_supported_axis(
-    raw_values: Any,
-    *,
-    missing_code: str,
-    message: str,
-) -> tuple[frozenset[str], dict[str, Any] | None]:
-    if raw_values is MISSING:
-        return frozenset(), runtime_contract_error(
-            missing_code,
-            message,
-            details={"reason": "missing"},
-        )
-    if raw_values is None:
-        return frozenset(), runtime_contract_error(
-            missing_code,
-            message,
-            details={"actual_type": "NoneType"},
-        )
-    if isinstance(raw_values, (str, bytes)):
-        return frozenset(), runtime_contract_error(
-            missing_code,
-            message,
-            details={"actual_type": type(raw_values).__name__},
-        )
-    try:
-        iterator = iter(raw_values)
-    except TypeError:
-        return frozenset(), runtime_contract_error(
-            missing_code,
-            message,
-            details={"actual_type": type(raw_values).__name__},
-        )
-    validated: list[str] = []
-    try:
-        for value in iterator:
-            if not isinstance(value, str):
-                return frozenset(), runtime_contract_error(
-                    missing_code,
-                    message,
-                    details={"invalid_value_type": type(value).__name__},
-                )
-            validated.append(value)
-    except Exception as error:
-        return frozenset(), runtime_contract_error(
-            missing_code,
-            message,
-            details={"error_type": error.__class__.__name__},
-        )
-    return frozenset(validated), None
 
 
 def resolve_task_id(task_id_factory: Callable[[], str] | None) -> tuple[str, dict[str, Any] | None]:

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from syvert.cli import main
 
@@ -262,6 +263,36 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["normalized"]["canonical_url"], "https://www.douyin.com/video/7580570616932224282")
         self.assertEqual(len(handler_state["sign_calls"]), 1)
         self.assertEqual(len(handler_state["detail_calls"]), 1)
+
+    def test_cli_shared_builder_fails_closed_for_duplicate_adapter_keys(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with mock.patch("syvert.adapters.build_xhs_adapters", return_value={"dup": SuccessfulAdapter()}), mock.patch(
+            "syvert.adapters.build_douyin_adapters",
+            return_value={"dup": SuccessfulAdapter()},
+        ):
+            exit_code = main(
+                [
+                    "--adapter",
+                    "dup",
+                    "--capability",
+                    "content_detail_by_url",
+                    "--url",
+                    "https://example.com/posts/1",
+                    "--adapter-module",
+                    "syvert.adapters:build_adapters",
+                ],
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "invalid_adapter_registry")
 
     def test_main_writes_success_envelope_to_stdout(self) -> None:
         stdout = io.StringIO()

--- a/tests/runtime/test_registry.py
+++ b/tests/runtime/test_registry.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import unittest
+from typing import Iterator, Tuple
+
+from syvert.registry import AdapterRegistry, RegistryError
+
+
+class SuccessfulAdapter:
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+
+class DiscoveryOnlyAdapter:
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self) -> None:
+        raise AssertionError("registry discovery must not execute adapters")
+
+
+class MissingCapabilitiesAdapter:
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+
+class MissingTargetsAdapter:
+    supported_capabilities = frozenset({"content_detail"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+
+class MissingCollectionModesAdapter:
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+
+
+class DuplicateAdapterRegistry(Mapping[str, object]):
+    def __init__(self, adapter: object) -> None:
+        self._adapter = adapter
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(("stub", "stub"))
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, key: str) -> object:
+        if key != "stub":
+            raise KeyError(key)
+        return self._adapter
+
+    def items(self) -> Iterator[Tuple[str, object]]:
+        return iter((("stub", self._adapter), ("stub", self._adapter)))
+
+
+class RegistryTests(unittest.TestCase):
+    def test_registry_materializes_declaration(self) -> None:
+        registry = AdapterRegistry.from_mapping({"stub": SuccessfulAdapter()})
+
+        declaration = registry.lookup("stub")
+        self.assertIsNotNone(declaration)
+        assert declaration is not None
+        self.assertEqual(declaration.adapter_key, "stub")
+        self.assertIn("content_detail", declaration.supported_capabilities)
+        self.assertIn("url", declaration.supported_targets)
+        self.assertIn("hybrid", declaration.supported_collection_modes)
+
+    def test_registry_discovery_is_side_effect_free(self) -> None:
+        registry = AdapterRegistry.from_mapping({"stub": DiscoveryOnlyAdapter()})
+
+        self.assertEqual(registry.discover_capabilities("stub"), frozenset({"content_detail"}))
+        self.assertEqual(registry.discover_targets("stub"), frozenset({"url"}))
+        self.assertEqual(registry.discover_collection_modes("stub"), frozenset({"hybrid"}))
+
+    def test_registry_rejects_duplicate_keys(self) -> None:
+        with self.assertRaises(RegistryError) as context:
+            AdapterRegistry.from_mapping(DuplicateAdapterRegistry(SuccessfulAdapter()))
+
+        self.assertEqual(context.exception.code, "invalid_adapter_registry")
+
+    def test_registry_rejects_missing_capabilities(self) -> None:
+        with self.assertRaises(RegistryError) as context:
+            AdapterRegistry.from_mapping({"stub": MissingCapabilitiesAdapter()})
+
+        self.assertEqual(context.exception.code, "invalid_adapter_capabilities")
+
+    def test_registry_rejects_missing_targets(self) -> None:
+        with self.assertRaises(RegistryError) as context:
+            AdapterRegistry.from_mapping({"stub": MissingTargetsAdapter()})
+
+        self.assertEqual(context.exception.code, "invalid_adapter_targets")
+
+    def test_registry_rejects_missing_collection_modes(self) -> None:
+        with self.assertRaises(RegistryError) as context:
+            AdapterRegistry.from_mapping({"stub": MissingCollectionModesAdapter()})
+
+        self.assertEqual(context.exception.code, "invalid_adapter_collection_modes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_registry.py
+++ b/tests/runtime/test_registry.py
@@ -12,6 +12,9 @@ class SuccessfulAdapter:
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
+    def execute(self) -> None:
+        raise AssertionError("registry tests must not execute adapters")
+
 
 class DiscoveryOnlyAdapter:
     supported_capabilities = frozenset({"content_detail"})
@@ -26,15 +29,30 @@ class MissingCapabilitiesAdapter:
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
+    def execute(self) -> None:
+        raise AssertionError("registry tests must not execute adapters")
+
 
 class MissingTargetsAdapter:
     supported_capabilities = frozenset({"content_detail"})
     supported_collection_modes = frozenset({"hybrid"})
 
+    def execute(self) -> None:
+        raise AssertionError("registry tests must not execute adapters")
+
 
 class MissingCollectionModesAdapter:
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
+
+    def execute(self) -> None:
+        raise AssertionError("registry tests must not execute adapters")
+
+
+class MissingExecuteAdapter:
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
 
 
 class DuplicateAdapterRegistry(Mapping[str, object]):
@@ -98,6 +116,12 @@ class RegistryTests(unittest.TestCase):
             AdapterRegistry.from_mapping({"stub": MissingCollectionModesAdapter()})
 
         self.assertEqual(context.exception.code, "invalid_adapter_collection_modes")
+
+    def test_registry_rejects_missing_execute_contract(self) -> None:
+        with self.assertRaises(RegistryError) as context:
+            AdapterRegistry.from_mapping({"stub": MissingExecuteAdapter()})
+
+        self.assertEqual(context.exception.code, "invalid_adapter_declaration")
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -289,6 +289,22 @@ class BroadAxesAdapter:
         raise AssertionError("shared admission should fail before adapter execution")
 
 
+class MissingCollectionModesAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
+class MissingExecuteAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+
 class RuntimeExecutionTests(unittest.TestCase):
     def test_execute_task_builds_success_envelope_from_adapter_payload(self) -> None:
         adapter = SuccessfulAdapter()
@@ -540,6 +556,23 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "collection_mode_not_supported")
+
+    def test_execute_task_fails_closed_for_missing_supported_collection_modes(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/1"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": MissingCollectionModesAdapter()},
+            task_id_factory=lambda: "task-missing-collection-modes",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_adapter_collection_modes")
 
     def test_execute_task_rejects_legacy_and_native_requests_with_same_hybrid_admission_error(self) -> None:
         legacy_request = TaskRequest(
@@ -990,6 +1023,23 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "invalid_adapter_capabilities")
+
+    def test_execute_task_fails_closed_for_missing_execute_contract(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/1"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={"stub": MissingExecuteAdapter()},
+            task_id_factory=lambda: "task-missing-execute",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_adapter_declaration")
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Iterator, Tuple
 import unittest
 
 from syvert.adapters.douyin import DouyinAdapter
@@ -220,9 +222,37 @@ class BrokenIterableCapabilitiesAdapter:
         raise AssertionError("execute should not be called")
 
 
-class ExplodingAdapterRegistry(dict):
-    def get(self, key, default=None):
+class ExplodingAdapterRegistry(Mapping[str, object]):
+    def __iter__(self) -> Iterator[str]:
+        return iter(())
+
+    def __len__(self) -> int:
+        return 0
+
+    def __getitem__(self, key: str) -> object:
+        raise KeyError(key)
+
+    def items(self) -> Iterator[Tuple[str, object]]:
         raise RuntimeError("boom")
+
+
+class DuplicateAdapterRegistry(Mapping[str, object]):
+    def __init__(self, adapter: object) -> None:
+        self._adapter = adapter
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(("stub", "stub"))
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, key: str) -> object:
+        if key != "stub":
+            raise KeyError(key)
+        return self._adapter
+
+    def items(self) -> Iterator[Tuple[str, object]]:
+        return iter((("stub", self._adapter), ("stub", self._adapter)))
 
 
 class ExplodingRequestMapping(dict):
@@ -875,7 +905,7 @@ class RuntimeExecutionTests(unittest.TestCase):
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "invalid_adapter_capabilities")
 
-    def test_execute_task_fails_closed_for_adapter_registry_that_raises_on_get(self) -> None:
+    def test_execute_task_fails_closed_for_adapter_registry_that_raises_on_items(self) -> None:
         request = TaskRequest(
             adapter_key="stub",
             capability="content_detail_by_url",
@@ -889,6 +919,24 @@ class RuntimeExecutionTests(unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_adapter_registry")
+
+    def test_execute_task_fails_closed_for_duplicate_adapter_registry_keys(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/1"),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters=DuplicateAdapterRegistry(SuccessfulAdapter()),
+            task_id_factory=lambda: "task-duplicate-registry",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["task_id"], "task-duplicate-registry")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "invalid_adapter_registry")
 


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：把 `FR-0005` 的 adapter registry contract 从 formal spec 落到 runtime，统一 materialization、lookup、capability discovery 与 fail-closed 语义。
- 主要改动：
  - 新增 `syvert/registry.py`，提供 `AdapterRegistry`、`AdapterDeclaration` 与 `RegistryError`，对重复 key、无效声明和无效 capability/axis metadata 统一 fail-closed。
  - 在 `syvert/runtime.py` 的 `execute_task()` 中先 materialize registry，再统一通过 lookup/discovery 做 admission；不再把裸 `Mapping.get()` 当作最终 registry 语义。
  - 调整 `syvert.adapters:build_adapters` 的默认聚合路径，保留 duplicate key 直到 registry materialization 阶段判定，避免默认共享 builder 在进入 registry 前吞掉重复注册。
  - 补充 `tests/runtime/test_registry.py`、`tests/runtime/test_runtime.py` 与 `tests/runtime/test_cli.py`，覆盖 materialization、duplicate key、invalid metadata、missing execute contract、shared builder duplicate-key fail-closed、adapter/capability unsupported、side-effect-free discovery 等场景。
  - 更新 `docs/exec-plans/CHORE-0070-fr-0005-adapter-registry.md`、`docs/releases/v0.2.0.md` 与 `docs/sprints/2026-S15.md`，把 `#70` 绑定到 release/sprint/exec-plan 证据链。

## Issue 摘要

- `#70` 是 `FR-0005` 的唯一剩余 implementation Work Item，目标是在不引入 fake adapter、harness、validator、version gate、FR-0006、FR-0007 的前提下落地 adapter registry。
- formal spec 已由 PR `#78` 合入，错误模型已由 PR `#97` 落地；本 PR 只承接 registry 侧 materialization / registration / lookup / discovery / fail-closed。

## 关联事项

- Issue: #70
- Parent FR: #65
- item_key: `CHORE-0070-fr-0005-adapter-registry`
- item_type: `CHORE`
- release: `v0.2.0`
- sprint: `2026-S15`
- Closing: Fixes #70

## 风险

- 风险级别：`normal`
- 审查关注：
  - registry / metadata / invalid declaration 失配是否稳定落到 `runtime_contract`，而不是误判为 `unsupported`
  - discovery 是否严格 side-effect-free，不触发 adapter `execute()` 或真实平台副作用
  - 默认共享 builder 路径是否保留 duplicate key，确保 duplicate registration 能在 registry materialization 阶段 fail-close
  - 当前 PR 是否保持在 `FR-0005/#70` 范围内，没有把 harness、gate 或相邻 FR 语义并入

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_cli tests.runtime.test_registry`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/open_pr.py --class implementation --issue 70 --item-key CHORE-0070-fr-0005-adapter-registry --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'feat(runtime): 落地 FR-0005 适配器注册表' --closing fixes --dry-run`
  - `SYVERT_GUARDIAN_TIMEOUT_SECONDS=36000 python3 scripts/pr_guardian.py review 98 --post-review`（首轮返回 `REQUEST_CHANGES`，阻断已在当前 head 收口）
- 未执行：
  - 最新 head 上的二轮 guardian
  - `SYVERT_GUARDIAN_TIMEOUT_SECONDS=36000 python3 scripts/merge_pr.py merge-if-safe 98 --delete-branch`

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
