### PR TITLE
docs(governance): 补齐 Syvert × WebEnvoy integration 联动插槽

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Syvert Repo Workflow Contract
+    url: https://github.com/MC-and-his-Agents/Syvert/blob/main/WORKFLOW.md
+    about: 先阅读仓库 workflow 与治理约束，再选择对应 issue form。

--- a/.github/ISSUE_TEMPLATE/fr.yml
+++ b/.github/ISSUE_TEMPLATE/fr.yml
@@ -1,0 +1,94 @@
+name: FR
+description: 创建或更新需要 formal spec / FR 容器承接的事项。
+title: "[FR-XXXX] "
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 摘要
+      description: 说明当前 FR 要解决的目标、非目标和阶段边界。
+      placeholder: |
+        目标：
+        非目标：
+        当前阶段：
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_artifacts
+    attributes:
+      label: Formal Spec 套件
+      description: 列出本 FR 需要承接的 formal spec / contract / 风险工件。
+      placeholder: |
+        spec.md:
+        plan.md:
+        contracts/:
+        data-model.md:
+        risks.md:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: shared_contract_changed
+    attributes:
+      label: shared_contract_changed
+      options:
+        - "no"
+        - "yes"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: integration_touchpoint
+    attributes:
+      label: integration_touchpoint
+      description: 纯本仓库事项默认选 `none`；会影响跨仓共享契约时选 `check_required` 或 `active`。
+      options:
+        - none
+        - check_required
+        - active
+    validations:
+      required: true
+
+  - type: input
+    id: integration_ref
+    attributes:
+      label: integration_ref
+      description: 填 integration project canonical issue / item 链接或编号；无则留空。
+
+  - type: dropdown
+    id: external_dependency
+    attributes:
+      label: external_dependency
+      options:
+        - none
+        - syvert
+        - webenvoy
+        - both
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contract_surface
+    attributes:
+      label: contract_surface
+      options:
+        - none
+        - execution_provider
+        - ids_trace
+        - errors
+        - raw_normalized
+        - diagnostics_observability
+        - runtime_modes
+    validations:
+      required: true
+
+  - type: dropdown
+    id: joint_acceptance_needed
+    attributes:
+      label: joint_acceptance_needed
+      options:
+        - "no"
+        - "yes"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/governance.yml
+++ b/.github/ISSUE_TEMPLATE/governance.yml
@@ -1,0 +1,93 @@
+name: Governance
+description: 创建治理栈、流程、模板或门禁相关事项。
+title: "治理协议："
+labels:
+  - governance
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: 治理目标
+      description: 说明要调整的治理载体、为什么现在需要改、成功标准是什么。
+      placeholder: |
+        当前问题：
+        目标状态：
+        成功标准：
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected_surfaces
+    attributes:
+      label: 影响载体
+      description: 列出将受影响的 workflow / review / template / GitHub project 载体。
+      placeholder: |
+        WORKFLOW.md
+        code_review.md
+        PULL_REQUEST_TEMPLATE.md
+        Project fields
+    validations:
+      required: true
+
+  - type: dropdown
+    id: shared_contract_changed
+    attributes:
+      label: shared_contract_changed
+      options:
+        - "no"
+        - "yes"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: integration_touchpoint
+    attributes:
+      label: integration_touchpoint
+      options:
+        - none
+        - check_required
+        - active
+    validations:
+      required: true
+
+  - type: input
+    id: integration_ref
+    attributes:
+      label: integration_ref
+
+  - type: dropdown
+    id: external_dependency
+    attributes:
+      label: external_dependency
+      options:
+        - none
+        - syvert
+        - webenvoy
+        - both
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contract_surface
+    attributes:
+      label: contract_surface
+      options:
+        - none
+        - execution_provider
+        - ids_trace
+        - errors
+        - raw_normalized
+        - diagnostics_observability
+        - runtime_modes
+    validations:
+      required: true
+
+  - type: dropdown
+    id: joint_acceptance_needed
+    attributes:
+      label: joint_acceptance_needed
+      options:
+        - "no"
+        - "yes"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,125 @@
+name: Work Item
+description: 创建可进入执行回合的本地事项。
+title: "工作项："
+body:
+  - type: input
+    id: issue_context
+    attributes:
+      label: 上位 Issue / FR
+      description: 填当前 work item 绑定的 canonical issue / FR 编号。
+      placeholder: "#123"
+    validations:
+      required: true
+
+  - type: input
+    id: item_key
+    attributes:
+      label: item_key
+      description: 使用 `<item_type>-<4-digit>-<slug>` 命名。
+      placeholder: FR-0123-content-detail-runtime
+    validations:
+      required: true
+
+  - type: dropdown
+    id: item_type
+    attributes:
+      label: item_type
+      options:
+        - FR
+        - HOTFIX
+        - GOV
+        - CHORE
+    validations:
+      required: true
+
+  - type: input
+    id: release
+    attributes:
+      label: release
+      placeholder: v0.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: sprint
+    attributes:
+      label: sprint
+      placeholder: sprint-contract-harness
+    validations:
+      required: true
+
+  - type: textarea
+    id: execution_goal
+    attributes:
+      label: 执行目标
+      description: 说明本次 work item 的交付边界、验证方式和回滚方式。
+      placeholder: |
+        交付目标：
+        验证方式：
+        回滚方式：
+    validations:
+      required: true
+
+  - type: dropdown
+    id: shared_contract_changed
+    attributes:
+      label: shared_contract_changed
+      options:
+        - "no"
+        - "yes"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: integration_touchpoint
+    attributes:
+      label: integration_touchpoint
+      options:
+        - none
+        - check_required
+        - active
+    validations:
+      required: true
+
+  - type: input
+    id: integration_ref
+    attributes:
+      label: integration_ref
+      description: 纯本仓库事项留空；跨仓事项必须填写 integration issue / item。
+
+  - type: dropdown
+    id: external_dependency
+    attributes:
+      label: external_dependency
+      options:
+        - none
+        - syvert
+        - webenvoy
+        - both
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contract_surface
+    attributes:
+      label: contract_surface
+      options:
+        - none
+        - execution_provider
+        - ids_trace
+        - errors
+        - raw_normalized
+        - diagnostics_observability
+        - runtime_modes
+    validations:
+      required: true
+
+  - type: dropdown
+    id: joint_acceptance_needed
+    attributes:
+      label: joint_acceptance_needed
+      options:
+        - "no"
+        - "yes"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,23 @@
 
 {{VALIDATION_SUGGESTION}}
 
