### PR TITLE
refactor(governance): 提取 integration contract kernel

### DIFF
--- a/docs/decisions/ADR-GOV-0105-integration-governance-baseline.md
+++ b/docs/decisions/ADR-GOV-0105-integration-governance-baseline.md
@@ -1,0 +1,37 @@
+# ADR-GOV-0105 Syvert × WebEnvoy integration governance baseline
+
+## 关联信息
+
+- Issue：`#105`
+- item_key：`GOV-0105-integration-governance-baseline`
+- item_type：`GOV`
+- release：`governance-baseline`
+- sprint：`integration-governance`
+
+## 背景
+
+当前 owner 下已经同时推进 `Syvert` 与 `WebEnvoy`，但两个仓库此前缺少统一的跨仓治理插槽，导致共享契约、跨仓依赖与联合验收只能靠口头约定或临时同步处理。
+
+`#107` 已验证单一大 PR 会把 contract 定义、消费者接线、载体对齐和 rollout evidence 一次性耦合，超出稳定审查范围。本事项改为按同一 Work Item `#105` 串行拆成多个小 PR 落地。
+
+## 决策
+
+- canonical integration contract 的单一真相源固定在仓库内：机器可读定义位于 `scripts/policy/integration_contract.json`，共享消费逻辑位于 `scripts/integration_contract.py`。
+- 本事项按四个串行 PR 收口：`PR-A Contract Kernel`、`PR-B Consumer Wiring`、`PR-C Carrier Alignment`、`PR-D Evidence / Rollout`。
+- 第一批必须先把 `Issue + decision + exec-plan` 的 bootstrap contract 落到 `main`，后续三个 PR 才能在同一事项上下文下继续通过受控入口推进。
+- 两个仓库的 issue / PR / review / workflow 载体最终都只消费 canonical integration contract，不再各自维护第二套 integration 枚举或组合约束。
+- 纯本仓库事项保持 `integration_touchpoint=none`；触及共享契约、跨仓依赖或联合验收时，必须显式绑定 integration ref。
+- 外部 GitHub Project、labels 与 issue backfill 只作为 rollout evidence，不再写入 repo 内 contract 主体。
+
+## 约束
+
+- 本轮只补跨仓联动插槽，不引入自动 bot、自动同步或第三个代码仓库。
+- 本地 issue / PR 仍是执行与关闭真相源；外部 integration project 只承担协调语义，且其当前 live state 只能作为 merge gate 运行时输入。
+- 当前事项继续只使用 `Issue #105` / `item_key=GOV-0105-integration-governance-baseline`，不额外拆新的执行 issue。
+- 若后续扩张共享契约枚举、联合验收流程或 merge gate 语义，必须在新的独立治理事项中推进，不得直接扩展当前事项范围。
+
+## 影响
+
+- 当前事项的 bootstrap contract 由 `Issue #105 + ADR-GOV-0105 + GOV-0105 exec-plan` 构成；替代链路中的各个 PR 只承担各自层级的实现与验证。
+- `#107` 保留为冻结的拆分母体和审查历史容器，不再进入 merge；替代 PR 链路全部合并后再按 superseded 关闭。
+- 后续所有触及跨仓共享契约的 Syvert / WebEnvoy PR，都必须通过 canonical integration contract 显式判断是否进入 integration merge gate。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -1,0 +1,65 @@
+# GOV-0105 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0105-integration-governance-baseline`
+- Issue：`#105`
+- item_type：`GOV`
+- release：`governance-baseline`
+- sprint：`integration-governance`
+- 关联 spec：无（治理联动事项）
+- 关联 decision：`docs/decisions/ADR-GOV-0105-integration-governance-baseline.md`
+- 关联 PR：待创建（`PR-A: Contract Kernel`）
+- active 收口事项：`GOV-0105-integration-governance-baseline`
+
+## 目标
+
+- 先把仓库内唯一的 canonical integration contract 落到 `main`，为后续消费者接线、载体对齐和 evidence 收口建立稳定真相源。
+- 保持 `Syvert` 继续作为本地执行真相源，同时为后续 `Syvert × WebEnvoy` integration 协同提供可执行的 contract 基线。
+
+## 范围
+
+- 当前 PR-A 只纳入：`scripts/policy/integration_contract.json`、`scripts/integration_contract.py`、`scripts/common.py` 中与 integration contract 直接相关的最小辅助逻辑、`tests/governance/test_integration_contract.py`，以及当前 bootstrap contract 文档。
+- 后续 PR-B 再纳入：`open_pr / pr_guardian / merge_pr / governance_status` 的共享消费链路。
+- 后续 PR-C 再纳入：`WORKFLOW.md`、`code_review.md`、PR template、issue forms 的 carrier alignment。
+- 后续 PR-D 再纳入：ADR / exec-plan 的最终叙事收口与 platform evidence。
+- 本次不纳入：自动 bot / 自动同步系统、新的产品仓库、跨仓实现代码、对现有 `Phase / FR / sprint` 语义做统一改造。
+
+## 当前停点
+
+- `#107` 保持 Draft 并冻结，不再继续修 findings 或提交 guardian；它只作为拆分母体和审查历史容器保留。
+- 当前真正需要先落地的是 `PR-A Contract Kernel`，否则 `#105` 在 `main` 上没有 active bootstrap contract，后续替代 PR 无法通过受控入口。
+- 当前 PR-A 必须只声明 contract kernel 与最小 bootstrap contract，不提前宣称消费者、载体和 evidence 已完成。
+
+## 下一步动作
+
+- 从 `#107` 母体裁出 contract kernel 与最小 bootstrap contract，形成独立分支和 Draft PR。
+- 运行 `tests.governance.test_integration_contract`、`workflow_guard --mode pre-commit` 与 `governance_gate --mode ci`，确保第一批能独立成立。
+- PR-A 合并后，再按同一 `Issue #105` 串行推进 PR-B、PR-C、PR-D。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为当前治理基线先建立可审查、可恢复、可复用的 canonical integration contract 内核，使后续联动规则有唯一真相源可依赖。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：替代链路的第一批 `PR-A Contract Kernel`。
+- 阻塞：在 PR-A 合并前，`main` 上不存在 `#105` 的 active bootstrap contract，后续替代 PR 无法通过 `open_pr` 的事项上下文校验。
+
+## 已验证项
+
+- 待本轮 contract kernel 裁剪完成后补记。
+
+## 未决风险
+
+- 若 PR-A 继续夹带消费者、carrier 或 evidence 叙事，scope 会再次膨胀，guardian finding 也会重新跨层连锁。
+- `main` 在替代链路推进期间继续前进；每一批 PR 在进入 guardian 和 merge 前都必须基于最新 `origin/main` 重跑本地门禁。
+- 由于当前 issue 已声明 canonical integration 字段，后续所有替代 PR 都必须完整对齐 contract，不允许退回 legacy 路径。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销 contract kernel 与当前 bootstrap contract 文档，让 `#105` 回到未建立 repo 内真相源的状态。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- 待 PR-A 首次 checkpoint 生成后补记当前 head SHA。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -9,7 +9,7 @@
 - sprint：`integration-governance`
 - 关联 spec：无（治理联动事项）
 - 关联 decision：`docs/decisions/ADR-GOV-0105-integration-governance-baseline.md`
-- 关联 PR：待创建（`PR-A: Contract Kernel`）
+- 关联 PR：`#114`
 - active 收口事项：`GOV-0105-integration-governance-baseline`
 
 ## 目标
@@ -29,11 +29,11 @@
 
 - `#107` 保持 Draft 并冻结，不再继续修 findings 或提交 guardian；它只作为拆分母体和审查历史容器保留。
 - 当前真正需要先落地的是 `PR-A Contract Kernel`，否则 `#105` 在 `main` 上没有 active bootstrap contract，后续替代 PR 无法通过受控入口。
-- 当前 PR-A 已完成 contract kernel 与最小 bootstrap contract 裁剪，并已通过本地 contract 单测与治理门禁；下一步进入 Draft PR 和仓外审查。
+- 当前 PR-A 已以 Draft PR `#114` 打开，当前受审目标是其 latest head。
+- contract kernel 本地门禁已通过；当前停点转为 reviewer / guardian 收口，并保持 scope 只限于 kernel 与最小 bootstrap contract。
 
 ## 下一步动作
 
-- 为当前分支创建 Draft PR，并将其声明为 `#107` 的 replacement PR-A。
 - 在同一 head 上等待 reviewer、GitHub checks 与 guardian 收口，再执行受控合并。
 - PR-A 合并后，再按同一 `Issue #105` 串行推进 PR-B、PR-C、PR-D。
 
@@ -64,4 +64,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `a1fd9a375ae7e83d1845b86b981a7288066b506d`
+- 最近一次完成 contract kernel 代码收口的 checkpoint：`eadb3b814af668814566efe96a6247f215b7a87a`
+- 当前 PR 审查态以 `#114` 的 latest head 为准；若后续只补充 review / guardian 元数据，不另起新的代码 checkpoint。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -29,12 +29,12 @@
 
 - `#107` 保持 Draft 并冻结，不再继续修 findings 或提交 guardian；它只作为拆分母体和审查历史容器保留。
 - 当前真正需要先落地的是 `PR-A Contract Kernel`，否则 `#105` 在 `main` 上没有 active bootstrap contract，后续替代 PR 无法通过受控入口。
-- 当前 PR-A 必须只声明 contract kernel 与最小 bootstrap contract，不提前宣称消费者、载体和 evidence 已完成。
+- 当前 PR-A 已完成 contract kernel 与最小 bootstrap contract 裁剪，并已通过本地 contract 单测与治理门禁；下一步进入 Draft PR 和仓外审查。
 
 ## 下一步动作
 
-- 从 `#107` 母体裁出 contract kernel 与最小 bootstrap contract，形成独立分支和 Draft PR。
-- 运行 `tests.governance.test_integration_contract`、`workflow_guard --mode pre-commit` 与 `governance_gate --mode ci`，确保第一批能独立成立。
+- 为当前分支创建 Draft PR，并将其声明为 `#107` 的 replacement PR-A。
+- 在同一 head 上等待 reviewer、GitHub checks 与 guardian 收口，再执行受控合并。
 - PR-A 合并后，再按同一 `Issue #105` 串行推进 PR-B、PR-C、PR-D。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -48,7 +48,9 @@
 
 ## 已验证项
 
-- 待本轮 contract kernel 裁剪完成后补记。
+- 已执行：`python3 -m unittest tests.governance.test_integration_contract`
+- 已执行：`python3 scripts/workflow_guard.py --mode pre-commit`
+- 已执行：`python3 scripts/governance_gate.py --mode ci --base-sha origin/main --head-sha HEAD --head-ref issue-105-integration-governance-baseline-contract-kernel`
 
 ## 未决风险
 
@@ -62,4 +64,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 待 PR-A 首次 checkpoint 生成后补记当前 head SHA。
+- `a1fd9a375ae7e83d1845b86b981a7288066b506d`

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -201,6 +201,11 @@ def default_github_repo() -> str:
     configured = os.environ.get("SYVERT_GITHUB_REPO", "").strip()
     if configured and re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", configured):
         return configured
+    completed = run(["git", "remote", "get-url", "origin"], cwd=REPO_ROOT, check=False)
+    if completed.returncode == 0:
+        parsed = parse_github_repo_from_remote_url(completed.stdout.strip())
+        if parsed:
+            return parsed
     return CANONICAL_GITHUB_REPO
 
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -219,13 +219,20 @@ def integration_ref_is_checkable(value: str) -> bool:
     normalized = value.strip()
     if not normalized or normalized.lower() == "none":
         return False