+## integration_check
+
+- integration_applicable（`yes` / `no`）:
+- integration_ref:
+- shared_contract_changed（`yes` / `no`）:
+- external_dependency（`none` / `syvert` / `webenvoy` / `both`）:
+- contract_surface（`none` / `execution_provider` / `ids_trace` / `errors` / `raw_normalized` / `diagnostics_observability` / `runtime_modes`）:
+- joint_acceptance_needed（`yes` / `no`）:
+- integration_status_checked_before_pr（`yes` / `no`）:
+- integration_status_checked_before_merge（`yes` / `no`）:
+
+补充说明：
+
+- `integration_applicable=yes` 时，`integration_ref` 不得为空。
+- `shared_contract_changed=yes` 或 `external_dependency != none` 时，当前事项的 `merge_gate` 必须收口为 `integration_check_required`。
+- 进入 merge gate 前必须再次核对 `integration_ref` 对应 integration issue / project item 的当前状态与依赖关系。
+
 ## 回滚
 
 - 回滚方式：{{ROLLBACK}}

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -82,6 +82,47 @@ codex:
 - 不应把与当前判断无关的历史讨论、相邻事项材料或整仓重复探索默认塞给 reviewer / guardian。
 - 若要补充额外上下文，必须以“消除当前阻断或验证当前 head 风险”为目的，而不是让审查器无限制二次侦察。
 
+## integration project 联动规则
+
+- 默认执行真相源仍是当前仓库的 GitHub Project；仅当事项触及跨仓共享契约、跨仓依赖或联合验收时，才查看 owner 级 integration project。
+- 每个进入执行回合的 issue / work item 在 GitHub 侧都必须显式声明：
+  - `integration_touchpoint`
+  - `integration_ref`
+  - `external_dependency`
+  - `merge_gate`
+  - `contract_surface`
+- 满足以下任一条件时，`integration_touchpoint` 不得为 `none`，并且开工前必须先查看 `integration_ref` 对应的 integration issue / item：
+  - 改共享输入输出
+  - 改错误码或错误语义
+  - 改 `raw` / `normalized` / `diagnostics` / `observability`
+  - 改 `task_id` / `request_id` / `run_id`
+  - 改执行模式或 gate 口径
+  - 依赖另一仓库先做、同步做或共同验收
+  - 影响联合 PoC、联合回归或共享桥接能力
+- `integration_touchpoint` 取值约定：
+  - `none`：纯本仓库事项，不需要 integration 联动
+  - `check_required`：实现前必须核对 integration 状态
+  - `active`：当前执行回合正受 integration 约束
+  - `blocked`：被另一仓库或 integration 契约阻塞
+  - `resolved`：当前回合的 integration 约束已完成
+- `external_dependency` 取值约定：
+  - `none`：无跨仓前置
+  - `syvert`：依赖 Syvert 侧动作
+  - `webenvoy`：依赖 WebEnvoy 侧动作
+  - `both`：两边都有前置或联合验收依赖
+- `merge_gate` 取值约定：
+  - `local_only`：只受本仓库门禁约束
+  - `integration_check_required`：除本仓库门禁外，还必须检查 integration 状态
+- `contract_surface` 用于标记触达的跨仓表面，固定枚举：
+  - `none`
+  - `execution_provider`
+  - `ids_trace`
+  - `errors`
+  - `raw_normalized`
+  - `diagnostics_observability`
+  - `runtime_modes`
+- integration project 只承载跨仓协调真相；本地 issue / PR / review 仍是实现、关闭语义与 merge gate 的真相源。
+
 ## stop conditions
 
 - 缺少必需输入（Issue、事项上下文、formal spec 或 bootstrap contract）。