-    patterns = (
-        r"^#\d+$",
-        r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+$",
-        r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/\d+$",
-        r"^https://github\.com/orgs/[A-Za-z0-9_.-]+/projects/\d+(?:/views/[A-Za-z0-9_-]+)?\?.*itemId=[A-Za-z0-9_-]+.*$",
-    )
-    return any(re.match(pattern, normalized) for pattern in patterns)
+    if re.match(r"^#\d+$", normalized):
+        return True
+    if re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+$", normalized):
+        return True
+    if re.match(r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/\d+$", normalized):
+        return True
+    parsed = urlparse(normalized)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        return False
+    if len(path_parts) < 4 or path_parts[0] != "orgs" or path_parts[2] != "projects":
+        return False
+    item_ids = parse_qs(parsed.query).get("itemId", [])
+    return bool(item_ids and str(item_ids[0]).strip())
 
 
 def normalize_integration_ref_for_comparison(value: str) -> str:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -201,11 +201,6 @@ def default_github_repo() -> str:
     configured = os.environ.get("SYVERT_GITHUB_REPO", "").strip()
     if configured and re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", configured):
         return configured
-    completed = run(["git", "remote", "get-url", "origin"], cwd=REPO_ROOT, check=False)
-    if completed.returncode == 0:
-        parsed = parse_github_repo_from_remote_url(completed.stdout.strip())
-        if parsed:
-            return parsed
     return CANONICAL_GITHUB_REPO
 
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -15,6 +15,10 @@ from typing import Iterable, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CANONICAL_GITHUB_REPO = "MC-and-his-Agents/Syvert"
+REPO_CANONICAL_GITHUB_REPOS = {
+    "syvert": "MC-and-his-Agents/Syvert",
+    "webenvoy": "MC-and-his-Agents/WebEnvoy",
+}
 
 
 class CommandError(RuntimeError):
@@ -201,6 +205,16 @@ def default_github_repo() -> str:
     configured = os.environ.get("SYVERT_GITHUB_REPO", "").strip()
     if configured and re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", configured):
         return configured
+    repo_name = REPO_ROOT.name.strip().casefold()
+    if repo_name in REPO_CANONICAL_GITHUB_REPOS:
+        return REPO_CANONICAL_GITHUB_REPOS[repo_name]
+    completed = run(["git", "remote", "get-url", "origin"], cwd=REPO_ROOT, check=False)
+    if completed.returncode == 0:
+        parsed = parse_github_repo_from_remote_url(completed.stdout.strip())
+        if parsed:
+            parsed_name = parsed.split("/", 1)[1].strip().casefold()
+            if parsed_name in REPO_CANONICAL_GITHUB_REPOS:
+                return REPO_CANONICAL_GITHUB_REPOS[parsed_name]
     return CANONICAL_GITHUB_REPO
 
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -7,11 +7,14 @@ import shlex
 import subprocess
 import sys
 import unicodedata
+from urllib.parse import parse_qs, urlparse
+from functools import lru_cache
 from pathlib import Path
 from typing import Iterable, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+CANONICAL_GITHUB_REPO = "MC-and-his-Agents/Syvert"
 
 
 class CommandError(RuntimeError):
@@ -177,7 +180,76 @@ def now_iso_utc() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def parse_github_repo_from_remote_url(origin_url: str) -> str | None:
+    normalized = origin_url.strip()
+    if not normalized:
+        return None
+    https_match = re.match(r"^https://github\.com/([^/]+/[^/]+?)(?:\.git)?$", normalized)
+    if https_match:
+        return https_match.group(1)
+    ssh_match = re.match(r"^git@github\.com:([^/]+/[^/]+?)(?:\.git)?$", normalized)
+    if ssh_match:
+        return ssh_match.group(1)
+    ssh_url_match = re.match(r"^ssh://git@github\.com(?::\d+)?/([^/]+/[^/]+?)(?:\.git)?/?$", normalized)
+    if ssh_url_match:
+        return ssh_url_match.group(1)
+    return None
+
+
+@lru_cache(maxsize=1)
+def default_github_repo() -> str:
+    configured = os.environ.get("SYVERT_GITHUB_REPO", "").strip()
+    if configured and re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", configured):
+        return configured
+    return CANONICAL_GITHUB_REPO
+
+
 def slugify(text: str) -> str:
     normalized = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
     tokens = re.findall(r"[a-z0-9]+", normalized.lower())
     return "-".join(tokens) or "task"
+
+
+def integration_ref_is_checkable(value: str) -> bool:
+    normalized = value.strip()
+    if not normalized or normalized.lower() == "none":
+        return False
+    patterns = (
+        r"^#\d+$",
+        r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+$",
+        r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/\d+$",
+        r"^https://github\.com/orgs/[A-Za-z0-9_.-]+/projects/\d+(?:/views/[A-Za-z0-9_-]+)?\?.*itemId=[A-Za-z0-9_-]+.*$",
+    )
+    return any(re.match(pattern, normalized) for pattern in patterns)
+
+
+def normalize_integration_ref_for_comparison(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    if normalized.lower() == "none":
+        return "none"
+
+    local_issue_match = re.match(r"^#(\d+)$", normalized)
+    if local_issue_match:
+        return f"issue:{default_github_repo().lower()}#{local_issue_match.group(1)}"
+
+    repo_issue_match = re.match(r"^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(\d+)$", normalized)
+    if repo_issue_match:
+        return f"issue:{repo_issue_match.group(1).lower()}#{repo_issue_match.group(2)}"
+
+    issue_url_match = re.match(r"^https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)$", normalized)
+    if issue_url_match:
+        return f"issue:{issue_url_match.group(1).lower()}#{issue_url_match.group(2)}"
+
+    parsed = urlparse(normalized)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if parsed.scheme == "https" and parsed.netloc.lower() == "github.com" and len(path_parts) >= 4:
+        if path_parts[0] == "orgs" and path_parts[2] == "projects":
+            item_ids = parse_qs(parsed.query).get("itemId", [])
+            if item_ids:
+                organization = path_parts[1].lower()
+                project_number = path_parts[3]
+                return f"project-item:{organization}/{project_number}#{item_ids[0]}"
+
+    return normalized

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -31,6 +31,16 @@ def load_integration_contract() -> dict:
     return load_json(CONTRACT_PATH)
 
 
+def decode_remote_json(stdout: str, *, error_message: str) -> dict[str, object]:
+    try:
+        payload = json.loads(stdout or "{}")
+    except json.JSONDecodeError:
+        return {"error": error_message}
+    if not isinstance(payload, dict):
+        return {"error": error_message}
+    return payload
+
+
 RAW_CONTRACT = load_integration_contract()
 FIELD_ORDER = tuple(str(name) for name in RAW_CONTRACT["field_order"])
 ISSUE_SCOPE_FIELDS = tuple(str(name) for name in RAW_CONTRACT["issue_scope_fields"])
@@ -294,13 +304,32 @@ def normalize_integration_value(field: str, value: str) -> str:
 
 
 def semantic_integration_ref_key(value: str) -> str:
-    return normalize_integration_ref_for_comparison(value)
+    identity, _, _ = semantic_integration_ref_identity(value)
+    return identity
+
+
+def semantic_integration_ref_identity(value: str) -> tuple[str, bool, str]:
+    normalized = normalize_integration_ref_for_comparison(value)
+    if normalized in {"", "none"}:
+        return normalized, True, normalized
+    if normalized.startswith("issue:"):
+        return normalized, True, normalized
+    if not normalized.startswith("project-item:"):
+        return normalized, True, normalized
+    live_state = fetch_integration_ref_live_state(value)
+    if str(live_state.get("error") or "").strip():
+        return normalized, False, normalized
+    content_repo = str(live_state.get("content_repo") or "").strip().lower()
+    content_issue_number = str(live_state.get("content_issue_number") or "").strip()
+    if content_repo and content_issue_number:
+        return f"issue:{content_repo}#{content_issue_number}", True, normalized
+    return normalized, False, normalized
 
 
 def normalize_integration_value_for_packet(field: str, value: str) -> str:
     raw = str(value or "").strip()
     if field == "integration_ref":
-        return normalize_integration_value(field, raw)
+        return semantic_integration_ref_key(raw)
     return normalize_integration_value(field, raw)
 
 
@@ -354,6 +383,19 @@ def compare_issue_and_pr_canonical(
 ) -> list[str]:
     errors: list[str] = []
     for field in ISSUE_SCOPE_FIELDS:
+        if field == "integration_ref":
+            expected, expected_resolved, expected_static = semantic_integration_ref_identity(str(issue_canonical.get(field, "") or ""))
+            actual, actual_resolved, actual_static = semantic_integration_ref_identity(str(pr_payload.get(field, "") or ""))
+            if expected == actual:
+                continue
+            cross_form_pair = {
+                expected_static.split(":", 1)[0],
+                actual_static.split(":", 1)[0],
+            } == {"issue", "project-item"}
+            if cross_form_pair and (not expected_resolved or not actual_resolved):
+                continue
+            errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
+            continue
         expected = normalize_integration_value(field, issue_canonical.get(field, ""))
         actual = normalize_integration_value(field, pr_payload.get(field, ""))
         if expected != actual:
@@ -729,7 +771,19 @@ def fetch_issue_integration_ref_live_state(integration_ref: str, repo_slug: str,
                 "error": f"无法读取 `integration_ref` 指向的 issue `{repo_slug}#{issue_number}`，拒绝继续。",
             }
 
-        payload = json.loads(completed.stdout or "{}")
+        payload = decode_remote_json(
+            completed.stdout,
+            error_message=(
+                f"无法解析 `integration_ref` 指向的 issue `{repo_slug}#{issue_number}` 的远端响应，拒绝继续。"
+            ),
+        )
+        if payload.get("error"):
+            return {
+                "integration_ref": integration_ref,
+                "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+                "source": "issue",
+                "error": str(payload["error"]),
+            }
         current_issue = (((payload.get("data") or {}).get("repository") or {}).get("issue") or {}) if isinstance(payload, dict) else {}
         if not isinstance(current_issue, dict) or not current_issue:
             return {
@@ -840,7 +894,17 @@ def fetch_project_item_integration_ref_live_state(
             "error": f"无法读取 `integration_ref` 指向的 project item `{item_id}`，拒绝继续。",
         }
 
-    payload = json.loads(completed.stdout or "{}")
+    payload = decode_remote_json(
+        completed.stdout,
+        error_message=f"无法解析 `integration_ref` 指向的 project item `{item_id}` 的远端响应，拒绝继续。",
+    )
+    if payload.get("error"):
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": "project_item",
+            "error": str(payload["error"]),
+        }
     node = ((payload.get("data") or {}).get("node") or {}) if isinstance(payload, dict) else {}
     live_state = build_project_item_live_state(
         integration_ref,
@@ -1007,7 +1071,16 @@ def validate_issue_fetch(issue_number: int, *, allow_missing_payload: bool) -> I
             canonical={},
             error=f"无法读取 Issue #{issue_number} 的 canonical integration 元数据，拒绝继续。",
         )
-    payload = json.loads(completed.stdout or "{}")
+    payload = decode_remote_json(
+        completed.stdout,
+        error_message=f"无法解析 Issue #{issue_number} 的 canonical integration 元数据响应，拒绝继续。",
+    )
+    if payload.get("error"):
+        return IssueCanonicalResolution(
+            issue_number=issue_number,
+            canonical={},
+            error=str(payload["error"]),
+        )
     canonical = extract_issue_canonical_integration_fields(str(payload.get("body") or ""))
     if not canonical and allow_missing_payload:
         return IssueCanonicalResolution(issue_number=issue_number, canonical={}, error=None)

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -55,6 +55,7 @@ REF_EXAMPLES = tuple(str(example) for example in FIELD_DEFINITIONS["integration_
 CONTRACT_SOURCE_MACHINE_READABLE = str(RAW_CONTRACT["canonical_source"]["machine_readable"])
 CONTRACT_SOURCE_MODULE = str(RAW_CONTRACT["canonical_source"]["python_module"])
 CANONICAL_INTEGRATION_PROJECT_TITLE = "Syvert × WebEnvoy Integration"
+CANONICAL_INTEGRATION_PROJECT_NUMBER = "3"
 CANONICAL_INTEGRATION_PROJECT_REQUIRED_FIELDS = frozenset(
     {
         "status",
@@ -647,9 +648,11 @@ def is_canonical_integration_project_item(node: Mapping[str, object], fields: Ma
     project = node.get("project") or {}
     project_title = str((project or {}).get("title") or "").strip()
     project_owner = str(((project or {}).get("owner") or {}).get("login") or "").strip().lower()
+    project_number = str((project or {}).get("number") or "").strip()
     return (
         project_title == CANONICAL_INTEGRATION_PROJECT_TITLE
         and project_owner == canonical_integration_project_owner()
+        and project_number == CANONICAL_INTEGRATION_PROJECT_NUMBER
         and CANONICAL_INTEGRATION_PROJECT_REQUIRED_FIELDS.issubset(fields.keys())
     )
 

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -393,6 +393,7 @@ def compare_issue_and_pr_canonical(
                 actual_static.split(":", 1)[0],
             } == {"issue", "project-item"}
             if cross_form_pair and (not expected_resolved or not actual_resolved):
+                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
                 continue
             errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
             continue

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -1,0 +1,1180 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+from urllib.parse import parse_qs, urlparse
+
+from scripts.common import (
+    REPO_ROOT,
+    default_github_repo,
+    integration_ref_is_checkable,
+    load_json,
+    normalize_integration_ref_for_comparison,
+    run,
+)
+
+
+CONTRACT_PATH = REPO_ROOT / "scripts" / "policy" / "integration_contract.json"
+
+
+@dataclass(frozen=True)
+class IssueCanonicalResolution:
+    issue_number: int | None
+    canonical: dict[str, str]
+    error: str | None
+
+
+def load_integration_contract() -> dict:
+    return load_json(CONTRACT_PATH)
+
+
+RAW_CONTRACT = load_integration_contract()
+FIELD_ORDER = tuple(str(name) for name in RAW_CONTRACT["field_order"])
+ISSUE_SCOPE_FIELDS = tuple(str(name) for name in RAW_CONTRACT["issue_scope_fields"])
+PR_SCOPE_FIELDS = tuple(str(name) for name in RAW_CONTRACT["pr_scope_fields"])
+FIELD_DEFINITIONS = {str(item["name"]): item for item in RAW_CONTRACT["fields"]}
+FIELD_CHOICES = {
+    name: tuple(str(choice) for choice in definition.get("choices", []))
+    for name, definition in FIELD_DEFINITIONS.items()
+    if definition.get("type") == "enum"
+}
+REF_EXAMPLES = tuple(str(example) for example in FIELD_DEFINITIONS["integration_ref"].get("examples", []))
+CONTRACT_SOURCE_MACHINE_READABLE = str(RAW_CONTRACT["canonical_source"]["machine_readable"])
+CONTRACT_SOURCE_MODULE = str(RAW_CONTRACT["canonical_source"]["python_module"])
+CANONICAL_INTEGRATION_PROJECT_TITLE = "Syvert × WebEnvoy Integration"
+CANONICAL_INTEGRATION_PROJECT_REQUIRED_FIELDS = frozenset(
+    {
+        "status",
+        "dependency order",
+        "joint acceptance",
+        "owner repo",
+        "contract status",
+    }
+)
+MERGE_TIME_ALLOWED_LIVE_STATUSES = tuple(
+    str(item).strip().lower() for item in RAW_CONTRACT["rules"].get("merge_time_allowed_live_statuses", [])
+)
+INTEGRATION_PROJECT_ITEM_QUERY = """
+query($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on ProjectV2Item {
+      id
+      isArchived
+      fieldValues(first: 100) {
+        nodes {
+          __typename
+          ... on ProjectV2ItemFieldSingleSelectValue {
+            name
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+          ... on ProjectV2ItemFieldTextValue {
+            text
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+          ... on ProjectV2ItemFieldNumberValue {
+            number
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+          ... on ProjectV2ItemFieldDateValue {
+            date
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+        }
+      }
+      project {
+        url
+        number
+        title
+        owner {
+          __typename
+          ... on Organization { login }
+          ... on User { login }
+        }
+      }
+      content {
+        __typename
+        ... on Issue {
+          number
+          state
+          title
+          url
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+ISSUE_PROJECT_ITEMS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number
+      title
+      url
+      state
+      projectItems(first: 100, after: $after) {
+        nodes {
+          __typename
+          ... on ProjectV2Item {
+            id
+            isArchived
+            fieldValues(first: 100) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field { ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldTextValue {
+                  text
+                  field { ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldNumberValue {
+                  number
+                  field { ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldDateValue {
+                  date
+                  field { ... on ProjectV2FieldCommon { name } }
+                }
+              }
+            }
+            project {
+              url
+              number
+              title
+              owner {
+                __typename
+                ... on Organization { login }
+                ... on User { login }
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+
+def field_names(scope: str) -> tuple[str, ...]:
+    if scope == "issue":
+        return ISSUE_SCOPE_FIELDS
+    if scope == "pr":
+        return PR_SCOPE_FIELDS
+    raise ValueError(f"未知 contract scope: {scope}")
+
+
+def field_choices(name: str) -> tuple[str, ...]:
+    return FIELD_CHOICES.get(name, ())
+
+
+def markdown_section_label(name: str) -> str:
+    choices = field_choices(name)
+    if not choices:
+        return f"- {name}:"
+    rendered = " / ".join(f"`{choice}`" for choice in choices)
+    return f"- {name}（{rendered}）:"
+
+
+def render_contract_reference_lines() -> list[str]:
+    return [
+        f"Canonical integration contract source: `{CONTRACT_SOURCE_MACHINE_READABLE}` / `{CONTRACT_SOURCE_MODULE}`",
+    ]
+
+
+def render_issue_form_guidance_lines() -> list[str]:
+    return [
+        "按 canonical contract 填写以下字段。",
+        "`merge_gate` 的触发条件、`integration_ref` 的合法格式与 legacy 兼容规则，以 canonical contract 为准。",
+        "纯本仓库事项必须显式收口为 local-only 组合；跨仓事项必须按 contract 进入 integration gate。",
+    ]
+
+
+def render_pr_template_guidance_lines() -> list[str]:
+    return [
+        "按 canonical contract 填写并校验 `integration_check`。",
+        "`merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。",
+        "`integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。",
+    ]
+
+
+def normalize_heading(text: str) -> str:
+    normalized = text.strip()
+    normalized = re.sub(r"\s*[:：]\s*$", "", normalized)
+    normalized = re.sub(r"\s+/+\s*", " / ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.casefold()
+
+
+FIELD_LOOKUP = {normalize_heading(name): name for name in FIELD_ORDER}
+
+
+def extract_markdown_heading_sections(body: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    heading_pattern = re.compile(r"^#{2,6}\s+(.+?)\s*$")
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        heading_match = heading_pattern.match(stripped)
+        if heading_match:
+            current = heading_match.group(1).strip()
+            sections.setdefault(current, [])
+            continue
+        if current:
+            sections[current].append(line.rstrip())
+
+    return {key: "\n".join(value).strip() for key, value in sections.items() if "\n".join(value).strip()}
+
+
+def extract_issue_canonical_integration_fields(body: str) -> dict[str, str]:
+    payload: dict[str, str] = {}
+    for heading, content in extract_markdown_heading_sections(body).items():
+        canonical = FIELD_LOOKUP.get(normalize_heading(heading))
+        if canonical in ISSUE_SCOPE_FIELDS and content:
+            payload[canonical] = content.strip()
+    return payload
+
+
+def extract_integration_check_section(body: str) -> str:
+    return extract_markdown_heading_sections(body).get("integration_check", "")
+
+
+def parse_integration_check_payload(section: str) -> dict[str, str]:
+    payload: dict[str, str] = {}
+    current_key: str | None = None
+    parsing_closed = False
+    for raw_line in section.splitlines():
+        stripped = raw_line.strip()
+        if parsing_closed:
+            continue
+        if stripped.startswith("- "):
+            entry = stripped[2:]
+            key_part, _, value_part = entry.partition(":")
+            if not _:
+                key_part, _, value_part = entry.partition("：")
+            normalized_key = key_part.split("（", 1)[0].split("(", 1)[0].strip()
+            if normalized_key not in PR_SCOPE_FIELDS:
+                current_key = None
+                continue
+            current_key = normalized_key
+            payload[current_key] = value_part.strip()
+            continue
+        if current_key and stripped and raw_line[:1].isspace():
+            payload[current_key] = "\n".join(filter(None, [payload[current_key], stripped])).strip()
+            continue
+        if stripped:
+            current_key = None
+            if payload:
+                parsing_closed = True
+    return payload
+
+
+def parse_pr_integration_check(body: str) -> dict[str, str]:
+    return parse_integration_check_payload(extract_integration_check_section(body))
+
+
+def normalize_integration_value(field: str, value: str) -> str:
+    raw = str(value or "").strip()
+    if field == "integration_ref":
+        return normalize_integration_ref_for_comparison(raw)
+    return raw.lower()
+
+
+def semantic_integration_ref_key(value: str) -> str:
+    normalized = normalize_integration_ref_for_comparison(value)
+    if normalized in {"", "none"}:
+        return normalized
+    live_state = fetch_integration_ref_live_state(value)
+    if str(live_state.get("error") or "").strip():
+        return normalized
+    item_id = str(live_state.get("item_id") or "").strip()
+    organization = str(live_state.get("organization") or "").strip().lower()
+    project_number = str(live_state.get("project_number") or "").strip()
+    if item_id and organization and project_number:
+        return f"project-item:{organization}/{project_number}#{item_id}"
+    return normalized
+
+
+def normalize_integration_value_for_packet(field: str, value: str) -> str:
+    raw = str(value or "").strip()
+    if field == "integration_ref":
+        return semantic_integration_ref_key(raw)
+    return normalize_integration_value(field, raw)
+
+
+def missing_required_fields(payload: Mapping[str, str], scope: str) -> list[str]:
+    return [field for field in field_names(scope) if not str(payload.get(field) or "").strip()]
+
+
+def validate_enum_values(payload: Mapping[str, str], scope: str, *, prefix: str) -> list[str]:
+    errors: list[str] = []
+    for field in field_names(scope):
+        choices = field_choices(field)
+        if not choices:
+            continue
+        value = str(payload.get(field) or "").strip().lower()
+        if value not in choices:
+            errors.append(
+                f"`{prefix}.{field}` 非法：`{value}`（仅允许 `{', '.join(choices)}`）。"
+            )
+    return errors
+
+
+def evaluate_rule(rule: Mapping[str, str], payload: Mapping[str, str]) -> bool:
+    field = str(rule["field"])
+    operator = str(rule["operator"])
+    expected = str(rule["value"]).lower()
+    actual = str(payload.get(field) or "").strip().lower()
+    if operator == "==":
+        return actual == expected
+    if operator == "!=":
+        return actual != expected
+    raise ValueError(f"未知 rule operator: {operator}")
+
+
+def requires_integration_gate(payload: Mapping[str, str]) -> bool:
+    for rule in RAW_CONTRACT["rules"]["merge_gate_required_when"]:
+        if evaluate_rule(rule, payload):
+            return True
+    return False
+
+
+def requires_checkable_integration_ref(payload: Mapping[str, str]) -> bool:
+    return evaluate_rule(RAW_CONTRACT["rules"]["integration_touchpoint_requires_checkable_ref"], payload)
+
+
+def compare_issue_and_pr_canonical(
+    issue_canonical: Mapping[str, str],
+    pr_payload: Mapping[str, str],
+    *,
+    issue_label: str,
+    field_prefix: str = "integration_check",
+) -> list[str]:
+    errors: list[str] = []
+    for field in ISSUE_SCOPE_FIELDS:
+        if field == "integration_ref":
+            expected = semantic_integration_ref_key(str(issue_canonical.get(field, "") or ""))
+            actual = semantic_integration_ref_key(str(pr_payload.get(field, "") or ""))
+        else:
+            expected = normalize_integration_value(field, issue_canonical.get(field, ""))
+            actual = normalize_integration_value(field, pr_payload.get(field, ""))
+        if expected != actual:
+            errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
+    return errors
+
+
+def missing_pr_integration_check_error(issue_number: int | None) -> str:
+    issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
+    return f"PR 对应的 {issue_label} 已声明 canonical integration 元数据，PR 描述缺少 canonical `integration_check` 段落。"
+
+
+def validate_issue_canonical_resolution(resolution: IssueCanonicalResolution, *, allow_missing_payload: bool) -> list[str]:
+    if resolution.error:
+        return [resolution.error]
+    if not resolution.canonical:
+        return [] if allow_missing_payload else [f"Issue #{resolution.issue_number} 缺少 canonical integration 元数据，受控入口拒绝继续。"]
+
+    missing = missing_required_fields(resolution.canonical, "issue")
+    if not missing:
+        return validate_enum_values(resolution.canonical, "issue", prefix="issue_canonical")
+    missing_text = "、".join(f"`{field}`" for field in missing)
+    return [f"Issue #{resolution.issue_number} 的 canonical integration 元数据缺少字段：{missing_text}。"]
+
+
+def validate_open_pr_payload(payload: Mapping[str, str], *, issue_canonical: Mapping[str, str], issue_number: int | None) -> list[str]:
+    errors: list[str] = []
+    errors.extend(validate_enum_values(payload, "pr", prefix="integration"))
+    integration_ref = str(payload.get("integration_ref") or "").strip()
+    merge_gate = str(payload.get("merge_gate") or "").strip().lower()
+    integration_touchpoint = str(payload.get("integration_touchpoint") or "").strip().lower()
+    if requires_checkable_integration_ref(payload):
+        if not integration_ref:
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 不能为空。")
+        elif integration_ref.lower() == "none":
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 不能为 `none`。")
+        elif not integration_ref_is_checkable(integration_ref):
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 必须指向可核查的具体 integration issue / item。")
+    if merge_gate == "integration_check_required":
+        if not integration_ref:
+            errors.append("`merge_gate=integration_check_required` 时，`integration_ref` 不能为空。")
+        if not integration_ref_is_checkable(integration_ref):
+            errors.append("`merge_gate=integration_check_required` 时，`integration_ref` 必须指向具体 integration issue / item。")
+        if integration_touchpoint == "none":
+            errors.append("`merge_gate=integration_check_required` 时，`integration_touchpoint` 不能为 `none`。")
+        if str(payload.get("integration_status_checked_before_pr") or "").strip().lower() != "yes":
+            errors.append("`merge_gate=integration_check_required` 时，进入 `open_pr` 前必须记录 `integration_status_checked_before_pr=yes`。")
+    if str(payload.get("integration_status_checked_before_merge") or "").strip().lower() == "yes":
+        errors.append("`open_pr` 阶段不得把 `integration_status_checked_before_merge` 设为 `yes`；该字段只能在进入 `merge_pr` 前显式确认。")
+    if requires_integration_gate(payload) and merge_gate != "integration_check_required":
+        errors.append("触及 integration 联动、共享契约、共享 contract surface、跨仓依赖或联合验收时，`merge_gate` 必须为 `integration_check_required`。")
+    if str(payload.get("external_dependency") or "").strip().lower() != "none" and integration_touchpoint == "none":
+        errors.append("存在跨仓依赖、联合验收或共享 contract surface 时，`integration_touchpoint` 不能为 `none`。")
+    if str(payload.get("joint_acceptance_needed") or "").strip().lower() == "yes" and integration_touchpoint == "none":
+        errors.append("存在跨仓依赖、联合验收或共享 contract surface 时，`integration_touchpoint` 不能为 `none`。")
+    if str(payload.get("contract_surface") or "").strip().lower() != "none" and integration_touchpoint == "none":
+        errors.append("`contract_surface != none` 时，`integration_touchpoint` 不能为 `none`。")
+    if merge_gate != "integration_check_required":
+        if integration_ref == "":
+            errors.append("纯本仓库事项也必须显式填写 `integration_ref`；若无 integration 联动，请写 `none`。")
+        elif normalize_integration_value("integration_ref", integration_ref) != "none" and not integration_ref_is_checkable(integration_ref):
+            errors.append("`integration_ref` 必须使用可核查的具体 integration issue / item 引用（例如 `#123`、`owner/repo#123`、issue URL 或带 `itemId=` 的 project item URL）。")
+        elif normalize_integration_value("integration_ref", integration_ref) != "none":
+            errors.append("纯本仓库事项必须显式使用 `integration_ref=none`，不得保留外部 integration 绑定。")
+
+    if issue_canonical:
+        issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
+        errors.extend(compare_issue_and_pr_canonical(issue_canonical, payload, issue_label=issue_label, field_prefix="cli"))
+    return errors
+
+
+def validate_pr_merge_gate_payload(
+    payload: Mapping[str, str],
+    *,
+    issue_number: int | None,
+    issue_canonical: Mapping[str, str],
+    require_merge_time_recheck: bool,
+) -> list[str]:
+    errors: list[str] = []
+    merge_gate = str(payload.get("merge_gate") or "").strip().lower()
+    if not merge_gate:
+        return ["PR 描述中的 `integration_check.merge_gate` 不能为空。"]
+    if merge_gate not in field_choices("merge_gate"):
+        return [f"PR 描述中的 `integration_check.merge_gate` 非法：`{merge_gate}`（仅允许 `local_only` / `integration_check_required`）。"]
+    missing = sorted(missing_required_fields(payload, "pr"))
+    if missing:
+        missing_text = "、".join(f"`integration_check.{field}`" for field in missing)
+        return [f"PR 描述中的 `integration_check` 缺少必填字段：{missing_text}。"]
+
+    errors.extend(validate_enum_values(payload, "pr", prefix="integration_check"))
+    if issue_canonical:
+        issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
+        errors.extend(compare_issue_and_pr_canonical(issue_canonical, payload, issue_label=issue_label))
+
+    integration_touchpoint = str(payload.get("integration_touchpoint") or "").strip().lower()
+    integration_ref = str(payload.get("integration_ref") or "").strip()
+    if requires_checkable_integration_ref(payload):
+        if not integration_ref:
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 不能为空。")
+        elif integration_ref.lower() == "none":
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 不能为 `none`。")
+        elif not integration_ref_is_checkable(integration_ref):
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 必须指向可核查的具体 integration issue / item。")
+
+    if requires_integration_gate(payload) and merge_gate != "integration_check_required":
+        errors.append(
+            "`merge_gate=local_only` 与当前 integration 元数据冲突："
+            "当 `integration_touchpoint != none`、`shared_contract_changed=yes`、`external_dependency != none`、"
+            "`contract_surface != none` 或 `joint_acceptance_needed=yes` 时，"
+            "`merge_gate` 必须为 `integration_check_required`。"
+        )
+    if str(payload.get("external_dependency") or "").strip().lower() != "none" and integration_touchpoint == "none":
+        errors.append("存在跨仓依赖、联合验收或共享 contract surface 时，`integration_touchpoint` 不能为 `none`。")
+    if str(payload.get("joint_acceptance_needed") or "").strip().lower() == "yes" and integration_touchpoint == "none":
+        errors.append("存在跨仓依赖、联合验收或共享 contract surface 时，`integration_touchpoint` 不能为 `none`。")
+    if str(payload.get("contract_surface") or "").strip().lower() != "none" and integration_touchpoint == "none":
+        errors.append("`contract_surface != none` 时，`integration_touchpoint` 不能为 `none`。")
+
+    if merge_gate != "integration_check_required":
+        if requires_integration_gate(payload):
+            return errors
+        if not integration_ref:
+            errors.append("纯本仓库事项也必须显式填写 `integration_ref`；若无 integration 联动，请写 `none`。")
+        elif normalize_integration_value("integration_ref", integration_ref) != "none" and not integration_ref_is_checkable(integration_ref):
+            errors.append("`integration_ref` 必须使用可核查的具体 integration issue / item 引用（例如 `#123`、`owner/repo#123`、issue URL 或带 `itemId=` 的 project item URL）。")
+        elif normalize_integration_value("integration_ref", integration_ref) != "none":
+            errors.append("纯本仓库事项必须显式使用 `integration_ref=none`，不得保留外部 integration 绑定。")
+        return errors
+
+    if integration_touchpoint == "none":
+        errors.append("`merge_gate=integration_check_required` 时，`integration_touchpoint` 不能为 `none`。")
+    if not integration_ref or not integration_ref_is_checkable(integration_ref):
+        errors.append("`merge_gate=integration_check_required` 时，`integration_ref` 必须指向具体 integration issue / item。")
+    if str(payload.get("integration_status_checked_before_pr") or "").strip().lower() != "yes":
+        errors.append("`merge_gate=integration_check_required` 时，PR 描述必须记录 `integration_status_checked_before_pr=yes`。")
+    if require_merge_time_recheck and str(payload.get("integration_status_checked_before_merge") or "").strip().lower() != "yes":
+        errors.append("`merge_gate=integration_check_required` 时，进入 `merge_pr` 前必须把 `integration_status_checked_before_merge` 更新为 `yes`。")
+    return errors
+
+
+def validate_pr_integration_contract(
+    payload: Mapping[str, str],
+    *,
+    issue_number: int | None,
+    issue_canonical: Mapping[str, str],
+    issue_error: str | None = None,
+    require_merge_time_recheck: bool,
+) -> list[str]:
+    if issue_error:
+        return [issue_error]
+    if not payload:
+        return [missing_pr_integration_check_error(issue_number)] if issue_canonical else []
+    return validate_pr_merge_gate_payload(
+        payload,
+        issue_number=issue_number,
+        issue_canonical=issue_canonical,
+        require_merge_time_recheck=require_merge_time_recheck,
+    )
+
+
+def merge_gate_requires_integration_recheck(payload: Mapping[str, str]) -> bool:
+    return str(payload.get("merge_gate") or "").strip().lower() == "integration_check_required"
+
+
+def parse_issue_ref(integration_ref: str) -> tuple[str, int] | None:
+    ref = integration_ref.strip()
+    local_match = re.match(r"^#(\d+)$", ref)
+    if local_match:
+        return default_github_repo(), int(local_match.group(1))
+
+    repo_match = re.match(r"^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(\d+)$", ref)
+    if repo_match:
+        return repo_match.group(1), int(repo_match.group(2))
+
+    url_match = re.match(r"^https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)$", ref)
+    if url_match:
+        return url_match.group(1), int(url_match.group(2))
+    return None
+
+
+def parse_project_item_ref(integration_ref: str) -> tuple[str, str, str] | None:
+    parsed = urlparse(integration_ref.strip())
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        return None
+    if len(path_parts) < 4 or path_parts[0] != "orgs" or path_parts[2] != "projects":
+        return None
+    item_ids = parse_qs(parsed.query).get("itemId", [])
+    if not item_ids:
+        return None
+    return path_parts[1], path_parts[3], item_ids[0]
+
+
+def value_from_project_item_node(node: Mapping[str, object]) -> str:
+    typename = str(node.get("__typename") or "")
+    if typename == "ProjectV2ItemFieldSingleSelectValue":
+        return str(node.get("name") or "").strip()
+    if typename == "ProjectV2ItemFieldTextValue":
+        return str(node.get("text") or "").strip()
+    if typename == "ProjectV2ItemFieldNumberValue":
+        number = node.get("number")
+        return "" if number is None else str(number).strip()
+    if typename == "ProjectV2ItemFieldDateValue":
+        return str(node.get("date") or "").strip()
+    return ""
+
+
+def normalize_label_value(value: str) -> str:
+    return value.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def extract_label_value(labels: Iterable[str], prefixes: tuple[str, ...]) -> str:
+    for label in labels:
+        candidate = label.strip().lower()
+        for prefix in prefixes:
+            if candidate.startswith(prefix):
+                return normalize_label_value(candidate[len(prefix) :])
+    return ""
+
+
+def repo_name_from_slug(slug: str) -> str:
+    if "/" not in slug:
+        return slug.strip().lower()
+    return slug.split("/", 1)[1].strip().lower()
+
+
+def canonical_integration_project_owner() -> str:
+    repo_slug = default_github_repo()
+    owner, _, _ = repo_slug.partition("/")
+    return owner.strip().lower()
+
+
+def project_item_fields(node: Mapping[str, object]) -> dict[str, str]:
+    field_nodes = ((node.get("fieldValues") or {}).get("nodes") or []) if isinstance(node, dict) else []
+    fields: dict[str, str] = {}
+    if isinstance(field_nodes, list):
+        for raw_node in field_nodes:
+            if not isinstance(raw_node, dict):
+                continue
+            field_name = str(((raw_node.get("field") or {}).get("name") or "")).strip()
+            if not field_name:
+                continue
+            fields[field_name.lower()] = value_from_project_item_node(raw_node)
+    return fields
+
+
+def is_canonical_integration_project_item(node: Mapping[str, object], fields: Mapping[str, str]) -> bool:
+    project = node.get("project") or {}
+    project_title = str((project or {}).get("title") or "").strip()
+    project_owner = str(((project or {}).get("owner") or {}).get("login") or "").strip().lower()
+    return (
+        project_title == CANONICAL_INTEGRATION_PROJECT_TITLE
+        and project_owner == canonical_integration_project_owner()
+        and CANONICAL_INTEGRATION_PROJECT_REQUIRED_FIELDS.issubset(fields.keys())
+    )
+
+
+def build_project_item_live_state(
+    integration_ref: str,
+    node: Mapping[str, object],
+    *,
+    source: str,
+    expected_owner: str | None = None,
+    expected_project_number: str | None = None,
+    require_canonical_contract: bool = False,
+) -> dict[str, object]:
+    if str(node.get("__typename") or "") != "ProjectV2Item":
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": source,
+            "error": "`integration_ref` 指向对象不是可读的 ProjectV2Item，拒绝继续。",
+        }
+    if bool(node.get("isArchived")):
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": source,
+            "error": "`integration_ref` 指向的 ProjectV2Item 已归档，不能作为 merge gate 真相源。",
+        }
+
+    fields = project_item_fields(node)
+    if require_canonical_contract and not is_canonical_integration_project_item(node, fields):
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": source,
+            "error": (
+                "`integration_ref` 必须指向 owner 级 canonical integration project item "
+                f"`{CANONICAL_INTEGRATION_PROJECT_TITLE}`，拒绝继续。"
+            ),
+        }
+    project = node.get("project") or {}
+    project_url = str((project or {}).get("url") or "").strip()
+    project_owner = str(((project or {}).get("owner") or {}).get("login") or "").strip().lower()
+    project_number_actual = str((project or {}).get("number") or "").strip()
+    if expected_owner and project_owner and project_owner != expected_owner.strip().lower():
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": source,
+            "error": (
+                "`integration_ref` 与 project item 实际归属不一致："
+                f"URL owner=`{expected_owner}`，返回 owner=`{project_owner}`。"
+            ),
+        }
+    if expected_project_number and project_number_actual and project_number_actual != expected_project_number.strip():
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": source,
+            "error": (
+                "`integration_ref` 与 project item 实际 project 编号不一致："
+                f"URL projects/{expected_project_number}，返回 projects/{project_number_actual}。"
+            ),
+        }
+
+    status = normalize_label_value(fields.get("status", ""))
+    dependency_order = normalize_label_value(fields.get("dependency order", ""))
+    joint_acceptance = normalize_label_value(fields.get("joint acceptance", ""))
+    contract_status = normalize_label_value(fields.get("contract status", ""))
+    owner_repo = normalize_label_value(fields.get("owner repo", ""))
+    blocked = status == "blocked"
+
+    return {
+        "integration_ref": integration_ref,
+        "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+        "source": source,
+        "url": integration_ref,
+        "project_url": project_url,
+        "project_title": str((project or {}).get("title") or "").strip(),
+        "project_number": project_number_actual or (expected_project_number or "").strip(),
+        "organization": project_owner or (expected_owner or "").strip().lower(),
+        "item_id": str(node.get("id") or "").strip(),
+        "status": status,
+        "dependency_order": dependency_order,
+        "joint_acceptance": joint_acceptance,
+        "contract_status": contract_status,
+        "owner_repo": owner_repo,
+        "blocked": blocked,
+        "error": "",
+    }
+
+
+def fetch_issue_integration_ref_live_state(integration_ref: str, repo_slug: str, issue_number: int) -> dict[str, object]:
+    owner, _, name = repo_slug.partition("/")
+    issue: dict[str, object] | None = None
+    project_nodes: list[dict[str, object]] = []
+    after: str | None = None
+
+    while True:
+        command = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={ISSUE_PROJECT_ITEMS_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={issue_number}",
+        ]
+        if after:
+            command.extend(["-f", f"after={after}"])
+        completed = run(command, cwd=REPO_ROOT, check=False)
+        if completed.returncode != 0:
+            return {
+                "integration_ref": integration_ref,
+                "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+                "source": "issue",
+                "error": f"无法读取 `integration_ref` 指向的 issue `{repo_slug}#{issue_number}`，拒绝继续。",
+            }
+
+        payload = json.loads(completed.stdout or "{}")
+        current_issue = (((payload.get("data") or {}).get("repository") or {}).get("issue") or {}) if isinstance(payload, dict) else {}
+        if not isinstance(current_issue, dict) or not current_issue:
+            return {
+                "integration_ref": integration_ref,
+                "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+                "source": "issue",
+                "error": f"无法读取 `integration_ref` 指向的 issue `{repo_slug}#{issue_number}`，拒绝继续。",
+            }
+
+        issue = current_issue
+        project_items = (current_issue.get("projectItems") or {}) if isinstance(current_issue, dict) else {}
+        nodes = project_items.get("nodes") or []
+        if isinstance(nodes, list):
+            project_nodes.extend(item for item in nodes if isinstance(item, dict))
+        page_info = project_items.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        if not has_next_page:
+            break
+        after = str(page_info.get("endCursor") or "").strip()
+        if not after:
+            return {
+                "integration_ref": integration_ref,
+                "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+                "source": "issue",
+                "error": (
+                    f"`integration_ref` 指向的 issue `{repo_slug}#{issue_number}` 的 projectItems 分页信息不完整，"
+                    "无法完整读取 owner 级 integration project item，拒绝继续。"
+                ),
+            }
+
+    if issue is None:
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": "issue",
+            "error": f"无法读取 `integration_ref` 指向的 issue `{repo_slug}#{issue_number}`，拒绝继续。",
+        }
+
+    candidates: list[dict[str, object]] = []
+    for raw_node in project_nodes:
+        if not isinstance(raw_node, dict) or bool(raw_node.get("isArchived")):
+            continue
+        fields = project_item_fields(raw_node)
+        if not is_canonical_integration_project_item(raw_node, fields):
+            continue
+        candidate = build_project_item_live_state(integration_ref, raw_node, source="issue_project_item")
+        if str(candidate.get("error") or "").strip():
+            continue
+        candidates.append(candidate)
+
+    if not candidates:
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": "issue",
+            "url": str(issue.get("url") or "").strip(),
+            "title": str(issue.get("title") or "").strip(),
+            "error": (
+                f"`integration_ref` 指向的 issue `{repo_slug}#{issue_number}` 未挂接可核查的 integration project item，"
+                "无法读取 `status` / `dependency_order` / `joint_acceptance`，拒绝继续。"
+            ),
+        }
+    if len(candidates) > 1:
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": "issue",
+            "url": str(issue.get("url") or "").strip(),
+            "title": str(issue.get("title") or "").strip(),
+            "error": (
+                f"`integration_ref` 指向的 issue `{repo_slug}#{issue_number}` 命中多个可核查的 integration project item，"
+                "当前无法唯一确定 merge gate 真相源，拒绝继续。"
+            ),
+        }
+
+    candidate = dict(candidates[0])
+    candidate["source"] = "issue"
+    candidate["url"] = str(issue.get("url") or "").strip()
+    candidate["title"] = str(issue.get("title") or "").strip()
+    candidate["issue_state"] = normalize_label_value(str(issue.get("state") or ""))
+    return candidate
+
+
+def fetch_project_item_integration_ref_live_state(
+    integration_ref: str,
+    organization: str,
+    project_number: str,
+    item_id: str,
+) -> dict[str, object]:
+    completed = run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={INTEGRATION_PROJECT_ITEM_QUERY}",
+            "-F",
+            f"id={item_id}",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return {
+            "integration_ref": integration_ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+            "source": "project_item",
+            "error": f"无法读取 `integration_ref` 指向的 project item `{item_id}`，拒绝继续。",
+        }
+
+    payload = json.loads(completed.stdout or "{}")
+    node = ((payload.get("data") or {}).get("node") or {}) if isinstance(payload, dict) else {}
+    live_state = build_project_item_live_state(
+        integration_ref,
+        node,
+        source="project_item",
+        expected_owner=organization,
+        expected_project_number=project_number,
+        require_canonical_contract=True,
+    )
+    if not str(live_state.get("error") or "").strip():
+        live_state["item_id"] = item_id
+    return live_state
+
+
+def fetch_integration_ref_live_state(integration_ref: str) -> dict[str, object]:
+    ref = integration_ref.strip()
+    if not ref:
+        return {}
+    if not integration_ref_is_checkable(ref):
+        return {
+            "integration_ref": ref,
+            "normalized_ref": normalize_integration_ref_for_comparison(ref),
+            "source": "unknown",
+            "error": "`integration_ref` 不是可核查的 issue / project item 引用，拒绝继续。",
+        }
+
+    issue_ref = parse_issue_ref(ref)
+    if issue_ref:
+        repo_slug, issue_number = issue_ref
+        return fetch_issue_integration_ref_live_state(ref, repo_slug, issue_number)
+
+    project_item_ref = parse_project_item_ref(ref)
+    if project_item_ref:
+        organization, project_number, item_id = project_item_ref
+        return fetch_project_item_integration_ref_live_state(ref, organization, project_number, item_id)
+
+    return {
+        "integration_ref": ref,
+        "normalized_ref": normalize_integration_ref_for_comparison(ref),
+        "source": "unknown",
+        "error": "`integration_ref` 格式无法解析为 issue / project item，拒绝继续。",
+    }
+
+
+def validate_integration_ref_live_state(
+    payload: Mapping[str, str],
+    live_state: Mapping[str, object],
+    *,
+    current_repo_slug: str | None = None,
+) -> list[str]:
+    if not merge_gate_requires_integration_recheck(payload):
+        return []
+    integration_ref = str(payload.get("integration_ref") or "").strip()
+    if not integration_ref or not integration_ref_is_checkable(integration_ref):
+        return []
+    if not live_state:
+        return ["无法读取 `integration_ref` 当前状态，拒绝继续。"]
+
+    errors: list[str] = []
+    error_text = str(live_state.get("error") or "").strip()
+    if error_text:
+        return [error_text]
+
+    if bool(live_state.get("blocked")):
+        errors.append("`integration_ref` 当前状态为 `blocked`，拒绝继续。")
+
+    dependency_order = normalize_label_value(str(live_state.get("dependency_order") or ""))
+    status = normalize_label_value(str(live_state.get("status") or ""))
+    owner_repo = normalize_label_value(str(live_state.get("owner_repo") or ""))
+    contract_status = normalize_label_value(str(live_state.get("contract_status") or ""))
+    if not status:
+        errors.append("无法从 `integration_ref` 读取当前 `status`，拒绝继续。")
+    elif status not in MERGE_TIME_ALLOWED_LIVE_STATUSES:
+        allowed = " / ".join(MERGE_TIME_ALLOWED_LIVE_STATUSES)
+        errors.append(
+            f"`integration_ref` 当前 `status` 为 `{status}`，未进入允许合并的状态集合（仅允许 `{allowed}`）。"
+        )
+    if not dependency_order:
+        errors.append("无法从 `integration_ref` 读取当前 `dependency_order`，拒绝继续。")
+    if not owner_repo:
+        errors.append("无法从 `integration_ref` 读取当前 `owner_repo`，拒绝继续。")
+    if not contract_status:
+        errors.append("无法从 `integration_ref` 读取当前 `contract_status`，拒绝继续。")
+    repo_name = repo_name_from_slug(current_repo_slug or default_github_repo())
+    if dependency_order == "webenvoy_first" and repo_name == "syvert":
+        errors.append("`integration_ref` 的依赖顺序要求 `webenvoy_first`，当前仓库不得先合并。")
+    if dependency_order == "syvert_first" and repo_name == "webenvoy":
+        errors.append("`integration_ref` 的依赖顺序要求 `syvert_first`，当前仓库不得先合并。")
+
+    if str(payload.get("joint_acceptance_needed") or "").strip().lower() == "yes":
+        joint_acceptance = normalize_label_value(str(live_state.get("joint_acceptance") or ""))
+        if not joint_acceptance:
+            errors.append("`joint_acceptance_needed=yes`，但无法从 `integration_ref` 读取联合验收状态，拒绝继续。")
+        elif joint_acceptance == "failed":
+            errors.append("`integration_ref` 联合验收状态为 `failed`，拒绝继续。")
+        elif joint_acceptance not in {"ready", "passed"}:
+            errors.append(f"`integration_ref` 联合验收状态未就绪（当前 `{joint_acceptance}`），拒绝继续。")
+    return errors
+
+
+def validate_issue_canonical_payload(payload: Mapping[str, str]) -> list[str]:
+    errors: list[str] = []
+    merge_gate = str(payload.get("merge_gate") or "").strip().lower()
+    integration_touchpoint = str(payload.get("integration_touchpoint") or "").strip().lower()
+    integration_ref = str(payload.get("integration_ref") or "").strip()
+    if requires_checkable_integration_ref(payload):
+        if not integration_ref:
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 不能为空。")
+        elif integration_ref.lower() == "none":
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 不能为 `none`。")
+        elif not integration_ref_is_checkable(integration_ref):
+            errors.append("`integration_touchpoint != none` 时，`integration_ref` 必须指向可核查的具体 integration issue / item。")
+    if requires_integration_gate(payload) and merge_gate != "integration_check_required":
+        errors.append(
+            "Issue canonical integration 元数据与 contract 组合约束冲突："
+            "当 `integration_touchpoint != none`、`shared_contract_changed=yes`、`external_dependency != none`、"
+            "`contract_surface != none` 或 `joint_acceptance_needed=yes` 时，`merge_gate` 必须为 `integration_check_required`。"
+        )
+    if str(payload.get("external_dependency") or "").strip().lower() != "none" and integration_touchpoint == "none":
+        errors.append("存在跨仓依赖、联合验收或共享 contract surface 时，`integration_touchpoint` 不能为 `none`。")
+    if str(payload.get("joint_acceptance_needed") or "").strip().lower() == "yes" and integration_touchpoint == "none":
+        errors.append("存在跨仓依赖、联合验收或共享 contract surface 时，`integration_touchpoint` 不能为 `none`。")
+    if str(payload.get("contract_surface") or "").strip().lower() != "none" and integration_touchpoint == "none":
+        errors.append("`contract_surface != none` 时，`integration_touchpoint` 不能为 `none`。")
+
+    if merge_gate != "integration_check_required":
+        if not integration_ref:
+            errors.append("Issue canonical integration 元数据中的 `integration_ref` 不能为空；纯本仓库事项请显式填写 `none`。")
+        elif normalize_integration_value("integration_ref", integration_ref) != "none" and not integration_ref_is_checkable(integration_ref):
+            errors.append("Issue canonical integration 元数据中的 `integration_ref` 必须使用可核查的具体 integration issue / item 引用。")
+        elif normalize_integration_value("integration_ref", integration_ref) != "none":
+            errors.append("Issue canonical integration 元数据中 `merge_gate=local_only` 时必须显式使用 `integration_ref=none`。")
+        return errors
+
+    if integration_touchpoint == "none":
+        errors.append("`merge_gate=integration_check_required` 时，`integration_touchpoint` 不能为 `none`。")
+    if not integration_ref or not integration_ref_is_checkable(integration_ref):
+        errors.append("`merge_gate=integration_check_required` 时，`integration_ref` 必须指向具体 integration issue / item。")
+    return errors
+
+
+def validate_issue_fetch(issue_number: int, *, allow_missing_payload: bool) -> IssueCanonicalResolution:
+    completed = run(
+        ["gh", "issue", "view", str(issue_number), "--json", "body"],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return IssueCanonicalResolution(
+            issue_number=issue_number,
+            canonical={},
+            error=f"无法读取 Issue #{issue_number} 的 canonical integration 元数据，拒绝继续。",
+        )
+    payload = json.loads(completed.stdout or "{}")
+    canonical = extract_issue_canonical_integration_fields(str(payload.get("body") or ""))
+    if not canonical and allow_missing_payload:
+        return IssueCanonicalResolution(issue_number=issue_number, canonical={}, error=None)
+    if not canonical:
+        return IssueCanonicalResolution(
+            issue_number=issue_number,
+            canonical={},
+            error=f"Issue #{issue_number} 缺少 canonical integration 元数据，受控入口拒绝继续。",
+        )
+    missing = missing_required_fields(canonical, "issue")
+    if missing:
+        missing_text = "、".join(f"`{field}`" for field in missing)
+        return IssueCanonicalResolution(
+            issue_number=issue_number,
+            canonical=canonical,
+            error=f"Issue #{issue_number} 的 canonical integration 元数据缺少字段：{missing_text}。",
+        )
+    enum_errors = validate_enum_values(canonical, "issue", prefix="issue_canonical")
+    if enum_errors:
+        return IssueCanonicalResolution(
+            issue_number=issue_number,
+            canonical=canonical,
+            error=enum_errors[0],
+        )
+    contract_errors = validate_issue_canonical_payload(canonical)
+    if contract_errors:
+        return IssueCanonicalResolution(
+            issue_number=issue_number,
+            canonical=canonical,
+            error=contract_errors[0],
+        )
+    return IssueCanonicalResolution(issue_number=issue_number, canonical=canonical, error=None)
+
+
+def build_review_packet(
+    body: str,
+    *,
+    issue_number: int | None,
+    issue_canonical: Mapping[str, str],
+    issue_error: str | None,
+    integration_ref_live: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    pr_payload = parse_pr_integration_check(body)
+    issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
+    packet_issue_error = str(issue_error or "").strip()
+    missing_pr_error = missing_pr_integration_check_error(issue_number) if issue_canonical and not pr_payload else ""
+    comparison_errors = (
+        [packet_issue_error]
+        if packet_issue_error
+        else
+        [missing_pr_error]
+        if missing_pr_error
+        else compare_issue_and_pr_canonical(issue_canonical, pr_payload, issue_label=issue_label) if issue_canonical and pr_payload else []
+    )
+    normalized_issue = {
+        field: normalize_integration_value_for_packet(field, issue_canonical.get(field, ""))
+        for field in ISSUE_SCOPE_FIELDS
+        if str(issue_canonical.get(field) or "").strip()
+    }
+    normalized_pr = {
+        field: normalize_integration_value_for_packet(field, pr_payload.get(field, ""))
+        for field in PR_SCOPE_FIELDS
+        if str(pr_payload.get(field) or "").strip()
+    }
+    merge_validation_errors = validate_pr_integration_contract(
+        pr_payload,
+        issue_number=issue_number,
+        issue_canonical=issue_canonical,
+        issue_error=packet_issue_error,
+        require_merge_time_recheck=False,
+    )
+    packet_integration_ref_live = dict(integration_ref_live or {})
+    integration_ref_live_errors = (
+        validate_integration_ref_live_state(
+            pr_payload,
+            packet_integration_ref_live,
+            current_repo_slug=default_github_repo(),
+        )
+        if integration_ref_live is not None
+        else []
+    )
+    if integration_ref_live_errors:
+        merge_validation_errors = [*merge_validation_errors, *[item for item in integration_ref_live_errors if item not in merge_validation_errors]]
+    return {
+        "contract_sources": [
+            CONTRACT_SOURCE_MACHINE_READABLE,
+            CONTRACT_SOURCE_MODULE,
+        ],
+        "issue_number": issue_number,
+        "issue_error": issue_error or "",
+        "issue_canonical": dict(issue_canonical),
+        "normalized_issue_canonical": normalized_issue,
+        "pr_canonical": pr_payload,
+        "normalized_pr_canonical": normalized_pr,
+        "comparison_errors": comparison_errors,
+        "merge_gate": str(pr_payload.get("merge_gate") or "").strip().lower() if pr_payload else "",
+        "merge_gate_requires_recheck": merge_gate_requires_integration_recheck(pr_payload) if pr_payload else False,
+        "integration_ref_live": packet_integration_ref_live,
+        "integration_ref_live_errors": integration_ref_live_errors,
+        "merge_validation_errors": merge_validation_errors,
+    }
+
+
+def render_review_packet_lines(packet: Mapping[str, object]) -> list[str]:
+    lines = [
+        f"- contract source: `{CONTRACT_SOURCE_MACHINE_READABLE}`",
+        f"- contract module: `{CONTRACT_SOURCE_MODULE}`",
+        f"- issue_number: {packet.get('issue_number') or '无'}",
+        f"- issue_lookup_error: {packet.get('issue_error') or 'none'}",
+    ]
+    issue_canonical = packet.get("issue_canonical") or {}
+    if issue_canonical:
+        lines.append("- issue_canonical:")
+        lines.extend([f"  - {field}: {issue_canonical[field]}" for field in ISSUE_SCOPE_FIELDS if field in issue_canonical])
+    else:
+        lines.append("- issue_canonical: none")
+    pr_canonical = packet.get("pr_canonical") or {}
+    if pr_canonical:
+        lines.append("- pr_canonical:")
+        lines.extend([f"  - {field}: {pr_canonical[field]}" for field in PR_SCOPE_FIELDS if field in pr_canonical])
+    else:
+        lines.append("- pr_canonical: none")
+    normalized_issue = packet.get("normalized_issue_canonical") or {}
+    if normalized_issue:
+        lines.append("- normalized_issue_canonical:")
+        lines.extend([f"  - {field}: {normalized_issue[field]}" for field in ISSUE_SCOPE_FIELDS if field in normalized_issue])
+    normalized_pr = packet.get("normalized_pr_canonical") or {}
+    if normalized_pr:
+        lines.append("- normalized_pr_canonical:")
+        lines.extend([f"  - {field}: {normalized_pr[field]}" for field in PR_SCOPE_FIELDS if field in normalized_pr])
+    comparison_errors = packet.get("comparison_errors") or []
+    if comparison_errors:
+        lines.append("- canonical_mismatches:")
+        lines.extend([f"  - {item}" for item in comparison_errors])
+    else:
+        lines.append("- canonical_mismatches: none")
+    integration_ref_live = packet.get("integration_ref_live") or {}
+    if integration_ref_live:
+        lines.append("- integration_ref_live:")
+        for key in (
+            "source",
+            "status",
+            "dependency_order",
+            "joint_acceptance",
+            "contract_status",
+            "owner_repo",
+            "url",
+            "project_url",
+            "error",
+        ):
+            value = str(integration_ref_live.get(key) or "").strip()
+            if value:
+                lines.append(f"  - {key}: {value}")
+    else:
+        lines.append("- integration_ref_live: none")
+    integration_ref_live_errors = packet.get("integration_ref_live_errors") or []
+    if integration_ref_live_errors:
+        lines.append("- integration_ref_live_validation:")
+        lines.extend([f"  - {item}" for item in integration_ref_live_errors])
+    merge_validation_errors = packet.get("merge_validation_errors") or []
+    if merge_validation_errors:
+        lines.append("- merge_gate_validation:")
+        lines.extend([f"  - {item}" for item in merge_validation_errors])
+    else:
+        lines.append("- merge_gate_validation: ok")
+    lines.append(f"- merge_gate: {packet.get('merge_gate') or 'none'}")
+    lines.append(f"- merge_gate_requires_recheck: {'yes' if packet.get('merge_gate_requires_recheck') else 'no'}")
+    return lines

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -851,6 +851,19 @@ def fetch_project_item_integration_ref_live_state(
         require_canonical_contract=True,
     )
     if not str(live_state.get("error") or "").strip():
+        content = node.get("content") or {}
+        if str(content.get("__typename") or "") != "Issue":
+            return {
+                "integration_ref": integration_ref,
+                "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
+                "source": "project_item",
+                "error": "`integration_ref` 直连的 project item 必须绑定到可核查的 Issue 内容，拒绝继续。",
+            }
+        repository = content.get("repository") or {}
+        live_state["content_type"] = "issue"
+        live_state["content_url"] = str(content.get("url") or "").strip()
+        live_state["content_issue_number"] = str(content.get("number") or "").strip()
+        live_state["content_repo"] = str(repository.get("nameWithOwner") or "").strip()
         live_state["item_id"] = item_id
     return live_state
 

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -294,24 +294,13 @@ def normalize_integration_value(field: str, value: str) -> str:
 
 
 def semantic_integration_ref_key(value: str) -> str:
-    normalized = normalize_integration_ref_for_comparison(value)
-    if normalized in {"", "none"}:
-        return normalized
-    live_state = fetch_integration_ref_live_state(value)
-    if str(live_state.get("error") or "").strip():
-        return normalized
-    item_id = str(live_state.get("item_id") or "").strip()
-    organization = str(live_state.get("organization") or "").strip().lower()
-    project_number = str(live_state.get("project_number") or "").strip()
-    if item_id and organization and project_number:
-        return f"project-item:{organization}/{project_number}#{item_id}"
-    return normalized
+    return normalize_integration_ref_for_comparison(value)
 
 
 def normalize_integration_value_for_packet(field: str, value: str) -> str:
     raw = str(value or "").strip()
     if field == "integration_ref":
-        return semantic_integration_ref_key(raw)
+        return normalize_integration_value(field, raw)
     return normalize_integration_value(field, raw)
 
 
@@ -365,12 +354,8 @@ def compare_issue_and_pr_canonical(
 ) -> list[str]:
     errors: list[str] = []
     for field in ISSUE_SCOPE_FIELDS:
-        if field == "integration_ref":
-            expected = semantic_integration_ref_key(str(issue_canonical.get(field, "") or ""))
-            actual = semantic_integration_ref_key(str(pr_payload.get(field, "") or ""))
-        else:
-            expected = normalize_integration_value(field, issue_canonical.get(field, ""))
-            actual = normalize_integration_value(field, pr_payload.get(field, ""))
+        expected = normalize_integration_value(field, issue_canonical.get(field, ""))
+        actual = normalize_integration_value(field, pr_payload.get(field, ""))
         if expected != actual:
             errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
     return errors

--- a/scripts/policy/integration_contract.json
+++ b/scripts/policy/integration_contract.json
@@ -1,0 +1,204 @@
+{
+  "canonical_source": {
+    "machine_readable": "scripts/policy/integration_contract.json",
+    "python_module": "scripts/integration_contract.py"
+  },
+  "field_order": [
+    "integration_touchpoint",
+    "shared_contract_changed",
+    "integration_ref",
+    "external_dependency",
+    "merge_gate",
+    "contract_surface",
+    "joint_acceptance_needed",
+    "integration_status_checked_before_pr",
+    "integration_status_checked_before_merge"
+  ],
+  "issue_scope_fields": [
+    "integration_touchpoint",
+    "shared_contract_changed",
+    "integration_ref",
+    "external_dependency",
+    "merge_gate",
+    "contract_surface",
+    "joint_acceptance_needed"
+  ],
+  "pr_scope_fields": [
+    "integration_touchpoint",
+    "shared_contract_changed",
+    "integration_ref",
+    "external_dependency",
+    "merge_gate",
+    "contract_surface",
+    "joint_acceptance_needed",
+    "integration_status_checked_before_pr",
+    "integration_status_checked_before_merge"
+  ],
+  "fields": [
+    {
+      "name": "integration_touchpoint",
+      "scopes": [
+        "issue",
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "none",
+        "check_required",
+        "active",
+        "blocked",
+        "resolved"
+      ]
+    },
+    {
+      "name": "shared_contract_changed",
+      "scopes": [
+        "issue",
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "no",
+        "yes"
+      ]
+    },
+    {
+      "name": "integration_ref",
+      "scopes": [
+        "issue",
+        "pr"
+      ],
+      "type": "string",
+      "examples": [
+        "#123",
+        "owner/repo#123",
+        "https://github.com/owner/repo/issues/123",
+        "https://github.com/orgs/owner/projects/3?pane=issue&itemId=PVTI_xxx"
+      ]
+    },
+    {
+      "name": "external_dependency",
+      "scopes": [
+        "issue",
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "none",
+        "syvert",
+        "webenvoy",
+        "both"
+      ]
+    },
+    {
+      "name": "merge_gate",
+      "scopes": [
+        "issue",
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "local_only",
+        "integration_check_required"
+      ]
+    },
+    {
+      "name": "contract_surface",
+      "scopes": [
+        "issue",
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "none",
+        "execution_provider",
+        "ids_trace",
+        "errors",
+        "raw_normalized",
+        "diagnostics_observability",
+        "runtime_modes"
+      ]
+    },
+    {
+      "name": "joint_acceptance_needed",
+      "scopes": [
+        "issue",
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "no",
+        "yes"
+      ]
+    },
+    {
+      "name": "integration_status_checked_before_pr",
+      "scopes": [
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "no",
+        "yes"
+      ]
+    },
+    {
+      "name": "integration_status_checked_before_merge",
+      "scopes": [
+        "pr"
+      ],
+      "type": "enum",
+      "choices": [
+        "no",
+        "yes"
+      ]
+    }
+  ],
+  "rules": {
+    "merge_gate_required_when": [
+      {
+        "field": "integration_touchpoint",
+        "operator": "!=",
+        "value": "none"
+      },
+      {
+        "field": "shared_contract_changed",
+        "operator": "==",
+        "value": "yes"
+      },
+      {
+        "field": "external_dependency",
+        "operator": "!=",
+        "value": "none"
+      },
+      {
+        "field": "contract_surface",
+        "operator": "!=",
+        "value": "none"
+      },
+      {
+        "field": "joint_acceptance_needed",
+        "operator": "==",
+        "value": "yes"
+      }
+    ],
+    "integration_touchpoint_requires_checkable_ref": {
+      "field": "integration_touchpoint",
+      "operator": "!=",
+      "value": "none"
+    },
+    "local_only_required_values": {
+      "integration_ref": "none"
+    },
+    "merge_time_allowed_live_statuses": [
+      "ready",
+      "review",
+      "done"
+    ]
+  },
+  "legacy_compatibility": {
+    "issue_lookup_failure": "fail_closed",
+    "issue_without_canonical_payload": "allow_legacy_path",
+    "issue_with_canonical_payload": "pr_must_match_issue"
+  }
+}

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -266,7 +266,7 @@ class IntegrationContractTests(unittest.TestCase):
         )
         self.assertGreaterEqual(fetch_live_mock.call_count, 1)
 
-    def test_default_github_repo_uses_origin_remote_when_env_missing(self) -> None:
+    def test_default_github_repo_falls_back_to_canonical_repo_when_env_missing(self) -> None:
         default_github_repo.cache_clear()
         with patch.dict("os.environ", {}, clear=True), patch("scripts.common.run") as run_mock:
             run_mock.return_value = subprocess.CompletedProcess(
@@ -276,8 +276,14 @@ class IntegrationContractTests(unittest.TestCase):
                 stderr="",
             )
 
-            self.assertEqual(default_github_repo(), "MC-and-his-Agents/WebEnvoy")
+            self.assertEqual(default_github_repo(), "MC-and-his-Agents/Syvert")
 
+        default_github_repo.cache_clear()
+
+    def test_default_github_repo_honors_explicit_env_override(self) -> None:
+        default_github_repo.cache_clear()
+        with patch.dict("os.environ", {"SYVERT_GITHUB_REPO": "MC-and-his-Agents/WebEnvoy"}, clear=True):
+            self.assertEqual(default_github_repo(), "MC-and-his-Agents/WebEnvoy")
         default_github_repo.cache_clear()
 
     def test_build_review_packet_rejects_missing_pr_canonical_when_issue_declares_contract(self) -> None:
@@ -856,6 +862,72 @@ class IntegrationContractTests(unittest.TestCase):
         self.assertEqual(run_mock.call_count, 2)
         self.assertEqual(payload["source"], "issue")
         self.assertEqual(payload["joint_acceptance"], "ready")
+
+    def test_fetch_integration_ref_live_state_rejects_issue_path_project_with_wrong_number(self) -> None:
+        graphql_payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 105,
+                        "title": "integration baseline",
+                        "url": "https://github.com/MC-and-his-Agents/Syvert/issues/105",
+                        "state": "OPEN",
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "__typename": "ProjectV2Item",
+                                    "id": "PVTI_wrong_number",
+                                    "isArchived": False,
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "Review",
+                                                "field": {"name": "Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "parallel",
+                                                "field": {"name": "Dependency Order"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "ready",
+                                                "field": {"name": "Joint Acceptance"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "reviewing",
+                                                "field": {"name": "Contract Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "joint",
+                                                "field": {"name": "Owner Repo"},
+                                            },
+                                        ]
+                                    },
+                                    "project": {
+                                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/99",
+                                        "number": 99,
+                                        "title": "Syvert × WebEnvoy Integration",
+                                        "owner": {"login": "MC-and-his-Agents"},
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        },
+                    }
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=json.dumps(graphql_payload), stderr="")
+
+            payload = fetch_integration_ref_live_state("MC-and-his-Agents/Syvert#105")
+
+        self.assertEqual(payload["source"], "issue")
+        self.assertIn("未挂接可核查的 integration project item", payload["error"])
 
     def test_fetch_integration_ref_live_state_rejects_project_item_owner_mismatch(self) -> None:
         graphql_payload = {

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -226,6 +226,46 @@ class IntegrationContractTests(unittest.TestCase):
         self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
         self.assertGreaterEqual(fetch_live_mock.call_count, 1)
 
+    @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        return_value={"source": "project_item", "error": "lookup failed"},
+    )
+    def test_build_review_packet_fail_closed_when_cross_form_ref_cannot_be_resolved(self, fetch_live_mock) -> None:
+        packet = build_review_packet(
+            "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_missing",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            ),
+            issue_number=105,
+            issue_canonical={
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "MC-and-his-Agents/Syvert#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+            issue_error="",
+        )
+
+        self.assertEqual(
+            packet["comparison_errors"],
+            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
+        )
+        self.assertGreaterEqual(fetch_live_mock.call_count, 1)
+
     def test_default_github_repo_uses_origin_remote_when_env_missing(self) -> None:
         default_github_repo.cache_clear()
         with patch.dict("os.environ", {}, clear=True), patch("scripts.common.run") as run_mock:

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from scripts.common import REPO_ROOT, default_github_repo, normalize_integration_ref_for_comparison
+from scripts.common import REPO_ROOT, default_github_repo, integration_ref_is_checkable, normalize_integration_ref_for_comparison
 from scripts.integration_contract import (
     CONTRACT_SOURCE_MACHINE_READABLE,
     CONTRACT_SOURCE_MODULE,
@@ -25,6 +25,7 @@ from scripts.integration_contract import (
     render_pr_template_guidance_lines,
     render_review_packet_lines,
     validate_integration_ref_live_state,
+    validate_issue_fetch,
     validate_issue_canonical_payload,
     validate_pr_merge_gate_payload,
 )
@@ -180,8 +181,17 @@ class IntegrationContractTests(unittest.TestCase):
         self.assertEqual(packet["merge_validation_errors"], [])
         self.assertTrue(packet["merge_gate_requires_recheck"])
 
-    @patch("scripts.integration_contract.fetch_integration_ref_live_state")
-    def test_build_review_packet_treats_issue_and_project_item_refs_as_distinct_canonical_forms(self, fetch_live_mock) -> None:
+    @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        return_value={
+            "source": "project_item",
+            "content_repo": "MC-and-his-Agents/Syvert",
+            "content_issue_number": "12",
+            "content_type": "issue",
+            "error": "",
+        },
+    )
+    def test_build_review_packet_collapses_equivalent_issue_and_project_item_refs(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -211,13 +221,10 @@ class IntegrationContractTests(unittest.TestCase):
             issue_error="",
         )
 
-        self.assertEqual(
-            packet["comparison_errors"],
-            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
-        )
+        self.assertEqual(packet["comparison_errors"], [])
         self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
-        self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
-        fetch_live_mock.assert_not_called()
+        self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
+        self.assertGreaterEqual(fetch_live_mock.call_count, 1)
 
     def test_default_github_repo_uses_origin_remote_when_env_missing(self) -> None:
         default_github_repo.cache_clear()
@@ -523,6 +530,42 @@ class IntegrationContractTests(unittest.TestCase):
 
         self.assertEqual(payload["source"], "issue")
         self.assertIn("无法读取", payload["error"])
+
+    def test_fetch_integration_ref_live_state_fail_closed_on_malformed_issue_json(self) -> None:
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="not-json", stderr="")
+
+            payload = fetch_integration_ref_live_state("MC-and-his-Agents/Syvert#105")
+
+        self.assertEqual(payload["source"], "issue")
+        self.assertIn("无法解析", payload["error"])
+
+    def test_fetch_integration_ref_live_state_fail_closed_on_malformed_project_item_json(self) -> None:
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="not-json", stderr="")
+
+            payload = fetch_integration_ref_live_state(
+                "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test"
+            )
+
+        self.assertEqual(payload["source"], "project_item")
+        self.assertIn("无法解析", payload["error"])
+
+    def test_validate_issue_fetch_fail_closed_on_malformed_issue_json(self) -> None:
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="not-json", stderr="")
+
+            resolution = validate_issue_fetch(105, allow_missing_payload=False)
+
+        self.assertIn("无法解析", resolution.error or "")
+
+    def test_integration_ref_is_checkable_matches_project_item_parser_shape(self) -> None:
+        self.assertFalse(
+            integration_ref_is_checkable("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&foo=itemId=PVTI_test")
+        )
+        self.assertTrue(
+            integration_ref_is_checkable("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+        )
 
     def test_fetch_integration_ref_live_state_reads_issue_ref_from_integration_project_item(self) -> None:
         graphql_payload = {

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -266,24 +266,32 @@ class IntegrationContractTests(unittest.TestCase):
         )
         self.assertGreaterEqual(fetch_live_mock.call_count, 1)
 
-    def test_default_github_repo_falls_back_to_canonical_repo_when_env_missing(self) -> None:
+    def test_default_github_repo_uses_repo_root_name_when_env_missing(self) -> None:
         default_github_repo.cache_clear()
-        with patch.dict("os.environ", {}, clear=True), patch("scripts.common.run") as run_mock:
-            run_mock.return_value = subprocess.CompletedProcess(
-                args=["git"],
-                returncode=0,
-                stdout="git@github.com:MC-and-his-Agents/WebEnvoy.git\n",
-                stderr="",
-            )
-
-            self.assertEqual(default_github_repo(), "MC-and-his-Agents/Syvert")
-
+        with patch.dict("os.environ", {}, clear=True), patch("scripts.common.REPO_ROOT", Path("/tmp/WebEnvoy")):
+            self.assertEqual(default_github_repo(), "MC-and-his-Agents/WebEnvoy")
         default_github_repo.cache_clear()
 
     def test_default_github_repo_honors_explicit_env_override(self) -> None:
         default_github_repo.cache_clear()
         with patch.dict("os.environ", {"SYVERT_GITHUB_REPO": "MC-and-his-Agents/WebEnvoy"}, clear=True):
             self.assertEqual(default_github_repo(), "MC-and-his-Agents/WebEnvoy")
+        default_github_repo.cache_clear()
+
+    def test_default_github_repo_maps_fork_origin_to_canonical_repo(self) -> None:
+        default_github_repo.cache_clear()
+        with patch.dict("os.environ", {}, clear=True), patch("scripts.common.REPO_ROOT", Path("/tmp/unknown-repo")), patch(
+            "scripts.common.run"
+        ) as run_mock:
+            run_mock.return_value = subprocess.CompletedProcess(
+                args=["git"],
+                returncode=0,
+                stdout="git@github.com:contributor/WebEnvoy.git\n",
+                stderr="",
+            )
+
+            self.assertEqual(default_github_repo(), "MC-and-his-Agents/WebEnvoy")
+
         default_github_repo.cache_clear()
 
     def test_build_review_packet_rejects_missing_pr_canonical_when_issue_declares_contract(self) -> None:

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -7,7 +7,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from scripts.common import REPO_ROOT, normalize_integration_ref_for_comparison
+from scripts.common import REPO_ROOT, default_github_repo, normalize_integration_ref_for_comparison
 from scripts.integration_contract import (
     CONTRACT_SOURCE_MACHINE_READABLE,
     CONTRACT_SOURCE_MODULE,
@@ -180,11 +180,8 @@ class IntegrationContractTests(unittest.TestCase):
         self.assertEqual(packet["merge_validation_errors"], [])
         self.assertTrue(packet["merge_gate_requires_recheck"])
 
-    @patch(
-        "scripts.integration_contract.fetch_integration_ref_live_state",
-        return_value={"item_id": "PVTI_same", "organization": "mc-and-his-agents", "project_number": "3", "error": ""},
-    )
-    def test_build_review_packet_collapses_equivalent_issue_and_project_item_refs(self, fetch_live_mock) -> None:
+    @patch("scripts.integration_contract.fetch_integration_ref_live_state")
+    def test_build_review_packet_treats_issue_and_project_item_refs_as_distinct_canonical_forms(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -214,10 +211,27 @@ class IntegrationContractTests(unittest.TestCase):
             issue_error="",
         )
 
-        self.assertEqual(packet["comparison_errors"], [])
-        self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
+        self.assertEqual(
+            packet["comparison_errors"],
+            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
+        )
+        self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
         self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
-        self.assertGreaterEqual(fetch_live_mock.call_count, 2)
+        fetch_live_mock.assert_not_called()
+
+    def test_default_github_repo_uses_origin_remote_when_env_missing(self) -> None:
+        default_github_repo.cache_clear()
+        with patch.dict("os.environ", {}, clear=True), patch("scripts.common.run") as run_mock:
+            run_mock.return_value = subprocess.CompletedProcess(
+                args=["git"],
+                returncode=0,
+                stdout="git@github.com:MC-and-his-Agents/WebEnvoy.git\n",
+                stderr="",
+            )
+
+            self.assertEqual(default_github_repo(), "MC-and-his-Agents/WebEnvoy")
+
+        default_github_repo.cache_clear()
 
     def test_build_review_packet_rejects_missing_pr_canonical_when_issue_declares_contract(self) -> None:
         packet = build_review_packet(
@@ -440,6 +454,64 @@ class IntegrationContractTests(unittest.TestCase):
         )
 
         self.assertTrue(any("dependency_order" in item for item in errors))
+
+    def test_validate_integration_ref_live_state_blocks_webenvoy_first_for_syvert(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+            "external_dependency": "both",
+            "merge_gate": "integration_check_required",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+            "integration_status_checked_before_pr": "yes",
+            "integration_status_checked_before_merge": "yes",
+        }
+        errors = validate_integration_ref_live_state(
+            payload,
+            {
+                "source": "project_item",
+                "status": "review",
+                "dependency_order": "webenvoy_first",
+                "joint_acceptance": "ready",
+                "owner_repo": "joint",
+                "contract_status": "reviewing",
+                "blocked": False,
+                "error": "",
+            },
+            current_repo_slug="MC-and-his-Agents/Syvert",
+        )
+
+        self.assertTrue(any("webenvoy_first" in item for item in errors))
+
+    def test_validate_integration_ref_live_state_blocks_syvert_first_for_webenvoy(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+            "external_dependency": "both",
+            "merge_gate": "integration_check_required",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+            "integration_status_checked_before_pr": "yes",
+            "integration_status_checked_before_merge": "yes",
+        }
+        errors = validate_integration_ref_live_state(
+            payload,
+            {
+                "source": "project_item",
+                "status": "review",
+                "dependency_order": "syvert_first",
+                "joint_acceptance": "ready",
+                "owner_repo": "joint",
+                "contract_status": "reviewing",
+                "blocked": False,
+                "error": "",
+            },
+            current_repo_slug="MC-and-his-Agents/WebEnvoy",
+        )
+
+        self.assertTrue(any("syvert_first" in item for item in errors))
 
     def test_fetch_integration_ref_live_state_returns_error_for_unreadable_issue(self) -> None:
         with patch("scripts.integration_contract.run") as run_mock:
@@ -707,6 +779,7 @@ class IntegrationContractTests(unittest.TestCase):
             "data": {
                 "node": {
                     "__typename": "ProjectV2Item",
+                    "isArchived": False,
                     "fieldValues": {
                         "nodes": [
                             {
@@ -724,12 +797,22 @@ class IntegrationContractTests(unittest.TestCase):
                                 "name": "ready",
                                 "field": {"name": "Joint Acceptance"},
                             },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "reviewing",
+                                "field": {"name": "Contract Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "joint",
+                                "field": {"name": "Owner Repo"},
+                            },
                         ]
                     },
                     "project": {
                         "url": "https://github.com/orgs/another-owner/projects/3",
                         "number": 3,
-                        "title": "Integration",
+                        "title": "Syvert × WebEnvoy Integration",
                         "owner": {"login": "another-owner"},
                     },
                 }

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -828,6 +828,63 @@ class IntegrationContractTests(unittest.TestCase):
         self.assertEqual(payload["source"], "project_item")
         self.assertIn("canonical integration project item", payload["error"])
 
+    def test_fetch_integration_ref_live_state_rejects_project_item_without_issue_content(self) -> None:
+        graphql_payload = {
+            "data": {
+                "node": {
+                    "__typename": "ProjectV2Item",
+                    "isArchived": False,
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "Review",
+                                "field": {"name": "Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "parallel",
+                                "field": {"name": "Dependency Order"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "ready",
+                                "field": {"name": "Joint Acceptance"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "reviewing",
+                                "field": {"name": "Contract Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "joint",
+                                "field": {"name": "Owner Repo"},
+                            },
+                        ]
+                    },
+                    "project": {
+                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/3",
+                        "number": 3,
+                        "title": "Syvert × WebEnvoy Integration",
+                        "owner": {"login": "MC-and-his-Agents"},
+                    },
+                    "content": {
+                        "__typename": "DraftIssue",
+                    },
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+
+        self.assertEqual(payload["source"], "project_item")
+        self.assertIn("必须绑定到可核查的 Issue 内容", payload["error"])
+
     def test_fetch_integration_ref_live_state_rejects_non_canonical_project_item(self) -> None:
         graphql_payload = {
             "data": {

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -1,0 +1,887 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.common import REPO_ROOT, normalize_integration_ref_for_comparison
+from scripts.integration_contract import (
+    CONTRACT_SOURCE_MACHINE_READABLE,
+    CONTRACT_SOURCE_MODULE,
+    FIELD_ORDER,
+    ISSUE_SCOPE_FIELDS,
+    PR_SCOPE_FIELDS,
+    build_review_packet,
+    fetch_integration_ref_live_state,
+    extract_issue_canonical_integration_fields,
+    field_choices,
+    markdown_section_label,
+    parse_pr_integration_check,
+    render_contract_reference_lines,
+    render_issue_form_guidance_lines,
+    render_pr_template_guidance_lines,
+    render_review_packet_lines,
+    validate_integration_ref_live_state,
+    validate_issue_canonical_payload,
+    validate_pr_merge_gate_payload,
+)
+
+
+LOCAL_ONLY_PR_BODY = "\n".join(
+    [
+        "## integration_check",
+        "",
+        "- integration_touchpoint: none",
+        "- shared_contract_changed: no",
+        "- integration_ref: none",
+        "- external_dependency: none",
+        "- merge_gate: local_only",
+        "- contract_surface: none",
+        "- joint_acceptance_needed: no",
+        "- integration_status_checked_before_pr: no",
+        "- integration_status_checked_before_merge: no",
+    ]
+)
+
+
+class IntegrationContractTests(unittest.TestCase):
+    def test_scope_fields_follow_contract_order(self) -> None:
+        self.assertEqual(ISSUE_SCOPE_FIELDS, FIELD_ORDER[: len(ISSUE_SCOPE_FIELDS)])
+        self.assertEqual(PR_SCOPE_FIELDS, FIELD_ORDER)
+
+    def test_normalize_integration_ref_for_comparison_supports_all_documented_forms(self) -> None:
+        self.assertEqual(
+            normalize_integration_ref_for_comparison("#12"),
+            "issue:mc-and-his-agents/syvert#12",
+        )
+        self.assertEqual(
+            normalize_integration_ref_for_comparison("MC-and-his-Agents/Syvert#12"),
+            "issue:mc-and-his-agents/syvert#12",
+        )
+        self.assertEqual(
+            normalize_integration_ref_for_comparison("https://github.com/MC-and-his-Agents/Syvert/issues/12"),
+            "issue:mc-and-his-agents/syvert#12",
+        )
+        self.assertEqual(
+            normalize_integration_ref_for_comparison(
+                "https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test"
+            ),
+            "project-item:mc-and-his-agents/3#PVTI_test",
+        )
+        self.assertEqual(
+            normalize_integration_ref_for_comparison(
+                "https://github.com/orgs/MC-and-his-Agents/projects/3?itemId=PVTI_test&pane=issue"
+            ),
+            "project-item:mc-and-his-agents/3#PVTI_test",
+        )
+
+    def test_extract_issue_canonical_integration_fields_uses_issue_scope_fields(self) -> None:
+        body = "\n".join(
+            [
+                "### integration_touchpoint",
+                "",
+                "active",
+                "",
+                "### shared_contract_changed",
+                "",
+                "yes",
+                "",
+                "### integration_ref",
+                "",
+                "#12",
+                "",
+                "### external_dependency",
+                "",
+                "both",
+                "",
+                "### merge_gate",
+                "",
+                "integration_check_required",
+                "",
+                "### contract_surface",
+                "",
+                "runtime_modes",
+                "",
+                "### joint_acceptance_needed",
+                "",
+                "yes",
+                "",
+                "### integration_status_checked_before_pr",
+                "",
+                "yes",
+            ]
+        )
+
+        payload = extract_issue_canonical_integration_fields(body)
+
+        self.assertEqual(tuple(payload.keys()), ISSUE_SCOPE_FIELDS)
+        self.assertNotIn("integration_status_checked_before_pr", payload)
+
+    def test_parse_pr_integration_check_uses_full_pr_scope_fields(self) -> None:
+        body = "\n".join(
+            [
+                "## integration_check",
+                "",
+                "- integration_touchpoint: active",
+                "- shared_contract_changed: no",
+                "- integration_ref: #12",
+                "- external_dependency: both",
+                "- merge_gate: integration_check_required",
+                "- contract_surface: runtime_modes",
+                "- joint_acceptance_needed: yes",
+                "- integration_status_checked_before_pr: yes",
+                "- integration_status_checked_before_merge: no",
+            ]
+        )
+
+        payload = parse_pr_integration_check(body)
+
+        self.assertEqual(tuple(payload.keys()), PR_SCOPE_FIELDS)
+
+    def test_build_review_packet_surfaces_issue_and_pr_canonical_metadata(self) -> None:
+        packet = build_review_packet(
+            "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/MC-and-his-Agents/Syvert/issues/12",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            ),
+            issue_number=105,
+            issue_canonical={
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+            issue_error="",
+        )
+
+        self.assertEqual(packet["issue_number"], 105)
+        self.assertIn("integration_ref", packet["issue_canonical"])
+        self.assertIn("integration_ref", packet["pr_canonical"])
+        self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
+        self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
+        self.assertFalse(packet["comparison_errors"])
+        self.assertEqual(packet["merge_validation_errors"], [])
+        self.assertTrue(packet["merge_gate_requires_recheck"])
+
+    @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        return_value={"item_id": "PVTI_same", "organization": "mc-and-his-agents", "project_number": "3", "error": ""},
+    )
+    def test_build_review_packet_collapses_equivalent_issue_and_project_item_refs(self, fetch_live_mock) -> None:
+        packet = build_review_packet(
+            "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            ),
+            issue_number=105,
+            issue_canonical={
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "MC-and-his-Agents/Syvert#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+            issue_error="",
+        )
+
+        self.assertEqual(packet["comparison_errors"], [])
+        self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
+        self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
+        self.assertGreaterEqual(fetch_live_mock.call_count, 2)
+
+    def test_build_review_packet_rejects_missing_pr_canonical_when_issue_declares_contract(self) -> None:
+        packet = build_review_packet(
+            "## 摘要\n\n- 变更目的：验证 reviewer packet\n",
+            issue_number=105,
+            issue_canonical={
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+            issue_error="",
+        )
+
+        rendered = "\n".join(render_review_packet_lines(packet))
+        expected_error = "PR 对应的 Issue #105 已声明 canonical integration 元数据，PR 描述缺少 canonical `integration_check` 段落。"
+
+        self.assertEqual(packet["pr_canonical"], {})
+        self.assertEqual(packet["comparison_errors"], [expected_error])
+        self.assertEqual(packet["merge_validation_errors"], [expected_error])
+        self.assertIn(expected_error, rendered)
+        self.assertNotIn("canonical_mismatches: none", rendered)
+        self.assertNotIn("merge_gate_validation: ok", rendered)
+
+    def test_build_review_packet_propagates_issue_lookup_error_into_reviewer_packet(self) -> None:
+        packet = build_review_packet(
+            LOCAL_ONLY_PR_BODY,
+            issue_number=105,
+            issue_canonical={},
+            issue_error="无法读取 Issue #105 的 canonical integration 元数据，拒绝继续。",
+        )
+
+        rendered = "\n".join(render_review_packet_lines(packet))
+        expected_error = "无法读取 Issue #105 的 canonical integration 元数据，拒绝继续。"
+
+        self.assertEqual(packet["comparison_errors"], [expected_error])
+        self.assertEqual(packet["merge_validation_errors"], [expected_error])
+        self.assertIn(expected_error, rendered)
+        self.assertNotIn("canonical_mismatches: none", rendered)
+        self.assertNotIn("merge_gate_validation: ok", rendered)
+
+    def test_build_review_packet_includes_integration_ref_live_snapshot_when_provided(self) -> None:
+        packet = build_review_packet(
+            "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            ),
+            issue_number=105,
+            issue_canonical={},
+            issue_error="",
+            integration_ref_live={
+                "source": "project_item",
+                "status": "review",
+                "dependency_order": "parallel",
+                "joint_acceptance": "ready",
+                "owner_repo": "joint",
+                "contract_status": "reviewing",
+                "url": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                "error": "",
+            },
+        )
+
+        rendered = "\n".join(render_review_packet_lines(packet))
+        self.assertEqual(packet["integration_ref_live"]["source"], "project_item")
+        self.assertEqual(packet["integration_ref_live_errors"], [])
+        self.assertIn("integration_ref_live:", rendered)
+        self.assertIn("joint_acceptance: ready", rendered)
+
+    def test_validate_integration_ref_live_state_blocks_blocked_status(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+            "external_dependency": "both",
+            "merge_gate": "integration_check_required",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+            "integration_status_checked_before_pr": "yes",
+            "integration_status_checked_before_merge": "yes",
+        }
+        errors = validate_integration_ref_live_state(
+            payload,
+            {
+                "source": "project_item",
+                "status": "blocked",
+                "dependency_order": "parallel",
+                "joint_acceptance": "ready",
+                "owner_repo": "joint",
+                "contract_status": "reviewing",
+                "blocked": True,
+                "error": "",
+            },
+            current_repo_slug="MC-and-his-Agents/Syvert",
+        )
+
+        self.assertTrue(any("blocked" in item for item in errors))
+
+    def test_validate_integration_ref_live_state_blocks_unready_joint_acceptance(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+            "external_dependency": "both",
+            "merge_gate": "integration_check_required",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+            "integration_status_checked_before_pr": "yes",
+            "integration_status_checked_before_merge": "yes",
+        }
+        errors = validate_integration_ref_live_state(
+            payload,
+            {
+                "source": "project_item",
+                "status": "review",
+                "dependency_order": "parallel",
+                "joint_acceptance": "pending",
+                "owner_repo": "joint",
+                "contract_status": "reviewing",
+                "blocked": False,
+                "error": "",
+            },
+            current_repo_slug="MC-and-his-Agents/Syvert",
+        )
+
+        self.assertTrue(any("联合验收状态未就绪" in item for item in errors))
+
+    def test_validate_integration_ref_live_state_rejects_in_progress_status(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+            "external_dependency": "both",
+            "merge_gate": "integration_check_required",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+            "integration_status_checked_before_pr": "yes",
+            "integration_status_checked_before_merge": "yes",
+        }
+        errors = validate_integration_ref_live_state(
+            payload,
+            {
+                "source": "project_item",
+                "status": "in_progress",
+                "dependency_order": "parallel",
+                "joint_acceptance": "ready",
+                "owner_repo": "joint",
+                "contract_status": "reviewing",
+                "blocked": False,
+                "error": "",
+            },
+            current_repo_slug="MC-and-his-Agents/Syvert",
+        )
+
+        self.assertTrue(any("未进入允许合并的状态集合" in item for item in errors))
+
+    def test_validate_integration_ref_live_state_fail_closed_when_status_missing(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+            "external_dependency": "both",
+            "merge_gate": "integration_check_required",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+            "integration_status_checked_before_pr": "yes",
+            "integration_status_checked_before_merge": "yes",
+        }
+        errors = validate_integration_ref_live_state(
+            payload,
+            {
+                "source": "project_item",
+                "status": "",
+                "dependency_order": "parallel",
+                "joint_acceptance": "ready",
+                "blocked": False,
+                "error": "",
+            },
+            current_repo_slug="MC-and-his-Agents/Syvert",
+        )
+
+        self.assertTrue(any("status" in item for item in errors))
+
+    def test_validate_integration_ref_live_state_fail_closed_when_dependency_missing(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+            "external_dependency": "both",
+            "merge_gate": "integration_check_required",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+            "integration_status_checked_before_pr": "yes",
+            "integration_status_checked_before_merge": "yes",
+        }
+        errors = validate_integration_ref_live_state(
+            payload,
+            {
+                "source": "project_item",
+                "status": "review",
+                "dependency_order": "",
+                "joint_acceptance": "ready",
+                "blocked": False,
+                "error": "",
+            },
+            current_repo_slug="MC-and-his-Agents/Syvert",
+        )
+
+        self.assertTrue(any("dependency_order" in item for item in errors))
+
+    def test_fetch_integration_ref_live_state_returns_error_for_unreadable_issue(self) -> None:
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 1
+            run_mock.return_value.stdout = ""
+            run_mock.return_value.stderr = "not found"
+
+            payload = fetch_integration_ref_live_state("MC-and-his-Agents/Syvert#105")
+
+        self.assertEqual(payload["source"], "issue")
+        self.assertIn("无法读取", payload["error"])
+
+    def test_fetch_integration_ref_live_state_reads_issue_ref_from_integration_project_item(self) -> None:
+        graphql_payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 105,
+                        "title": "integration baseline",
+                        "url": "https://github.com/MC-and-his-Agents/Syvert/issues/105",
+                        "state": "OPEN",
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "__typename": "ProjectV2Item",
+                                    "id": "PVTI_ready",
+                                    "isArchived": False,
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "In Progress",
+                                                "field": {"name": "Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "parallel",
+                                                "field": {"name": "Dependency Order"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "ready",
+                                                "field": {"name": "Joint Acceptance"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "reviewing",
+                                                "field": {"name": "Contract Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "joint",
+                                                "field": {"name": "Owner Repo"},
+                                            },
+                                        ]
+                                    },
+                                    "project": {
+                                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/3",
+                                        "number": 3,
+                                        "title": "Syvert × WebEnvoy Integration",
+                                        "owner": {"login": "MC-and-his-Agents"},
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        },
+                    }
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("MC-and-his-Agents/Syvert#105")
+
+        self.assertEqual(payload["source"], "issue")
+        self.assertEqual(payload["status"], "in_progress")
+        self.assertEqual(payload["dependency_order"], "parallel")
+        self.assertEqual(payload["joint_acceptance"], "ready")
+        self.assertEqual(payload["project_url"], "https://github.com/orgs/MC-and-his-Agents/projects/3")
+        self.assertEqual(payload["title"], "integration baseline")
+
+    def test_fetch_integration_ref_live_state_rejects_issue_without_integration_project_item(self) -> None:
+        graphql_payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 105,
+                        "title": "integration baseline",
+                        "url": "https://github.com/MC-and-his-Agents/Syvert/issues/105",
+                        "state": "OPEN",
+                        "projectItems": {"nodes": [], "pageInfo": {"hasNextPage": False, "endCursor": None}},
+                    }
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("MC-and-his-Agents/Syvert#105")
+
+        self.assertEqual(payload["source"], "issue")
+        self.assertIn("未挂接可核查的 integration project item", payload["error"])
+
+    def test_fetch_integration_ref_live_state_ignores_non_canonical_project_items(self) -> None:
+        graphql_payload = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 105,
+                        "title": "integration baseline",
+                        "url": "https://github.com/MC-and-his-Agents/Syvert/issues/105",
+                        "state": "OPEN",
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "__typename": "ProjectV2Item",
+                                    "id": "PVTI_wrong",
+                                    "isArchived": False,
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "In Progress",
+                                                "field": {"name": "Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "parallel",
+                                                "field": {"name": "Dependency Order"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "ready",
+                                                "field": {"name": "Joint Acceptance"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "reviewing",
+                                                "field": {"name": "Contract Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "joint",
+                                                "field": {"name": "Owner Repo"},
+                                            },
+                                        ]
+                                    },
+                                    "project": {
+                                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/99",
+                                        "number": 99,
+                                        "title": "Some Other Project",
+                                        "owner": {"login": "MC-and-his-Agents"},
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        },
+                    }
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("MC-and-his-Agents/Syvert#105")
+
+        self.assertEqual(payload["source"], "issue")
+        self.assertIn("未挂接可核查的 integration project item", payload["error"])
+
+    def test_fetch_integration_ref_live_state_paginates_issue_project_items(self) -> None:
+        first_page = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 105,
+                        "title": "integration baseline",
+                        "url": "https://github.com/MC-and-his-Agents/Syvert/issues/105",
+                        "state": "OPEN",
+                        "projectItems": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "cursor-2"},
+                        },
+                    }
+                }
+            }
+        }
+        second_page = {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "number": 105,
+                        "title": "integration baseline",
+                        "url": "https://github.com/MC-and-his-Agents/Syvert/issues/105",
+                        "state": "OPEN",
+                        "projectItems": {
+                            "nodes": [
+                                {
+                                    "__typename": "ProjectV2Item",
+                                    "id": "PVTI_ready",
+                                    "isArchived": False,
+                                    "fieldValues": {
+                                        "nodes": [
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "In Progress",
+                                                "field": {"name": "Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "parallel",
+                                                "field": {"name": "Dependency Order"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "ready",
+                                                "field": {"name": "Joint Acceptance"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "reviewing",
+                                                "field": {"name": "Contract Status"},
+                                            },
+                                            {
+                                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                                "name": "joint",
+                                                "field": {"name": "Owner Repo"},
+                                            },
+                                        ]
+                                    },
+                                    "project": {
+                                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/3",
+                                        "number": 3,
+                                        "title": "Syvert × WebEnvoy Integration",
+                                        "owner": {"login": "MC-and-his-Agents"},
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        },
+                    }
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.side_effect = [
+                subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=json.dumps(first_page), stderr=""),
+                subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=json.dumps(second_page), stderr=""),
+            ]
+
+            payload = fetch_integration_ref_live_state("MC-and-his-Agents/Syvert#105")
+
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(payload["source"], "issue")
+        self.assertEqual(payload["joint_acceptance"], "ready")
+
+    def test_fetch_integration_ref_live_state_rejects_project_item_owner_mismatch(self) -> None:
+        graphql_payload = {
+            "data": {
+                "node": {
+                    "__typename": "ProjectV2Item",
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "In Progress",
+                                "field": {"name": "Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "parallel",
+                                "field": {"name": "Dependency Order"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "ready",
+                                "field": {"name": "Joint Acceptance"},
+                            },
+                        ]
+                    },
+                    "project": {
+                        "url": "https://github.com/orgs/another-owner/projects/3",
+                        "number": 3,
+                        "title": "Integration",
+                        "owner": {"login": "another-owner"},
+                    },
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+
+        self.assertEqual(payload["source"], "project_item")
+        self.assertIn("canonical integration project item", payload["error"])
+
+    def test_fetch_integration_ref_live_state_rejects_non_canonical_project_item(self) -> None:
+        graphql_payload = {
+            "data": {
+                "node": {
+                    "__typename": "ProjectV2Item",
+                    "isArchived": False,
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "In Progress",
+                                "field": {"name": "Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "parallel",
+                                "field": {"name": "Dependency Order"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "ready",
+                                "field": {"name": "Joint Acceptance"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "reviewing",
+                                "field": {"name": "Contract Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "joint",
+                                "field": {"name": "Owner Repo"},
+                            },
+                        ]
+                    },
+                    "project": {
+                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/3",
+                        "number": 3,
+                        "title": "Some Other Project",
+                        "owner": {"login": "MC-and-his-Agents"},
+                    },
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+
+        self.assertEqual(payload["source"], "project_item")
+        self.assertIn("canonical integration project item", payload["error"])
+
+    def test_fetch_integration_ref_live_state_rejects_project_item_missing_required_canonical_fields(self) -> None:
+        graphql_payload = {
+            "data": {
+                "node": {
+                    "__typename": "ProjectV2Item",
+                    "isArchived": False,
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "In Progress",
+                                "field": {"name": "Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "parallel",
+                                "field": {"name": "Dependency Order"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "ready",
+                                "field": {"name": "Joint Acceptance"},
+                            },
+                        ]
+                    },
+                    "project": {
+                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/3",
+                        "number": 3,
+                        "title": "Syvert × WebEnvoy Integration",
+                        "owner": {"login": "MC-and-his-Agents"},
+                    },
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+
+        self.assertEqual(payload["source"], "project_item")
+        self.assertIn("canonical integration project item", payload["error"])
+
+    def test_validate_pr_merge_gate_payload_keeps_legacy_compatibility_decision_outside_payload_validation(self) -> None:
+        payload = {
+            "integration_touchpoint": "none",
+            "shared_contract_changed": "no",
+            "integration_ref": "none",
+            "external_dependency": "none",
+            "merge_gate": "local_only",
+            "contract_surface": "none",
+            "joint_acceptance_needed": "no",
+            "integration_status_checked_before_pr": "no",
+            "integration_status_checked_before_merge": "no",
+        }
+
+        errors = validate_pr_merge_gate_payload(
+            payload,
+            issue_number=None,
+            issue_canonical={},
+            require_merge_time_recheck=True,
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_validate_issue_canonical_payload_enforces_contract_combinations(self) -> None:
+        payload = {
+            "integration_touchpoint": "active",
+            "shared_contract_changed": "no",
+            "integration_ref": "none",
+            "external_dependency": "both",
+            "merge_gate": "local_only",
+            "contract_surface": "runtime_modes",
+            "joint_acceptance_needed": "yes",
+        }
+
+        errors = validate_issue_canonical_payload(payload)
+
+        self.assertTrue(errors)
+        self.assertTrue(
+            any("Issue canonical integration 元数据与 contract 组合约束冲突" in item for item in errors)
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- PR Class: `governance`
- 变更目的：从 `#107` 中拆出 `PR-A Contract Kernel`，先把仓库内唯一的 canonical integration contract 与 `#105` 的最小 bootstrap contract 落到 `main`。
- 主要改动：
  - 新增 `scripts/policy/integration_contract.json` 与 `scripts/integration_contract.py`
  - 在 `scripts/common.py` 中补齐 integration ref 归一、repo 身份解析与 checkable 判断的最小辅助逻辑
  - 新增 `tests.governance.test_integration_contract`
  - 新增 `ADR-GOV-0105` 与 `GOV-0105 exec-plan`，让后续替代 PR 能在同一事项上下文下通过受控入口

## Issue 摘要

- 当前事项要解决的是 `Syvert × WebEnvoy` 的跨仓治理联动插槽。
- 本 PR 只负责 contract kernel，不负责 consumer wiring、carrier alignment、platform evidence。
- 后续替代链路：PR-B（consumer wiring）/ PR-C（carrier alignment）/ PR-D（evidence / rollout）。

## 关联事项

- Issue: #105
- item_key: `GOV-0105-integration-governance-baseline`
- item_type: `GOV`
- release: `governance-baseline`
- sprint: `integration-governance`
- Closing: Refs #105

## 风险

- 风险级别：`high`
- 审查关注：
  - 当前 diff 是否只包含 contract kernel 与最小 bootstrap contract
  - `integration_ref` 归一、语义等价比较、legacy 兼容与 live-state fail-closed 是否已收口到单一模块
  - 测试面是否只锁 kernel，而没有提前耦合 consumer / carrier / evidence

## 验证

- 已执行：
  - 当前受审 head：`d60811d788b3f4ca450d122a2b5e3986a6111fd1`
  - `python3 -m unittest tests.governance.test_integration_contract`
  - `python3 scripts/workflow_guard.py --mode pre-commit`
  - `python3 scripts/governance_gate.py --mode ci --base-sha origin/main --head-sha HEAD --head-ref issue-105-integration-governance-baseline-contract-kernel`
- 未执行：
  - guardian 最终通过后的受控合并

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次 contract kernel 与 bootstrap contract 增量。