@@ -117,3 +158,4 @@ codex:
   - `safe_to_merge=true`
   - GitHub checks 全绿
   - PR 非 Draft，且审查与合并使用同一 head SHA
+  - 若 `merge_gate=integration_check_required`，则已在提 PR 前和合并前分别核对一次 `integration_ref` 对应 integration issue / item 的状态、依赖与联合验收约束

--- a/code_review.md
+++ b/code_review.md
@@ -12,6 +12,7 @@
 - 与当前事项直接相关的 `spec` / `plan` / bootstrap contract / `exec-plan`
 - 与当前改动直接相关的治理或流程文档
 - 当前 diff、受影响文件与必要的调用链 / contract 边界
+- 若事项声明 `integration_touchpoint != none`，补充对应的 `integration_ref` 及其当前依赖 / 联合验收状态
 
 仅当历史事项确有 legacy `TODO.md`，且其中内容对当前风险、恢复或历史判断直接相关时，才补充该文件作为审查输入。
 
@@ -57,6 +58,7 @@
 | 可观测性 | 日志、指标、状态面、错误上下文是否足够定位问题 | 关键路径可定位，必要输出可支持发布后排障 | 出问题后无法判断输入、状态或失败原因 |
 | 安全 / 性能 / 成本 | 是否引入安全缺口、性能回退、额外成本或配额风险 | 风险已评估并在必要处验证或约束 | 新增高耗时/高成本路径或安全暴露但无说明 |
 | 发布与回滚准备 | 发布依赖、迁移步骤、回滚方式是否就绪 | 发布前提、回滚步骤、操作顺序清晰 | 需要人工操作却未记录，回滚方案缺失或不可执行 |
+| integration 联动一致性 | 是否正确标记跨仓触点、依赖和联合验收约束 | `integration_touchpoint`、`integration_ref`、`external_dependency`、`merge_gate` 与实际改动一致 | 共享契约改动未标记 integration 联动，或 merge 前未核对 integration 状态 |
 
 ## 事项分级视角
 
@@ -87,6 +89,7 @@
 4. PR 不是 Draft
 5. 合并时 head 与审查时 head 一致
 6. 必须通过受控入口 `merge_pr`
+7. 若当前事项 `merge_gate=integration_check_required`，PR 描述必须补齐 `integration_check`，且 reviewer / guardian 已确认提 PR 前与合并前都核对过 `integration_ref` 对应状态
 
 merge gate 只回答“当前 PR 是否允许进入受控合并”，不替代 reviewer 对实现质量的实质判断。
 


### PR DESCRIPTION
## 摘要

- PR Class: `governance`
- 变更目的：补齐 Syvert 与 WebEnvoy 的 integration 联动插槽
- 主要改动：新增 issue forms，补充 workflow / review / PR 模板中的 integration 规则

## Issue 摘要

为 Syvert 保留本地执行真相源，同时明确何时必须查看 owner 级 integration project，并把跨仓依赖、共享契约和联合验收约束带入 issue / PR / review 载体。

## 关联事项

- Issue: #105
- item_key: `GOV-0105-integration-governance-baseline`
- item_type: `GOV`
- release: `governance-baseline`
- sprint: `integration-governance`
- Closing: `Fixes #105`

## 风险

- 风险级别：`medium`
- 审查关注：新增治理字段是否与现有 item_key / release / sprint 规则冲突

## 验证

- `python3` 解析 `.github/ISSUE_TEMPLATE/*.yml`
- 人工复核 PR 模板与 workflow / review 文档的字段口径一致性

## integration_check

- integration_applicable（`yes` / `no`）: yes
- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3
- shared_contract_changed（`yes` / `no`）: yes
- external_dependency（`none` / `syvert` / `webenvoy` / `both`）: both
- contract_surface（`none` / `execution_provider` / `ids_trace` / `errors` / `raw_normalized` / `diagnostics_observability` / `runtime_modes`）: none
- joint_acceptance_needed（`yes` / `no`）: yes
- integration_status_checked_before_pr（`yes` / `no`）: yes
- integration_status_checked_before_merge（`yes` / `no`）: no

补充说明：

- 本 PR 对应 integration governance baseline 与本地治理载体收口。
- merge 前仍需再次核对 integration project 状态。

## 回滚

- 回滚方式：revert 本 PR，撤回 issue forms 与治理文档中的 integration 字段增量
