### PR TITLE
GOV-0105 PR-B: wire consumers to canonical integration contract

### DIFF
--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -15,6 +15,7 @@
 ## 目标
 
 - 把 `open_pr / pr_guardian / merge_pr / governance_status` 全部接到仓库内唯一的 canonical integration contract 上，让 issue / PR / reviewer / guardian / merge gate 真正消费同一份真相源。
+- reviewer packet 在本批只消费 canonical issue/PR contract 对比与本地工件；`integration_ref` 的 live-state 证据改由 `governance_status` 状态面展示，并继续只在 merge gate 阶段作为阻断条件强制执行。
 - 保持 `Syvert` 继续作为本地执行真相源，并为后续 PR-C / PR-D 的 carrier alignment 与 evidence 收口提供稳定的运行时治理链路。
 
 ## 范围
@@ -29,7 +30,7 @@
 
 - `#107` 保持 Draft 并冻结，不再继续修 findings 或提交 guardian；它只作为拆分母体和审查历史容器保留。
 - `PR-A Contract Kernel` 已合并到 `main`，当前仓库内 canonical integration contract 已成为后续替代 PR 的 bootstrap truth source。
-- 当前真正需要收口的是 `PR-B Consumer Wiring`，即让 `open_pr / pr_guardian / merge_pr / governance_status` 只消费 shared contract，并把 reviewer packet、merge-time recheck、guardian cache 身份模型与 issue-side canonical integration 证据统一到同一链路。
+- 当前真正需要收口的是 `PR-B Consumer Wiring`，即让 `open_pr / pr_guardian / merge_pr / governance_status` 只消费 shared contract，并把 reviewer packet、status 面、merge-time recheck、guardian cache 身份模型与 issue-side canonical integration 证据统一到同一链路。
 - 当前 PR-B 已以 Draft PR `#115` 打开；本地门禁与 GitHub checks 已通过，当前停点转为 reviewer / guardian 对 `#115` latest head 的收口。
 
 ## 下一步动作
@@ -59,6 +60,7 @@
 - `main` 在替代链路推进期间继续前进；每一批 PR 在进入 guardian 和 merge 前都必须基于最新 `origin/main` 重跑本地门禁。
 - 由于当前 issue 已声明 canonical integration 字段，后续所有替代 PR 都必须完整对齐 contract，不允许退回 legacy 路径。
 - 当前 PR-B 仍处于 PR-C 之前的阶段，因此 PR 模板尚未成为唯一 carrier；在 PR-C 合并前，`open_pr` 需要继续保证缺失模板 section 时也能生成 canonical `integration_check` 区块。
+- reviewer 阶段不能把外部 integration project 的 live-state 漂移升级为审查阻断；相关 live-state 只允许出现在 `governance_status` 诊断面与 merge gate 入口。
 
 ## 回滚方式
 
@@ -66,5 +68,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 最近一次完成 PR-B consumer wiring 代码收口的 checkpoint：`e426116e0c25386cb1456f49eec938b14792342c`
+- 最近一次完成 PR-B consumer wiring 代码收口的 checkpoint：`93d0fd6d7fab16a492548294422236b1fb08b4d9`
 - 当前 PR 审查态以 `#115` 的 latest head 为准；若后续只补充 review / guardian 元数据，不另起新的代码 checkpoint。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -68,5 +68,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 最近一次完成 PR-B consumer wiring 代码收口的 checkpoint：`93d0fd6d7fab16a492548294422236b1fb08b4d9`
-- 当前 PR 审查态以 `#115` 的 latest head 为准；若后续只补充 review / guardian 元数据，不另起新的代码 checkpoint。
+- 最近一次完成 PR-B consumer wiring 代码收口并同步验证证据的 checkpoint：`3165cb69ae5eacae33e59d2833c7e0f671b92008`
+- 当前 PR 审查态以 `#115` 的 latest head 为准；本轮最小验证集与 guardian 必须绑定同一 latest head，不得继续复用旧 checkpoint 的验证摘要。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -9,18 +9,18 @@
 - sprint：`integration-governance`
 - 关联 spec：无（治理联动事项）
 - 关联 decision：`docs/decisions/ADR-GOV-0105-integration-governance-baseline.md`
-- 关联 PR：`#114`
+- 关联 PR：`#115`
 - active 收口事项：`GOV-0105-integration-governance-baseline`
 
 ## 目标
 
-- 先把仓库内唯一的 canonical integration contract 落到 `main`，为后续消费者接线、载体对齐和 evidence 收口建立稳定真相源。
-- 保持 `Syvert` 继续作为本地执行真相源，同时为后续 `Syvert × WebEnvoy` integration 协同提供可执行的 contract 基线。
+- 把 `open_pr / pr_guardian / merge_pr / governance_status` 全部接到仓库内唯一的 canonical integration contract 上，让 issue / PR / reviewer / guardian / merge gate 真正消费同一份真相源。
+- 保持 `Syvert` 继续作为本地执行真相源，并为后续 PR-C / PR-D 的 carrier alignment 与 evidence 收口提供稳定的运行时治理链路。
 
 ## 范围
 
-- 当前 PR-A 只纳入：`scripts/policy/integration_contract.json`、`scripts/integration_contract.py`、`scripts/common.py` 中与 integration contract 直接相关的最小辅助逻辑、`tests/governance/test_integration_contract.py`，以及当前 bootstrap contract 文档。
-- 后续 PR-B 再纳入：`open_pr / pr_guardian / merge_pr / governance_status` 的共享消费链路。
+- 已合并的 PR-A 只纳入：`scripts/policy/integration_contract.json`、`scripts/integration_contract.py`、`scripts/common.py` 中与 integration contract 直接相关的最小辅助逻辑、`tests/governance/test_integration_contract.py`，以及当前 bootstrap contract 文档。
+- 当前 PR-B 纳入：`open_pr / pr_guardian / merge_pr / governance_status` 的共享消费链路、对应治理测试，以及保证该链路在独立 worktree 上可执行的最小兼容修正。
 - 后续 PR-C 再纳入：`WORKFLOW.md`、`code_review.md`、PR template、issue forms 的 carrier alignment。
 - 后续 PR-D 再纳入：ADR / exec-plan 的最终叙事收口与 platform evidence。
 - 本次不纳入：自动 bot / 自动同步系统、新的产品仓库、跨仓实现代码、对现有 `Phase / FR / sprint` 语义做统一改造。
@@ -28,41 +28,43 @@
 ## 当前停点
 
 - `#107` 保持 Draft 并冻结，不再继续修 findings 或提交 guardian；它只作为拆分母体和审查历史容器保留。
-- 当前真正需要先落地的是 `PR-A Contract Kernel`，否则 `#105` 在 `main` 上没有 active bootstrap contract，后续替代 PR 无法通过受控入口。
-- 当前 PR-A 已以 Draft PR `#114` 打开，当前受审目标是其 latest head。
-- contract kernel 本地门禁已通过；当前停点转为 reviewer / guardian 收口，并保持 scope 只限于 kernel 与最小 bootstrap contract。
+- `PR-A Contract Kernel` 已合并到 `main`，当前仓库内 canonical integration contract 已成为后续替代 PR 的 bootstrap truth source。
+- 当前真正需要收口的是 `PR-B Consumer Wiring`，即让 `open_pr / pr_guardian / merge_pr / governance_status` 只消费 shared contract，并把 reviewer packet、merge-time recheck、guardian cache 身份模型与 issue-side canonical integration 证据统一到同一链路。
+- 当前 PR-B 已以 Draft PR `#115` 打开；本地门禁与 GitHub checks 已通过，当前停点转为 reviewer / guardian 对 `#115` latest head 的收口。
 
 ## 下一步动作
 
-- 在同一 head 上等待 reviewer、GitHub checks 与 guardian 收口，再执行受控合并。
-- PR-A 合并后，再按同一 `Issue #105` 串行推进 PR-B、PR-C、PR-D。
+- 在同一 head 上等待 reviewer 与 guardian 收口，再执行 `#115` 的受控合并。
+- `#115` 合并后，再按同一 `Issue #105` 串行推进 PR-C、PR-D。
 
 ## 当前 checkpoint 推进的 release 目标
 
-- 为当前治理基线先建立可审查、可恢复、可复用的 canonical integration contract 内核，使后续联动规则有唯一真相源可依赖。
+- 让 canonical integration contract 从“内核已存在”推进到“所有核心消费者已接线”，使 reviewer / guardian / merge gate 的运行时决策不再各自维护第二套 integration 语义。
 
 ## 当前事项在 sprint 中的角色 / 阻塞
 
-- 角色：替代链路的第一批 `PR-A Contract Kernel`。
-- 阻塞：在 PR-A 合并前，`main` 上不存在 `#105` 的 active bootstrap contract，后续替代 PR 无法通过 `open_pr` 的事项上下文校验。
+- 角色：替代链路的第二批 `PR-B Consumer Wiring`。
+- 阻塞：在 PR-B 合并前，`open_pr / pr_guardian / merge_pr / governance_status` 仍未完全共享同一份 canonical integration contract；PR-C / PR-D 的 carrier 和 evidence 收口缺少稳定的运行时治理链路可依赖。
 
 ## 已验证项
 
 - 已执行：`python3 -m unittest tests.governance.test_integration_contract`
+- 已执行：`python3 -m unittest tests.governance.test_open_pr tests.governance.test_pr_guardian tests.governance.test_governance_status`
 - 已执行：`python3 scripts/workflow_guard.py --mode pre-commit`
-- 已执行：`python3 scripts/governance_gate.py --mode ci --base-sha origin/main --head-sha HEAD --head-ref issue-105-integration-governance-baseline-contract-kernel`
+- 已执行：`python3 scripts/governance_gate.py --mode ci --base-sha origin/main --head-sha HEAD --head-ref issue-105-integration-governance-baseline-consumer-wiring`
 
 ## 未决风险
 
-- 若 PR-A 继续夹带消费者、carrier 或 evidence 叙事，scope 会再次膨胀，guardian finding 也会重新跨层连锁。
+- 若 PR-B 继续夹带 carrier alignment 或 evidence 叙事，scope 会再次膨胀，guardian finding 也会重新跨层连锁。
 - `main` 在替代链路推进期间继续前进；每一批 PR 在进入 guardian 和 merge 前都必须基于最新 `origin/main` 重跑本地门禁。
 - 由于当前 issue 已声明 canonical integration 字段，后续所有替代 PR 都必须完整对齐 contract，不允许退回 legacy 路径。
+- 当前 PR-B 仍处于 PR-C 之前的阶段，因此 PR 模板尚未成为唯一 carrier；在 PR-C 合并前，`open_pr` 需要继续保证缺失模板 section 时也能生成 canonical `integration_check` 区块。
 
 ## 回滚方式
 
-- 如需回滚，使用独立 revert PR 撤销 contract kernel 与当前 bootstrap contract 文档，让 `#105` 回到未建立 repo 内真相源的状态。
+- 如需回滚，使用独立 revert PR 撤销 consumer wiring 接线与对应最小兼容修正，让 `#105` 回退到“只有 contract kernel、尚未完成消费者统一接线”的状态。
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 最近一次完成 contract kernel 代码收口的 checkpoint：`eadb3b814af668814566efe96a6247f215b7a87a`
-- 当前 PR 审查态以 `#114` 的 latest head 为准；若后续只补充 review / guardian 元数据，不另起新的代码 checkpoint。
+- 最近一次完成 PR-B consumer wiring 代码收口的 checkpoint：`e426116e0c25386cb1456f49eec938b14792342c`
+- 当前 PR 审查态以 `#115` 的 latest head 为准；若后续只补充 review / guardian 元数据，不另起新的代码 checkpoint。

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -205,9 +205,24 @@ def default_github_repo() -> str:
     configured = os.environ.get("SYVERT_GITHUB_REPO", "").strip()
     if configured and re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", configured):
         return configured
-    repo_name = REPO_ROOT.name.strip().casefold()
-    if repo_name in REPO_CANONICAL_GITHUB_REPOS:
-        return REPO_CANONICAL_GITHUB_REPOS[repo_name]
+    repo_names = [REPO_ROOT.name.strip().casefold()]
+    git_entry = REPO_ROOT / ".git"
+    if git_entry.is_file():
+        try:
+            gitdir_line = git_entry.read_text(encoding="utf-8").strip()
+        except OSError:
+            gitdir_line = ""
+        if gitdir_line.lower().startswith("gitdir:"):
+            gitdir_path = Path(gitdir_line.split(":", 1)[1].strip())
+            if not gitdir_path.is_absolute():
+                gitdir_path = (REPO_ROOT / gitdir_path).resolve()
+            for parent in gitdir_path.parents:
+                if parent.name == ".git":
+                    repo_names.append(parent.parent.name.strip().casefold())
+                    break
+    for repo_name in repo_names:
+        if repo_name in REPO_CANONICAL_GITHUB_REPOS:
+            return REPO_CANONICAL_GITHUB_REPOS[repo_name]
     completed = run(["git", "remote", "get-url", "origin"], cwd=REPO_ROOT, check=False)
     if completed.returncode == 0:
         parsed = parse_github_repo_from_remote_url(completed.stdout.strip())

--- a/scripts/governance_status.py
+++ b/scripts/governance_status.py
@@ -10,12 +10,13 @@ if __package__ in {None, ""}:
 import argparse
 import json
 
-from scripts.common import REPO_ROOT, integration_ref_is_checkable, legacy_state_file, load_json, run, syvert_state_file
+from scripts.common import REPO_ROOT, default_github_repo, integration_ref_is_checkable, legacy_state_file, load_json, run, syvert_state_file
 from scripts.integration_contract import (
     build_review_packet,
     fetch_integration_ref_live_state,
     parse_pr_integration_check,
     validate_issue_fetch,
+    validate_integration_ref_live_state,
 )
 from scripts.item_context import (
     active_exec_plans_for_issue,
@@ -205,6 +206,12 @@ def build_integration_status_for_pr(meta: dict) -> dict[str, object]:
         issue_error=issue_error,
         integration_ref_live=integration_ref_live,
     )
+    live_errors = validate_integration_ref_live_state(
+        pr_canonical,
+        integration_ref_live,
+        current_repo_slug=default_github_repo(),
+    )
+    packet["integration_ref_live_errors"] = live_errors
     packet["issue_lookup_error"] = issue_error
     return packet
 
@@ -222,6 +229,18 @@ def build_integration_status_for_issue(issue_number: int) -> dict[str, object]:
         issue_error=issue_error,
         integration_ref_live=integration_ref_live,
     )
+    live_errors = validate_integration_ref_live_state(
+        issue_canonical,
+        integration_ref_live,
+        current_repo_slug=default_github_repo(),
+    )
+    packet["pr_canonical"] = {}
+    packet["normalized_pr_canonical"] = {}
+    packet["comparison_errors"] = []
+    packet["merge_validation_errors"] = []
+    packet["integration_ref_live_errors"] = live_errors
+    packet["merge_gate"] = str(issue_canonical.get("merge_gate") or "").strip().lower()
+    packet["merge_gate_requires_recheck"] = packet["merge_gate"] == "integration_check_required"
     packet["issue_lookup_error"] = issue_error
     return packet
 

--- a/scripts/governance_status.py
+++ b/scripts/governance_status.py
@@ -145,7 +145,12 @@ def build_status_payload(issue_number: int | None = None, pr_number: int | None 
     if pr_number is not None:
         meta = fetch_pr_meta(pr_number)
         head_sha = meta.get("headRefOid", "")
-        payload["guardian"] = find_latest_guardian_result(pr_number, head_sha, path=GUARDIAN_STATE_FILE) or {}
+        payload["guardian"] = find_latest_guardian_result(
+            pr_number,
+            head_sha,
+            body=str(meta.get("body") or ""),
+            path=GUARDIAN_STATE_FILE,
+        ) or {}
         payload["review_poller"] = review_poller_state.get("prs", {}).get(str(pr_number), {})
         payload["checks"] = fetch_checks_summary(pr_number)
         branch_name = meta.get("headRefName", "")

--- a/scripts/governance_status.py
+++ b/scripts/governance_status.py
@@ -206,8 +206,9 @@ def build_integration_status_for_pr(meta: dict) -> dict[str, object]:
         issue_error=issue_error,
         integration_ref_live=integration_ref_live,
     )
+    live_validation_payload = pr_canonical or issue_canonical
     live_errors = validate_integration_ref_live_state(
-        pr_canonical,
+        live_validation_payload,
         integration_ref_live,
         current_repo_slug=default_github_repo(),
     )

--- a/scripts/governance_status.py
+++ b/scripts/governance_status.py
@@ -10,7 +10,13 @@ if __package__ in {None, ""}:
 import argparse
 import json
 
-from scripts.common import REPO_ROOT, legacy_state_file, load_json, run, syvert_state_file
+from scripts.common import REPO_ROOT, integration_ref_is_checkable, legacy_state_file, load_json, run, syvert_state_file
+from scripts.integration_contract import (
+    build_review_packet,
+    fetch_integration_ref_live_state,
+    parse_pr_integration_check,
+    validate_issue_fetch,
+)
 from scripts.item_context import (
     active_exec_plans_for_issue,
     load_item_context_from_exec_plan,
@@ -140,6 +146,7 @@ def build_status_payload(issue_number: int | None = None, pr_number: int | None 
         "worktrees": [],
         "checks": [],
         "item_context": {},
+        "integration": {},
     }
 
     if pr_number is not None:
@@ -158,6 +165,7 @@ def build_status_payload(issue_number: int | None = None, pr_number: int | None 
         matched_worktree: dict | None = matching_worktrees[0] if len(matching_worktrees) == 1 else None
         payload["worktrees"] = matching_worktrees[:1] if len(matching_worktrees) == 1 else matching_worktrees
         payload["item_context"] = build_item_context_for_pr(meta, matched_worktree)
+        payload["integration"] = build_integration_status_for_pr(meta)
         return payload
 
     if issue_number is not None:
@@ -169,6 +177,34 @@ def build_status_payload(issue_number: int | None = None, pr_number: int | None 
     payload["review_poller"] = review_poller_state.get("prs", {})
     payload["worktrees"] = list(worktree_state.get("worktrees", {}).values())
     return payload
+
+
+def build_integration_status_for_pr(meta: dict) -> dict[str, object]:
+    body = str(meta.get("body") or "")
+    body_context = parse_item_context_from_body(body)
+    issue_number: int | None = None
+    try:
+        issue_text = str(body_context.get("issue") or "").strip()
+        issue_number = int(issue_text) if issue_text else None
+    except ValueError:
+        issue_number = None
+    issue_resolution = validate_issue_fetch(issue_number, allow_missing_payload=True) if issue_number is not None else None
+    issue_canonical = dict(issue_resolution.canonical) if issue_resolution else {}
+    issue_error = str(issue_resolution.error or "") if issue_resolution else ""
+    pr_canonical = parse_pr_integration_check(body)
+    integration_ref = str(pr_canonical.get("integration_ref") or "").strip()
+    if not integration_ref:
+        integration_ref = str(issue_canonical.get("integration_ref") or "").strip()
+    integration_ref_live = fetch_integration_ref_live_state(integration_ref) if integration_ref_is_checkable(integration_ref) else {}
+    packet = build_review_packet(
+        body,
+        issue_number=issue_number,
+        issue_canonical=issue_canonical,
+        issue_error=issue_error,
+        integration_ref_live=integration_ref_live,
+    )
+    packet["issue_lookup_error"] = issue_error
+    return packet
 
 
 def render_text(payload: dict) -> str:
@@ -229,6 +265,23 @@ def render_text(payload: dict) -> str:
         lines.append(f"count={len(checks)}")
         for item in checks:
             lines.append(f"- {item.get('name')} {item.get('bucket')} {item.get('state')}")
+
+    integration = payload.get("integration") or {}
+    lines.append("[integration]")
+    if not integration:
+        lines.append("empty=true")
+    else:
+        lines.append(f"issue_number={integration.get('issue_number', '')}")
+        lines.append(f"merge_gate={integration.get('merge_gate', '')}")
+        lines.append(f"merge_gate_requires_recheck={integration.get('merge_gate_requires_recheck', '')}")
+        pr_canonical = integration.get("pr_canonical") or {}
+        issue_canonical = integration.get("issue_canonical") or {}
+        lines.append(f"pr_integration_ref={pr_canonical.get('integration_ref', '')}")
+        lines.append(f"issue_integration_ref={issue_canonical.get('integration_ref', '')}")
+        live = integration.get("integration_ref_live") or {}
+        lines.append(f"live_source={live.get('source', '')}")
+        lines.append(f"live_status={live.get('status', '')}")
+        lines.append(f"live_dependency_order={live.get('dependency_order', '')}")
 
     return "\n".join(lines) + "\n"
 

--- a/scripts/governance_status.py
+++ b/scripts/governance_status.py
@@ -156,6 +156,7 @@ def build_status_payload(issue_number: int | None = None, pr_number: int | None 
             pr_number,
             head_sha,
             body=str(meta.get("body") or ""),
+            require_body_bound=True,
             path=GUARDIAN_STATE_FILE,
         ) or {}
         payload["review_poller"] = review_poller_state.get("prs", {}).get(str(pr_number), {})
@@ -171,6 +172,7 @@ def build_status_payload(issue_number: int | None = None, pr_number: int | None 
     if issue_number is not None:
         payload["worktrees"] = filter_worktrees_by_issue(worktree_state, issue_number)
         payload["item_context"] = matching_exec_plan_for_issue(REPO_ROOT, issue_number)
+        payload["integration"] = build_integration_status_for_issue(issue_number)
         return payload
 
     payload["guardian"] = guardian_state.get("prs", {})
@@ -198,6 +200,23 @@ def build_integration_status_for_pr(meta: dict) -> dict[str, object]:
     integration_ref_live = fetch_integration_ref_live_state(integration_ref) if integration_ref_is_checkable(integration_ref) else {}
     packet = build_review_packet(
         body,
+        issue_number=issue_number,
+        issue_canonical=issue_canonical,
+        issue_error=issue_error,
+        integration_ref_live=integration_ref_live,
+    )
+    packet["issue_lookup_error"] = issue_error
+    return packet
+
+
+def build_integration_status_for_issue(issue_number: int) -> dict[str, object]:
+    issue_resolution = validate_issue_fetch(issue_number, allow_missing_payload=True)
+    issue_canonical = dict(issue_resolution.canonical)
+    issue_error = str(issue_resolution.error or "")
+    integration_ref = str(issue_canonical.get("integration_ref") or "").strip()
+    integration_ref_live = fetch_integration_ref_live_state(integration_ref) if integration_ref_is_checkable(integration_ref) else {}
+    packet = build_review_packet(
+        "",
         issue_number=issue_number,
         issue_canonical=issue_canonical,
         issue_error=issue_error,
@@ -282,6 +301,21 @@ def render_text(payload: dict) -> str:
         lines.append(f"live_source={live.get('source', '')}")
         lines.append(f"live_status={live.get('status', '')}")
         lines.append(f"live_dependency_order={live.get('dependency_order', '')}")
+        issue_lookup_error = str(integration.get("issue_lookup_error") or "")
+        if issue_lookup_error:
+            lines.append(f"issue_lookup_error={issue_lookup_error}")
+        comparison_errors = integration.get("comparison_errors") or []
+        lines.append(f"comparison_errors={len(comparison_errors)}")
+        for item in comparison_errors:
+            lines.append(f"- comparison_error: {item}")
+        merge_validation_errors = integration.get("merge_validation_errors") or []
+        lines.append(f"merge_validation_errors={len(merge_validation_errors)}")
+        for item in merge_validation_errors:
+            lines.append(f"- merge_validation_error: {item}")
+        live_errors = integration.get("integration_ref_live_errors") or []
+        lines.append(f"integration_ref_live_errors={len(live_errors)}")
+        for item in live_errors:
+            lines.append(f"- integration_live_error: {item}")
 
     return "\n".join(lines) + "\n"
 

--- a/scripts/governance_status.py
+++ b/scripts/governance_status.py
@@ -14,6 +14,7 @@ from scripts.common import REPO_ROOT, default_github_repo, integration_ref_is_ch
 from scripts.integration_contract import (
     build_review_packet,
     fetch_integration_ref_live_state,
+    merge_gate_requires_integration_recheck,
     parse_pr_integration_check,
     validate_issue_fetch,
     validate_integration_ref_live_state,
@@ -206,6 +207,9 @@ def build_integration_status_for_pr(meta: dict) -> dict[str, object]:
         issue_error=issue_error,
         integration_ref_live=integration_ref_live,
     )
+    if not pr_canonical and issue_canonical:
+        packet["merge_gate"] = str(issue_canonical.get("merge_gate") or "").strip().lower()
+        packet["merge_gate_requires_recheck"] = merge_gate_requires_integration_recheck(issue_canonical)
     live_validation_payload = pr_canonical or issue_canonical
     live_errors = validate_integration_ref_live_state(
         live_validation_payload,

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -1175,17 +1175,6 @@ def build_review_packet(
         require_merge_time_recheck=False,
     )
     packet_integration_ref_live = dict(integration_ref_live or {})
-    integration_ref_live_errors = (
-        validate_integration_ref_live_state(
-            pr_payload,
-            packet_integration_ref_live,
-            current_repo_slug=default_github_repo(),
-        )
-        if integration_ref_live is not None
-        else []
-    )
-    if integration_ref_live_errors:
-        merge_validation_errors = [*merge_validation_errors, *[item for item in integration_ref_live_errors if item not in merge_validation_errors]]
     return {
         "contract_sources": [
             CONTRACT_SOURCE_MACHINE_READABLE,
@@ -1201,7 +1190,7 @@ def build_review_packet(
         "merge_gate": str(pr_payload.get("merge_gate") or "").strip().lower() if pr_payload else "",
         "merge_gate_requires_recheck": merge_gate_requires_integration_recheck(pr_payload) if pr_payload else False,
         "integration_ref_live": packet_integration_ref_live,
-        "integration_ref_live_errors": integration_ref_live_errors,
+        "integration_ref_live_errors": [],
         "merge_validation_errors": merge_validation_errors,
     }
 

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -344,6 +344,11 @@ def normalize_integration_value_for_packet(field: str, value: str) -> str:
     return normalize_integration_value(field, raw)
 
 
+def normalize_integration_value_for_review_packet(field: str, value: str) -> str:
+    raw = str(value or "").strip()
+    return normalize_integration_value(field, raw)
+
+
 def missing_required_fields(payload: Mapping[str, str], scope: str) -> list[str]:
     return [field for field in field_names(scope) if not str(payload.get(field) or "").strip()]
 
@@ -391,6 +396,7 @@ def compare_issue_and_pr_canonical(
     *,
     issue_label: str,
     field_prefix: str = "integration_check",
+    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     for field in ISSUE_SCOPE_FIELDS:
@@ -398,6 +404,9 @@ def compare_issue_and_pr_canonical(
             expected_normalized = normalize_integration_value(field, issue_canonical.get(field, ""))
             actual_normalized = normalize_integration_value(field, pr_payload.get(field, ""))
             if expected_normalized == actual_normalized:
+                continue
+            if not allow_live_resolution:
+                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
                 continue
             expected, expected_resolved, expected_static = semantic_integration_ref_identity(str(issue_canonical.get(field, "") or ""))
             actual, actual_resolved, actual_static = semantic_integration_ref_identity(str(pr_payload.get(field, "") or ""))
@@ -489,6 +498,7 @@ def validate_pr_merge_gate_payload(
     issue_number: int | None,
     issue_canonical: Mapping[str, str],
     require_merge_time_recheck: bool,
+    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     merge_gate = str(payload.get("merge_gate") or "").strip().lower()
@@ -504,7 +514,14 @@ def validate_pr_merge_gate_payload(
     errors.extend(validate_enum_values(payload, "pr", prefix="integration_check"))
     if issue_canonical:
         issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
-        errors.extend(compare_issue_and_pr_canonical(issue_canonical, payload, issue_label=issue_label))
+        errors.extend(
+            compare_issue_and_pr_canonical(
+                issue_canonical,
+                payload,
+                issue_label=issue_label,
+                allow_live_resolution=allow_live_resolution,
+            )
+        )
 
     integration_touchpoint = str(payload.get("integration_touchpoint") or "").strip().lower()
     integration_ref = str(payload.get("integration_ref") or "").strip()
@@ -559,6 +576,7 @@ def validate_pr_integration_contract(
     issue_canonical: Mapping[str, str],
     issue_error: str | None = None,
     require_merge_time_recheck: bool,
+    allow_live_resolution: bool = True,
 ) -> list[str]:
     if issue_error:
         return [issue_error]
@@ -569,6 +587,7 @@ def validate_pr_integration_contract(
         issue_number=issue_number,
         issue_canonical=issue_canonical,
         require_merge_time_recheck=require_merge_time_recheck,
+        allow_live_resolution=allow_live_resolution,
     )
 
 
@@ -1149,21 +1168,26 @@ def build_review_packet(
     issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
     packet_issue_error = str(issue_error or "").strip()
     missing_pr_error = missing_pr_integration_check_error(issue_number) if issue_canonical and not pr_payload else ""
-    comparison_errors = (
-        [packet_issue_error]
-        if packet_issue_error
-        else
-        [missing_pr_error]
-        if missing_pr_error
-        else compare_issue_and_pr_canonical(issue_canonical, pr_payload, issue_label=issue_label) if issue_canonical and pr_payload else []
-    )
+    if packet_issue_error:
+        comparison_errors = [packet_issue_error]
+    elif missing_pr_error:
+        comparison_errors = [missing_pr_error]
+    elif issue_canonical and pr_payload:
+        comparison_errors = compare_issue_and_pr_canonical(
+            issue_canonical,
+            pr_payload,
+            issue_label=issue_label,
+            allow_live_resolution=False,
+        )
+    else:
+        comparison_errors = []
     normalized_issue = {
-        field: normalize_integration_value_for_packet(field, issue_canonical.get(field, ""))
+        field: normalize_integration_value_for_review_packet(field, issue_canonical.get(field, ""))
         for field in ISSUE_SCOPE_FIELDS
         if str(issue_canonical.get(field) or "").strip()
     }
     normalized_pr = {
-        field: normalize_integration_value_for_packet(field, pr_payload.get(field, ""))
+        field: normalize_integration_value_for_review_packet(field, pr_payload.get(field, ""))
         for field in PR_SCOPE_FIELDS
         if str(pr_payload.get(field) or "").strip()
     }
@@ -1173,6 +1197,7 @@ def build_review_packet(
         issue_canonical=issue_canonical,
         issue_error=packet_issue_error,
         require_merge_time_recheck=False,
+        allow_live_resolution=False,
     )
     packet_integration_ref_live = dict(integration_ref_live or {})
     return {

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -396,6 +396,7 @@ def compare_issue_and_pr_canonical(
     *,
     issue_label: str,
     field_prefix: str = "integration_check",
+    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     for field in ISSUE_SCOPE_FIELDS:
@@ -403,6 +404,26 @@ def compare_issue_and_pr_canonical(
             expected_normalized = normalize_integration_value(field, issue_canonical.get(field, ""))
             actual_normalized = normalize_integration_value(field, pr_payload.get(field, ""))
             if expected_normalized == actual_normalized:
+                continue
+            cross_form_pair = {
+                expected_normalized.split(":", 1)[0],
+                actual_normalized.split(":", 1)[0],
+            } == {"issue", "project-item"}
+            if not allow_live_resolution:
+                if cross_form_pair:
+                    continue
+                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
+                continue
+            expected, expected_resolved, expected_static = semantic_integration_ref_identity(str(issue_canonical.get(field, "") or ""))
+            actual, actual_resolved, actual_static = semantic_integration_ref_identity(str(pr_payload.get(field, "") or ""))
+            if expected == actual:
+                continue
+            cross_form_pair = {
+                expected_static.split(":", 1)[0],
+                actual_static.split(":", 1)[0],
+            } == {"issue", "project-item"}
+            if cross_form_pair and (not expected_resolved or not actual_resolved):
+                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
                 continue
             errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
             continue
@@ -483,6 +504,7 @@ def validate_pr_merge_gate_payload(
     issue_number: int | None,
     issue_canonical: Mapping[str, str],
     require_merge_time_recheck: bool,
+    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     merge_gate = str(payload.get("merge_gate") or "").strip().lower()
@@ -498,7 +520,14 @@ def validate_pr_merge_gate_payload(
     errors.extend(validate_enum_values(payload, "pr", prefix="integration_check"))
     if issue_canonical:
         issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
-        errors.extend(compare_issue_and_pr_canonical(issue_canonical, payload, issue_label=issue_label))
+        errors.extend(
+            compare_issue_and_pr_canonical(
+                issue_canonical,
+                payload,
+                issue_label=issue_label,
+                allow_live_resolution=allow_live_resolution,
+            )
+        )
 
     integration_touchpoint = str(payload.get("integration_touchpoint") or "").strip().lower()
     integration_ref = str(payload.get("integration_ref") or "").strip()
@@ -553,6 +582,7 @@ def validate_pr_integration_contract(
     issue_canonical: Mapping[str, str],
     issue_error: str | None = None,
     require_merge_time_recheck: bool,
+    allow_live_resolution: bool = True,
 ) -> list[str]:
     if issue_error:
         return [issue_error]
@@ -563,6 +593,7 @@ def validate_pr_integration_contract(
         issue_number=issue_number,
         issue_canonical=issue_canonical,
         require_merge_time_recheck=require_merge_time_recheck,
+        allow_live_resolution=allow_live_resolution,
     )
 
 
@@ -1148,7 +1179,12 @@ def build_review_packet(
     elif missing_pr_error:
         comparison_errors = [missing_pr_error]
     elif issue_canonical and pr_payload:
-        comparison_errors = compare_issue_and_pr_canonical(issue_canonical, pr_payload, issue_label=issue_label)
+        comparison_errors = compare_issue_and_pr_canonical(
+            issue_canonical,
+            pr_payload,
+            issue_label=issue_label,
+            allow_live_resolution=False,
+        )
     else:
         comparison_errors = []
     normalized_issue = {
@@ -1167,6 +1203,7 @@ def build_review_packet(
         issue_canonical=issue_canonical,
         issue_error=packet_issue_error,
         require_merge_time_recheck=False,
+        allow_live_resolution=False,
     )
     packet_integration_ref_live = dict(integration_ref_live or {})
     return {

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -882,6 +882,10 @@ def fetch_issue_integration_ref_live_state(integration_ref: str, repo_slug: str,
     candidate["url"] = str(issue.get("url") or "").strip()
     candidate["title"] = str(issue.get("title") or "").strip()
     candidate["issue_state"] = normalize_label_value(str(issue.get("state") or ""))
+    candidate["content_type"] = "issue"
+    candidate["content_url"] = str(issue.get("url") or "").strip()
+    candidate["content_issue_number"] = str(issue.get("number") or issue_number).strip()
+    candidate["content_repo"] = repo_slug
     return candidate
 
 

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -1083,7 +1083,7 @@ def validate_issue_canonical_payload(payload: Mapping[str, str]) -> list[str]:
 
 def validate_issue_fetch(issue_number: int, *, allow_missing_payload: bool) -> IssueCanonicalResolution:
     completed = run(
-        ["gh", "issue", "view", str(issue_number), "--json", "body"],
+        ["gh", "issue", "view", str(issue_number), "--repo", default_github_repo(), "--json", "body"],
         cwd=REPO_ROOT,
         check=False,
     )

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -410,8 +410,6 @@ def compare_issue_and_pr_canonical(
                 actual_normalized.split(":", 1)[0],
             } == {"issue", "project-item"}
             if not allow_live_resolution:
-                if cross_form_pair:
-                    continue
                 errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
                 continue
             expected, expected_resolved, expected_static = semantic_integration_ref_identity(str(issue_canonical.get(field, "") or ""))

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -396,7 +396,6 @@ def compare_issue_and_pr_canonical(
     *,
     issue_label: str,
     field_prefix: str = "integration_check",
-    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     for field in ISSUE_SCOPE_FIELDS:
@@ -404,20 +403,6 @@ def compare_issue_and_pr_canonical(
             expected_normalized = normalize_integration_value(field, issue_canonical.get(field, ""))
             actual_normalized = normalize_integration_value(field, pr_payload.get(field, ""))
             if expected_normalized == actual_normalized:
-                continue
-            if not allow_live_resolution:
-                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
-                continue
-            expected, expected_resolved, expected_static = semantic_integration_ref_identity(str(issue_canonical.get(field, "") or ""))
-            actual, actual_resolved, actual_static = semantic_integration_ref_identity(str(pr_payload.get(field, "") or ""))
-            if expected == actual:
-                continue
-            cross_form_pair = {
-                expected_static.split(":", 1)[0],
-                actual_static.split(":", 1)[0],
-            } == {"issue", "project-item"}
-            if cross_form_pair and (not expected_resolved or not actual_resolved):
-                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
                 continue
             errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
             continue
@@ -498,7 +483,6 @@ def validate_pr_merge_gate_payload(
     issue_number: int | None,
     issue_canonical: Mapping[str, str],
     require_merge_time_recheck: bool,
-    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     merge_gate = str(payload.get("merge_gate") or "").strip().lower()
@@ -514,14 +498,7 @@ def validate_pr_merge_gate_payload(
     errors.extend(validate_enum_values(payload, "pr", prefix="integration_check"))
     if issue_canonical:
         issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
-        errors.extend(
-            compare_issue_and_pr_canonical(
-                issue_canonical,
-                payload,
-                issue_label=issue_label,
-                allow_live_resolution=allow_live_resolution,
-            )
-        )
+        errors.extend(compare_issue_and_pr_canonical(issue_canonical, payload, issue_label=issue_label))
 
     integration_touchpoint = str(payload.get("integration_touchpoint") or "").strip().lower()
     integration_ref = str(payload.get("integration_ref") or "").strip()
@@ -576,7 +553,6 @@ def validate_pr_integration_contract(
     issue_canonical: Mapping[str, str],
     issue_error: str | None = None,
     require_merge_time_recheck: bool,
-    allow_live_resolution: bool = True,
 ) -> list[str]:
     if issue_error:
         return [issue_error]
@@ -587,7 +563,6 @@ def validate_pr_integration_contract(
         issue_number=issue_number,
         issue_canonical=issue_canonical,
         require_merge_time_recheck=require_merge_time_recheck,
-        allow_live_resolution=allow_live_resolution,
     )
 
 
@@ -1173,12 +1148,7 @@ def build_review_packet(
     elif missing_pr_error:
         comparison_errors = [missing_pr_error]
     elif issue_canonical and pr_payload:
-        comparison_errors = compare_issue_and_pr_canonical(
-            issue_canonical,
-            pr_payload,
-            issue_label=issue_label,
-            allow_live_resolution=False,
-        )
+        comparison_errors = compare_issue_and_pr_canonical(issue_canonical, pr_payload, issue_label=issue_label)
     else:
         comparison_errors = []
     normalized_issue = {
@@ -1197,7 +1167,6 @@ def build_review_packet(
         issue_canonical=issue_canonical,
         issue_error=packet_issue_error,
         require_merge_time_recheck=False,
-        allow_live_resolution=False,
     )
     packet_integration_ref_live = dict(integration_ref_live or {})
     return {

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -115,6 +115,10 @@ query($id: ID!) {
           url
           repository { nameWithOwner }
         }
+        ... on DraftIssue {
+          title
+          body
+        }
       }
     }
   }
@@ -932,18 +936,24 @@ def fetch_project_item_integration_ref_live_state(
     )
     if not str(live_state.get("error") or "").strip():
         content = node.get("content") or {}
-        if str(content.get("__typename") or "") != "Issue":
+        content_type = str(content.get("__typename") or "").strip()
+        if content_type == "Issue":
+            repository = content.get("repository") or {}
+            live_state["content_type"] = "issue"
+            live_state["content_url"] = str(content.get("url") or "").strip()
+            live_state["content_issue_number"] = str(content.get("number") or "").strip()
+            live_state["content_repo"] = str(repository.get("nameWithOwner") or "").strip()
+        elif content_type == "DraftIssue":
+            live_state["content_type"] = "draft_issue"
+            live_state["content_title"] = str(content.get("title") or "").strip()
+            live_state["content_body"] = str(content.get("body") or "").strip()
+        else:
             return {
                 "integration_ref": integration_ref,
                 "normalized_ref": normalize_integration_ref_for_comparison(integration_ref),
                 "source": "project_item",
-                "error": "`integration_ref` 直连的 project item 必须绑定到可核查的 Issue 内容，拒绝继续。",
+                "error": "`integration_ref` 直连的 project item 必须绑定到可核查的 Issue / DraftIssue 内容，拒绝继续。",
             }
-        repository = content.get("repository") or {}
-        live_state["content_type"] = "issue"
-        live_state["content_url"] = str(content.get("url") or "").strip()
-        live_state["content_issue_number"] = str(content.get("number") or "").strip()
-        live_state["content_repo"] = str(repository.get("nameWithOwner") or "").strip()
         live_state["item_id"] = item_id
     return live_state
 

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -396,7 +396,6 @@ def compare_issue_and_pr_canonical(
     *,
     issue_label: str,
     field_prefix: str = "integration_check",
-    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     for field in ISSUE_SCOPE_FIELDS:
@@ -404,24 +403,6 @@ def compare_issue_and_pr_canonical(
             expected_normalized = normalize_integration_value(field, issue_canonical.get(field, ""))
             actual_normalized = normalize_integration_value(field, pr_payload.get(field, ""))
             if expected_normalized == actual_normalized:
-                continue
-            cross_form_pair = {
-                expected_normalized.split(":", 1)[0],
-                actual_normalized.split(":", 1)[0],
-            } == {"issue", "project-item"}
-            if not allow_live_resolution:
-                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
-                continue
-            expected, expected_resolved, expected_static = semantic_integration_ref_identity(str(issue_canonical.get(field, "") or ""))
-            actual, actual_resolved, actual_static = semantic_integration_ref_identity(str(pr_payload.get(field, "") or ""))
-            if expected == actual:
-                continue
-            cross_form_pair = {
-                expected_static.split(":", 1)[0],
-                actual_static.split(":", 1)[0],
-            } == {"issue", "project-item"}
-            if cross_form_pair and (not expected_resolved or not actual_resolved):
-                errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
                 continue
             errors.append(f"`{field_prefix}.{field}` 与 {issue_label} 中的 canonical integration 元数据不一致。")
             continue
@@ -502,7 +483,6 @@ def validate_pr_merge_gate_payload(
     issue_number: int | None,
     issue_canonical: Mapping[str, str],
     require_merge_time_recheck: bool,
-    allow_live_resolution: bool = True,
 ) -> list[str]:
     errors: list[str] = []
     merge_gate = str(payload.get("merge_gate") or "").strip().lower()
@@ -518,14 +498,7 @@ def validate_pr_merge_gate_payload(
     errors.extend(validate_enum_values(payload, "pr", prefix="integration_check"))
     if issue_canonical:
         issue_label = f"Issue #{issue_number}" if issue_number else "对应 Issue"
-        errors.extend(
-            compare_issue_and_pr_canonical(
-                issue_canonical,
-                payload,
-                issue_label=issue_label,
-                allow_live_resolution=allow_live_resolution,
-            )
-        )
+        errors.extend(compare_issue_and_pr_canonical(issue_canonical, payload, issue_label=issue_label))
 
     integration_touchpoint = str(payload.get("integration_touchpoint") or "").strip().lower()
     integration_ref = str(payload.get("integration_ref") or "").strip()
@@ -580,7 +553,6 @@ def validate_pr_integration_contract(
     issue_canonical: Mapping[str, str],
     issue_error: str | None = None,
     require_merge_time_recheck: bool,
-    allow_live_resolution: bool = True,
 ) -> list[str]:
     if issue_error:
         return [issue_error]
@@ -591,7 +563,6 @@ def validate_pr_integration_contract(
         issue_number=issue_number,
         issue_canonical=issue_canonical,
         require_merge_time_recheck=require_merge_time_recheck,
-        allow_live_resolution=allow_live_resolution,
     )
 
 
@@ -1177,12 +1148,7 @@ def build_review_packet(
     elif missing_pr_error:
         comparison_errors = [missing_pr_error]
     elif issue_canonical and pr_payload:
-        comparison_errors = compare_issue_and_pr_canonical(
-            issue_canonical,
-            pr_payload,
-            issue_label=issue_label,
-            allow_live_resolution=False,
-        )
+        comparison_errors = compare_issue_and_pr_canonical(issue_canonical, pr_payload, issue_label=issue_label)
     else:
         comparison_errors = []
     normalized_issue = {
@@ -1201,7 +1167,6 @@ def build_review_packet(
         issue_canonical=issue_canonical,
         issue_error=packet_issue_error,
         require_merge_time_recheck=False,
-        allow_live_resolution=False,
     )
     packet_integration_ref_live = dict(integration_ref_live or {})
     return {

--- a/scripts/integration_contract.py
+++ b/scripts/integration_contract.py
@@ -309,21 +309,31 @@ def semantic_integration_ref_key(value: str) -> str:
     return identity
 
 
+def semantic_identity_from_live_state(live_state: Mapping[str, object]) -> str:
+    content_repo = str(live_state.get("content_repo") or "").strip().lower()
+    content_issue_number = str(live_state.get("content_issue_number") or "").strip()
+    if content_repo and content_issue_number:
+        return f"issue:{content_repo}#{content_issue_number}"
+    organization = str(live_state.get("organization") or "").strip().lower()
+    project_number = str(live_state.get("project_number") or "").strip()
+    item_id = str(live_state.get("item_id") or "").strip()
+    if organization and project_number and item_id:
+        return f"project-item:{organization}/{project_number}#{item_id}"
+    return ""
+
+
 def semantic_integration_ref_identity(value: str) -> tuple[str, bool, str]:
     normalized = normalize_integration_ref_for_comparison(value)
     if normalized in {"", "none"}:
         return normalized, True, normalized
-    if normalized.startswith("issue:"):
-        return normalized, True, normalized
-    if not normalized.startswith("project-item:"):
+    if not (normalized.startswith("issue:") or normalized.startswith("project-item:")):
         return normalized, True, normalized
     live_state = fetch_integration_ref_live_state(value)
     if str(live_state.get("error") or "").strip():
         return normalized, False, normalized
-    content_repo = str(live_state.get("content_repo") or "").strip().lower()
-    content_issue_number = str(live_state.get("content_issue_number") or "").strip()
-    if content_repo and content_issue_number:
-        return f"issue:{content_repo}#{content_issue_number}", True, normalized
+    semantic_identity = semantic_identity_from_live_state(live_state)
+    if semantic_identity:
+        return semantic_identity, True, normalized
     return normalized, False, normalized
 
 
@@ -385,6 +395,10 @@ def compare_issue_and_pr_canonical(
     errors: list[str] = []
     for field in ISSUE_SCOPE_FIELDS:
         if field == "integration_ref":
+            expected_normalized = normalize_integration_value(field, issue_canonical.get(field, ""))
+            actual_normalized = normalize_integration_value(field, pr_payload.get(field, ""))
+            if expected_normalized == actual_normalized:
+                continue
             expected, expected_resolved, expected_static = semantic_integration_ref_identity(str(issue_canonical.get(field, "") or ""))
             actual, actual_resolved, actual_static = semantic_integration_ref_identity(str(pr_payload.get(field, "") or ""))
             if expected == actual:

--- a/scripts/merge_pr.py
+++ b/scripts/merge_pr.py
@@ -13,7 +13,10 @@ from scripts.pr_guardian import main as guardian_main
 def main(argv: list[str] | None = None) -> int:
     args = argv or sys.argv[1:]
     if not args:
-        print("用法: python3 scripts/merge_pr.py <pr-number> [--delete-branch] [--refresh-review]", file=sys.stderr)
+        print(
+            "用法: python3 scripts/merge_pr.py <pr-number> [--delete-branch] [--refresh-review] [--confirm-integration-recheck]",
+            file=sys.stderr,
+        )
         return 1
     return guardian_main(["merge-if-safe", *args])
 

--- a/scripts/open_pr.py
+++ b/scripts/open_pr.py
@@ -40,6 +40,7 @@ from scripts.context_guard import (
 from scripts.common import (
     CommandError,
     REPO_ROOT,
+    default_github_repo,
     git_changed_files,
     git_current_branch,
     git_fetch_branch,
@@ -266,7 +267,7 @@ def fetch_issue_body(issue: int | None) -> str:
 
     require_cli("gh")
     completed = run(
-        ["gh", "issue", "view", str(issue), "--json", "body"],
+        ["gh", "issue", "view", str(issue), "--repo", default_github_repo(), "--json", "body"],
         cwd=REPO_ROOT,
         check=False,
     )

--- a/scripts/open_pr.py
+++ b/scripts/open_pr.py
@@ -10,6 +10,7 @@ if __package__ in {None, ""}:
 import argparse
 import json
 import os
+import re
 import tempfile
 
 from scripts.item_context import (
@@ -47,6 +48,13 @@ from scripts.common import (
     run,
     syvert_state_file,
 )
+from scripts.integration_contract import (
+    ISSUE_SCOPE_FIELDS,
+    extract_issue_canonical_integration_fields,
+    field_choices,
+    validate_issue_fetch,
+    validate_open_pr_payload,
+)
 from scripts.policy.policy import classify_paths, formal_spec_dirs, get_policy, risk_level
 from scripts.pr_scope_guard import build_report
 from scripts.spec_guard import validate_suite
@@ -54,8 +62,22 @@ from scripts.spec_guard import validate_suite
 
 TEMPLATE_PATH = REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
 WORKTREE_STATE_FILE = syvert_state_file("worktrees.json")
-ISSUE_SUMMARY_HEADINGS = ("Goal", "Scope", "Required Outcomes", "Acceptance", "Acceptance Criteria", "Out of Scope", "Dependency")
+ISSUE_SUMMARY_HEADING_ALIASES: dict[str, tuple[str, ...]] = {
+    "Goal": ("Goal", "Summary", "摘要", "治理目标", "执行目标", "阶段目标"),
+    "Scope": ("Scope", "范围", "影响载体"),
+    "Required Outcomes": ("Required Outcomes", "Formal Spec Suite", "Formal Spec 套件"),
+    "Acceptance": ("Acceptance", "验收"),
+    "Acceptance Criteria": ("Acceptance Criteria", "验收标准", "进入 / 关闭条件", "进入/关闭条件"),
+    "Out of Scope": ("Out of Scope", "非目标"),
+    "Dependency": ("Dependency", "Dependencies", "依赖", "关联 FR"),
+}
+ISSUE_SUMMARY_HEADINGS = tuple(ISSUE_SUMMARY_HEADING_ALIASES.keys())
 FORMAL_SPEC_CORE_FILES = {"spec.md", "plan.md"}
+INTEGRATION_TOUCHPOINT_CHOICES = field_choices("integration_touchpoint")
+EXTERNAL_DEPENDENCY_CHOICES = field_choices("external_dependency")
+MERGE_GATE_CHOICES = field_choices("merge_gate")
+CONTRACT_SURFACE_CHOICES = field_choices("contract_surface")
+YES_NO_CHOICES = field_choices("shared_contract_changed")
 
 
 def is_deleted_legacy_todo_change(path: str, *, repo_root: Path) -> bool:
@@ -92,6 +114,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--closing", default="fixes", choices=get_policy()["closing_modes"])
     parser.add_argument("--draft", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--integration-touchpoint", default="none", choices=INTEGRATION_TOUCHPOINT_CHOICES)
+    parser.add_argument("--shared-contract-changed", default="no", choices=YES_NO_CHOICES)
+    parser.add_argument("--integration-ref", default="none")
+    parser.add_argument("--external-dependency", default="none", choices=EXTERNAL_DEPENDENCY_CHOICES)
+    parser.add_argument("--merge-gate", default="local_only", choices=MERGE_GATE_CHOICES)
+    parser.add_argument("--contract-surface", default="none", choices=CONTRACT_SURFACE_CHOICES)
+    parser.add_argument("--joint-acceptance-needed", default="no", choices=YES_NO_CHOICES)
+    parser.add_argument("--integration-status-checked-before-pr", default="no", choices=YES_NO_CHOICES)
+    parser.add_argument("--integration-status-checked-before-merge", default="no", choices=YES_NO_CHOICES)
     return parser.parse_args(argv)
 
 
@@ -187,18 +218,30 @@ def closing_line(issue: int | None, mode: str) -> str:
     return f"{prefix} #{issue}"
 
 
-def extract_issue_summary_sections(body: str) -> dict[str, str]:
+def normalize_issue_summary_heading(raw_heading: str) -> str:
+    heading = raw_heading.strip()
+    heading = re.sub(r"\s*[:：]\s*$", "", heading)
+    heading = re.sub(r"\s*/\s*", " / ", heading)
+    heading = re.sub(r"\s+", " ", heading)
+    return heading.casefold()
+
+
+ISSUE_SUMMARY_HEADING_LOOKUP = {
+    normalize_issue_summary_heading(alias): canonical
+    for canonical, aliases in ISSUE_SUMMARY_HEADING_ALIASES.items()
+    for alias in aliases
+}
+def extract_issue_form_sections(body: str) -> dict[str, str]:
     sections: dict[str, list[str]] = {}
     current: str | None = None
-    selected = set(ISSUE_SUMMARY_HEADINGS)
+    heading_pattern = re.compile(r"^#{2,6}\s+(.+?)\s*$")
 
     for line in body.splitlines():
         stripped = line.strip()
-        if stripped.startswith("## "):
-            heading = stripped[3:].strip()
-            current = heading if heading in selected else None
-            if current:
-                sections.setdefault(current, [])
+        heading_match = heading_pattern.match(stripped)
+        if heading_match:
+            current = heading_match.group(1).strip()
+            sections.setdefault(current, [])
             continue
         if current:
             sections[current].append(line.rstrip())
@@ -206,7 +249,18 @@ def extract_issue_summary_sections(body: str) -> dict[str, str]:
     return {key: "\n".join(value).strip() for key, value in sections.items() if "\n".join(value).strip()}
 
 
-def build_issue_summary(issue: int | None) -> str:
+def extract_issue_summary_sections(body: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    for heading, content in extract_issue_form_sections(body).items():
+        canonical = ISSUE_SUMMARY_HEADING_LOOKUP.get(normalize_issue_summary_heading(heading))
+        if canonical and content:
+            if canonical in sections:
+                sections[canonical] = "\n\n".join([sections[canonical], content]).strip()
+            else:
+                sections[canonical] = content
+    return sections
+
+def fetch_issue_body(issue: int | None) -> str:
     if issue is None:
         return ""
 
@@ -220,7 +274,22 @@ def build_issue_summary(issue: int | None) -> str:
         return ""
 
     payload = json.loads(completed.stdout or "{}")
-    sections = extract_issue_summary_sections(str(payload.get("body") or ""))
+    return str(payload.get("body") or "")
+
+
+def resolve_issue_canonical_integration(issue: int | None) -> tuple[dict[str, str], str | None]:
+    if issue is None:
+        return {}, None
+    resolution = validate_issue_fetch(issue, allow_missing_payload=True)
+    return resolution.canonical, resolution.error
+
+
+def build_issue_summary(issue: int | None) -> str:
+    body = fetch_issue_body(issue)
+    if not body:
+        return ""
+
+    sections = extract_issue_summary_sections(body)
     if not sections:
         return ""
 
@@ -431,6 +500,52 @@ def validate_pr_preflight(
     return errors
 
 
+def validate_integration_args(args: argparse.Namespace) -> list[str]:
+    errors: list[str] = []
+    issue_canonical_integration, issue_canonical_error = resolve_issue_canonical_integration(args.issue)
+    if issue_canonical_error:
+        errors.append(issue_canonical_error)
+    payload = {
+        field: str(getattr(args, field, "") or "").strip()
+        for field in (
+            *ISSUE_SCOPE_FIELDS,
+            "integration_status_checked_before_pr",
+            "integration_status_checked_before_merge",
+        )
+    }
+    payload["integration_ref"] = str(args.integration_ref or "").strip()
+    open_pr_errors = validate_open_pr_payload(
+        payload,
+        issue_canonical=issue_canonical_integration,
+        issue_number=args.issue,
+    )
+    for error in open_pr_errors:
+        if error.startswith("`cli."):
+            field = error.split(".", 1)[1].split("`", 1)[0]
+            cli_flag = f"--{field.replace('_', '-')}"
+            errors.append(error.replace(f"`cli.{field}`", f"`{cli_flag}`", 1))
+        else:
+            errors.append(error)
+    return errors
+
+
+def replace_markdown_field(body: str, label: str, value: str) -> str:
+    pattern = re.compile(rf"^- {re.escape(label)}(?:（[^\n]*?）)?:\s*$", re.MULTILINE)
+    replacement = f"- {label}: {value}"
+    return pattern.sub(replacement, body, count=1)
+
+
+def has_markdown_section(body: str, heading: str) -> bool:
+    pattern = re.compile(rf"(?im)^##\s+{re.escape(heading)}\s*$")
+    return bool(pattern.search(body))
+
+
+def render_integration_check_section(values: dict[str, str]) -> str:
+    lines = ["## integration_check", ""]
+    lines.extend([f"- {label}: {value}" for label, value in values.items()])
+    return "\n".join(lines)
+
+
 def build_body(args: argparse.Namespace, changed_files: list[str]) -> str:
     if not TEMPLATE_PATH.exists():
         raise SystemExit(f"缺少 PR 模板: {TEMPLATE_PATH}")
@@ -450,6 +565,21 @@ def build_body(args: argparse.Namespace, changed_files: list[str]) -> str:
     }
     for token, value in replacements.items():
         body = body.replace(token, value)
+    integration_values = {
+        "integration_touchpoint": args.integration_touchpoint,
+        "shared_contract_changed": args.shared_contract_changed,
+        "integration_ref": args.integration_ref,
+        "external_dependency": args.external_dependency,
+        "merge_gate": args.merge_gate,
+        "contract_surface": args.contract_surface,
+        "joint_acceptance_needed": args.joint_acceptance_needed,
+        "integration_status_checked_before_pr": args.integration_status_checked_before_pr,
+        "integration_status_checked_before_merge": args.integration_status_checked_before_merge,
+    }
+    if not has_markdown_section(body, "integration_check"):
+        body = body.rstrip() + "\n\n" + render_integration_check_section(integration_values) + "\n"
+    for label, value in integration_values.items():
+        body = replace_markdown_field(body, label, value)
     return body
 
 
@@ -477,6 +607,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     if preflight_errors:
         for error in preflight_errors:
+            print(error, file=sys.stderr)
+        return 1
+    integration_errors = validate_integration_args(args)
+    if integration_errors:
+        for error in integration_errors:
             print(error, file=sys.stderr)
         return 1
 

--- a/scripts/open_pr.py
+++ b/scripts/open_pr.py
@@ -507,6 +507,13 @@ def validate_integration_args(args: argparse.Namespace) -> list[str]:
     issue_canonical_integration, issue_canonical_error = resolve_issue_canonical_integration(args.issue)
     if issue_canonical_error:
         errors.append(issue_canonical_error)
+    canonical_integration_ref = canonicalize_integration_ref_for_issue(
+        args.issue,
+        args.integration_ref,
+        issue_canonical=issue_canonical_integration,
+        issue_error=issue_canonical_error,
+    )
+    args.integration_ref = canonical_integration_ref
     payload = {
         field: str(getattr(args, field, "") or "").strip()
         for field in (
@@ -515,7 +522,7 @@ def validate_integration_args(args: argparse.Namespace) -> list[str]:
             "integration_status_checked_before_merge",
         )
     }
-    payload["integration_ref"] = str(args.integration_ref or "").strip()
+    payload["integration_ref"] = canonical_integration_ref
     open_pr_errors = validate_open_pr_payload(
         payload,
         issue_canonical=issue_canonical_integration,
@@ -548,11 +555,19 @@ def render_integration_check_section(values: dict[str, str]) -> str:
     return "\n".join(lines)
 
 
-def canonicalize_integration_ref_for_body(issue: int | None, integration_ref: str) -> str:
+def canonicalize_integration_ref_for_issue(
+    issue: int | None,
+    integration_ref: str,
+    *,
+    issue_canonical: dict[str, str] | None = None,
+    issue_error: str | None = None,
+) -> str:
     raw_integration_ref = str(integration_ref or "").strip()
     if issue is None or not raw_integration_ref:
         return raw_integration_ref
-    issue_canonical, issue_error = resolve_issue_canonical_integration(issue)
+    if issue_canonical is None and issue_error is None:
+        issue_canonical, issue_error = resolve_issue_canonical_integration(issue)
+    issue_canonical = issue_canonical or {}
     if issue_error:
         return raw_integration_ref
     issue_integration_ref = str(issue_canonical.get("integration_ref") or "").strip()
@@ -587,7 +602,7 @@ def build_body(args: argparse.Namespace, changed_files: list[str]) -> str:
     integration_values = {
         "integration_touchpoint": args.integration_touchpoint,
         "shared_contract_changed": args.shared_contract_changed,
-        "integration_ref": canonicalize_integration_ref_for_body(args.issue, args.integration_ref),
+        "integration_ref": canonicalize_integration_ref_for_issue(args.issue, args.integration_ref),
         "external_dependency": args.external_dependency,
         "merge_gate": args.merge_gate,
         "contract_surface": args.contract_surface,

--- a/scripts/open_pr.py
+++ b/scripts/open_pr.py
@@ -53,6 +53,7 @@ from scripts.integration_contract import (
     ISSUE_SCOPE_FIELDS,
     extract_issue_canonical_integration_fields,
     field_choices,
+    semantic_integration_ref_identity,
     validate_issue_fetch,
     validate_open_pr_payload,
 )
@@ -547,6 +548,23 @@ def render_integration_check_section(values: dict[str, str]) -> str:
     return "\n".join(lines)
 
 
+def canonicalize_integration_ref_for_body(issue: int | None, integration_ref: str) -> str:
+    raw_integration_ref = str(integration_ref or "").strip()
+    if issue is None or not raw_integration_ref:
+        return raw_integration_ref
+    issue_canonical, issue_error = resolve_issue_canonical_integration(issue)
+    if issue_error:
+        return raw_integration_ref
+    issue_integration_ref = str(issue_canonical.get("integration_ref") or "").strip()
+    if not issue_integration_ref or issue_integration_ref == raw_integration_ref:
+        return raw_integration_ref
+    issue_identity, issue_resolved, _ = semantic_integration_ref_identity(issue_integration_ref)
+    pr_identity, pr_resolved, _ = semantic_integration_ref_identity(raw_integration_ref)
+    if issue_resolved and pr_resolved and issue_identity == pr_identity:
+        return issue_integration_ref
+    return raw_integration_ref
+
+
 def build_body(args: argparse.Namespace, changed_files: list[str]) -> str:
     if not TEMPLATE_PATH.exists():
         raise SystemExit(f"缺少 PR 模板: {TEMPLATE_PATH}")
@@ -569,7 +587,7 @@ def build_body(args: argparse.Namespace, changed_files: list[str]) -> str:
     integration_values = {
         "integration_touchpoint": args.integration_touchpoint,
         "shared_contract_changed": args.shared_contract_changed,
-        "integration_ref": args.integration_ref,
+        "integration_ref": canonicalize_integration_ref_for_body(args.issue, args.integration_ref),
         "external_dependency": args.external_dependency,
         "merge_gate": args.merge_gate,
         "contract_surface": args.contract_surface,

--- a/scripts/open_pr.py
+++ b/scripts/open_pr.py
@@ -53,7 +53,6 @@ from scripts.integration_contract import (
     ISSUE_SCOPE_FIELDS,
     extract_issue_canonical_integration_fields,
     field_choices,
-    semantic_integration_ref_identity,
     validate_issue_fetch,
     validate_open_pr_payload,
 )
@@ -573,9 +572,9 @@ def canonicalize_integration_ref_for_issue(
     issue_integration_ref = str(issue_canonical.get("integration_ref") or "").strip()
     if not issue_integration_ref or issue_integration_ref == raw_integration_ref:
         return raw_integration_ref
-    issue_identity, issue_resolved, _ = semantic_integration_ref_identity(issue_integration_ref)
-    pr_identity, pr_resolved, _ = semantic_integration_ref_identity(raw_integration_ref)
-    if issue_resolved and pr_resolved and issue_identity == pr_identity:
+    if raw_integration_ref.lower() == "none":
+        return raw_integration_ref
+    if issue_integration_ref:
         return issue_integration_ref
     return raw_integration_ref
 

--- a/scripts/open_pr.py
+++ b/scripts/open_pr.py
@@ -13,6 +13,7 @@ import os
 import re
 import tempfile
 
+from scripts import integration_contract
 from scripts.item_context import (
     ITEM_TYPES,
     INPUT_MODE_BOOTSTRAP,
@@ -53,6 +54,7 @@ from scripts.integration_contract import (
     ISSUE_SCOPE_FIELDS,
     extract_issue_canonical_integration_fields,
     field_choices,
+    normalize_integration_value,
     validate_issue_fetch,
     validate_open_pr_payload,
 )
@@ -574,8 +576,18 @@ def canonicalize_integration_ref_for_issue(
         return raw_integration_ref
     if raw_integration_ref.lower() == "none":
         return raw_integration_ref
-    if issue_integration_ref:
+    issue_normalized = normalize_integration_value("integration_ref", issue_integration_ref)
+    raw_normalized = normalize_integration_value("integration_ref", raw_integration_ref)
+    if issue_integration_ref and issue_normalized == raw_normalized:
         return issue_integration_ref
+    live_state = integration_contract.fetch_integration_ref_live_state(raw_integration_ref)
+    if not str(live_state.get("error") or "").strip():
+        live_repo = str(live_state.get("content_repo") or "").strip()
+        live_issue_number = str(live_state.get("content_issue_number") or "").strip()
+        if live_repo and live_issue_number:
+            live_issue_ref = f"{live_repo}#{live_issue_number}"
+            if normalize_integration_value("integration_ref", live_issue_ref) == issue_normalized:
+                return issue_integration_ref
     return raw_integration_ref
 
 

--- a/scripts/open_pr.py
+++ b/scripts/open_pr.py
@@ -580,15 +580,28 @@ def canonicalize_integration_ref_for_issue(
     raw_normalized = normalize_integration_value("integration_ref", raw_integration_ref)
     if issue_integration_ref and issue_normalized == raw_normalized:
         return issue_integration_ref
-    live_state = integration_contract.fetch_integration_ref_live_state(raw_integration_ref)
-    if not str(live_state.get("error") or "").strip():
-        live_repo = str(live_state.get("content_repo") or "").strip()
-        live_issue_number = str(live_state.get("content_issue_number") or "").strip()
-        if live_repo and live_issue_number:
-            live_issue_ref = f"{live_repo}#{live_issue_number}"
-            if normalize_integration_value("integration_ref", live_issue_ref) == issue_normalized:
-                return issue_integration_ref
+    issue_canonical_issue_identity = resolved_issue_identity_from_integration_ref(issue_integration_ref)
+    raw_issue_identity = resolved_issue_identity_from_integration_ref(raw_integration_ref)
+    if issue_canonical_issue_identity and raw_issue_identity and issue_canonical_issue_identity == raw_issue_identity:
+        return issue_integration_ref
     return raw_integration_ref
+
+
+def resolved_issue_identity_from_integration_ref(integration_ref: str) -> str:
+    raw_ref = str(integration_ref or "").strip()
+    if not raw_ref:
+        return ""
+    normalized_ref = normalize_integration_value("integration_ref", raw_ref)
+    if normalized_ref.startswith("issue:"):
+        return normalized_ref
+    live_state = integration_contract.fetch_integration_ref_live_state(raw_ref)
+    if str(live_state.get("error") or "").strip():
+        return ""
+    live_repo = str(live_state.get("content_repo") or "").strip()
+    live_issue_number = str(live_state.get("content_issue_number") or "").strip()
+    if not live_repo or not live_issue_number:
+        return ""
+    return normalize_integration_value("integration_ref", f"{live_repo}#{live_issue_number}")
 
 
 def build_body(args: argparse.Namespace, changed_files: list[str]) -> str:

--- a/scripts/pr_guardian.py
+++ b/scripts/pr_guardian.py
@@ -8,6 +8,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -15,9 +16,38 @@ import shutil
 import subprocess
 import tempfile
 from datetime import datetime, timezone
+from tempfile import NamedTemporaryFile
 
-from scripts.common import REPO_ROOT, bool_text, dump_json, ensure_parent, format_changed_files, load_json, require_cli, run
+from scripts.common import (
+    CommandError,
+    REPO_ROOT,
+    bool_text,
+    default_github_repo,
+    dump_json,
+    ensure_parent,
+    format_changed_files,
+    integration_ref_is_checkable,
+    load_json,
+    require_cli,
+    run,
+)
+from scripts.integration_contract import (
+    ISSUE_SCOPE_FIELDS,
+    PR_SCOPE_FIELDS,
+    build_review_packet,
+    extract_issue_canonical_integration_fields,
+    fetch_integration_ref_live_state,
+    field_choices,
+    merge_gate_requires_integration_recheck as merge_gate_requires_integration_recheck_payload,
+    parse_integration_check_payload,
+    parse_pr_integration_check,
+    render_review_packet_lines,
+    validate_integration_ref_live_state,
+    validate_issue_fetch,
+    validate_pr_integration_contract,
+)
 from scripts.item_context import active_exec_plans_for_issue, load_item_context_from_exec_plan, parse_item_context_from_body
+from scripts.open_pr import extract_issue_summary_sections
 from scripts.state_paths import guardian_legacy_state_path, guardian_state_path
 
 
@@ -25,6 +55,7 @@ SCHEMA_PATH = REPO_ROOT / "scripts" / "policy" / "pr_review_result_schema.json"
 CODE_REVIEW_PATH = "code_review.md"
 DEFAULT_STATE_FILE = guardian_state_path()
 VALID_VERDICTS = {"APPROVE", "REQUEST_CHANGES"}
+INTEGRATION_STATUS_VALUES = set(field_choices("integration_status_checked_before_pr"))
 REVIEW_REQUIRED_BODY_FIELDS = ("issue", "item_key", "item_type", "release", "sprint")
 REVIEW_EXECUTION_RULES = (
     "工件完整性只用于确认输入是否足够，不要把 checks、Draft 状态或 merge 动作当成 reviewer 结论来源。",
@@ -79,6 +110,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     merge.add_argument("--post-review", action="store_true")
     merge.add_argument("--delete-branch", action="store_true")
     merge.add_argument("--refresh-review", action="store_true")
+    merge.add_argument("--confirm-integration-recheck", action="store_true")
 
     return parser.parse_args(argv)
 
@@ -126,11 +158,16 @@ def now_iso_utc() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def guardian_body_fingerprint(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
 def build_guardian_payload(meta: dict, result: dict) -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "pr_number": meta["number"],
         "head_sha": meta["headRefOid"],
+        "body_fingerprint": guardian_body_fingerprint(str(meta.get("body") or "")),
         "verdict": result["verdict"],
         "safe_to_merge": result["safe_to_merge"],
         "summary": result["summary"],
@@ -154,14 +191,31 @@ def save_guardian_result(pr_number: int, payload: dict, *, path: Path = DEFAULT_
     dump_json(path, state)
 
 
-def valid_guardian_payload(payload: object, *, pr_number: int, head_sha: str) -> dict | None:
+def valid_guardian_payload(
+    payload: object,
+    *,
+    pr_number: int,
+    head_sha: str,
+    body: str | None = None,
+    require_body_bound: bool = False,
+) -> dict | None:
     if not isinstance(payload, dict):
         return None
-    if payload.get("schema_version") != 1:
+    schema_version = payload.get("schema_version")
+    if schema_version not in {1, 2}:
         return None
     if payload.get("pr_number") != pr_number:
         return None
     if payload.get("head_sha") != head_sha:
+        return None
+    body_fingerprint = payload.get("body_fingerprint")
+    if body is not None:
+        if schema_version == 2:
+            if body_fingerprint != guardian_body_fingerprint(body):
+                return None
+        elif require_body_bound:
+            return None
+    elif schema_version == 2 and not isinstance(body_fingerprint, str):
         return None
     if payload.get("verdict") not in VALID_VERDICTS:
         return None
@@ -174,13 +228,39 @@ def valid_guardian_payload(payload: object, *, pr_number: int, head_sha: str) ->
     return payload
 
 
-def local_guardian_result(pr_number: int, head_sha: str, *, path: Path = DEFAULT_STATE_FILE) -> dict | None:
+def local_guardian_result(
+    pr_number: int,
+    head_sha: str,
+    *,
+    body: str | None = None,
+    require_body_bound: bool = False,
+    path: Path = DEFAULT_STATE_FILE,
+) -> dict | None:
     payload = load_guardian_state(path).get("prs", {}).get(str(pr_number))
-    return valid_guardian_payload(payload, pr_number=pr_number, head_sha=head_sha)
+    return valid_guardian_payload(
+        payload,
+        pr_number=pr_number,
+        head_sha=head_sha,
+        body=body,
+        require_body_bound=require_body_bound,
+    )
 
 
-def find_latest_guardian_result(pr_number: int, head_sha: str, *, path: Path = DEFAULT_STATE_FILE) -> dict | None:
-    return local_guardian_result(pr_number, head_sha, path=path)
+def find_latest_guardian_result(
+    pr_number: int,
+    head_sha: str,
+    *,
+    body: str | None = None,
+    require_body_bound: bool = False,
+    path: Path = DEFAULT_STATE_FILE,
+) -> dict | None:
+    return local_guardian_result(
+        pr_number,
+        head_sha,
+        body=body,
+        require_body_bound=require_body_bound,
+        path=path,
+    )
 
 
 def parse_all_markdown_sections(body: str) -> dict[str, str]:
@@ -219,6 +299,152 @@ def parse_markdown_sections(body: str) -> dict[str, str]:
         if key and content:
             sections[key] = content
     return sections
+
+
+def parse_bullet_kv_section(section: str) -> dict[str, str]:
+    payload: dict[str, str] = {}
+    current_key: str | None = None
+    for raw_line in section.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            entry = stripped[2:]
+            key_part, _, value_part = entry.partition(":")
+            if not _:
+                key_part, _, value_part = entry.partition("：")
+            normalized_key = key_part.split("（", 1)[0].split("(", 1)[0].strip()
+            current_key = normalized_key
+            payload[current_key] = value_part.strip()
+            continue
+        if current_key and stripped and raw_line[:1].isspace():
+            payload[current_key] = "\n".join(filter(None, [payload[current_key], stripped])).strip()
+    return payload
+
+
+def integration_merge_gate_errors(meta: dict, *, require_live_state: bool = False) -> list[str]:
+    body = str(meta.get("body") or "")
+    issue_number, issue_canonical_integration = resolve_issue_canonical_integration(meta)
+    issue_canonical_error = str(meta.get("_issue_canonical_integration_error") or "").strip()
+    integration_payload = parse_pr_integration_check(body)
+    if issue_canonical_error:
+        return [issue_canonical_error]
+    errors = validate_pr_integration_contract(
+        integration_payload,
+        issue_number=issue_number,
+        issue_canonical=issue_canonical_integration,
+        issue_error=issue_canonical_error,
+        require_merge_time_recheck=True,
+    )
+    if errors:
+        return errors
+    if not require_live_state or not merge_gate_requires_integration_recheck_payload(integration_payload):
+        return []
+    integration_ref = str(integration_payload.get("integration_ref") or "").strip()
+    live_state = fetch_integration_ref_live_state(integration_ref)
+    meta["_integration_ref_live_state"] = live_state
+    return validate_integration_ref_live_state(
+        integration_payload,
+        live_state,
+        current_repo_slug=default_github_repo(),
+    )
+
+
+def merge_gate_requires_integration_recheck(meta: dict) -> bool:
+    payload = parse_pr_integration_check(str(meta.get("body") or ""))
+    return bool(payload) and merge_gate_requires_integration_recheck_payload(payload)
+
+
+def integration_check_section_span(body: str) -> tuple[int, int]:
+    heading_pattern = re.compile(r"(?im)^#{2,6}\s+(.+?)\s*$")
+    matches = list(heading_pattern.finditer(body))
+    for index, match in enumerate(matches):
+        if match.group(1).strip().casefold() != "integration_check":
+            continue
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        return start, end
+    raise SystemExit("PR 描述缺少 `## integration_check` 段落，无法在 merge 前记录 integration 复核。")
+
+
+def integration_check_section_text(body: str) -> str:
+    start, end = integration_check_section_span(body)
+    return body[start:end]
+
+
+def set_integration_status_checked_before_merge(body: str, value: str = "yes") -> str:
+    pattern = re.compile(
+        r"(?im)^(\s*-\s*integration_status_checked_before_merge(?:（[^）]*）|\([^)]*\))?\s*[：:]\s*)(yes|no)\s*$"
+    )
+    section_start, section_end = integration_check_section_span(body)
+    section_body = body[section_start:section_end]
+    updated_section, count = pattern.subn(rf"\1{value}", section_body, count=1)
+    if count == 0:
+        raise SystemExit("PR 描述缺少 `integration_status_checked_before_merge` 字段，无法在 merge 前记录 integration 复核。")
+    return body[:section_start] + updated_section + body[section_end:]
+
+
+def integration_status_checked_before_merge_value(body: str) -> str:
+    section_body = integration_check_section_text(body)
+    payload = parse_integration_check_payload(section_body)
+    value = str(payload.get("integration_status_checked_before_merge") or "").strip().lower()
+    if not value:
+        raise SystemExit("PR 描述缺少 `integration_status_checked_before_merge` 字段，无法读取 merge 前 integration 复核状态。")
+    if value not in INTEGRATION_STATUS_VALUES:
+        allowed = " / ".join(sorted(INTEGRATION_STATUS_VALUES))
+        raise SystemExit(
+            "PR 描述中的 `integration_status_checked_before_merge` 非法："
+            f"`{value}`（仅允许 `{allowed}`）。"
+        )
+    return value
+
+
+def record_merge_time_integration_recheck(pr_number: int, meta: dict) -> tuple[dict, str]:
+    expected_head_sha = str(meta.get("headRefOid") or "")
+    latest = pr_meta(pr_number)
+    latest_body = str(latest.get("body") or "")
+    original_body = str(meta.get("body") or "")
+    if expected_head_sha and latest.get("headRefOid") != expected_head_sha:
+        raise SystemExit("merge 前记录 integration 复核时发现 PR HEAD 已变化，拒绝继续。")
+    if latest_body != original_body:
+        raise SystemExit("merge 前记录 integration 复核时发现 PR 描述已变化，拒绝覆盖并发编辑。")
+    previous_value = integration_status_checked_before_merge_value(latest_body)
+    updated_body = set_integration_status_checked_before_merge(latest_body, "yes")
+    if updated_body != latest_body:
+        update_pr_body(pr_number, updated_body)
+        try:
+            latest = pr_meta(pr_number)
+        except (CommandError, SystemExit):
+            raise SystemExit(
+                "merge 前写入 `integration_status_checked_before_merge=yes` 后，无法重新读取最新 PR 描述；"
+                "为避免覆盖并发编辑，当前不会尝试自动恢复，请人工复核 PR 正文。"
+            )
+    return latest, previous_value
+
+
+def update_pr_body(pr_number: int, body: str) -> None:
+    with NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(body)
+        temp_path = Path(handle.name)
+    try:
+        run(["gh", "pr", "edit", str(pr_number), "--body-file", str(temp_path)], cwd=REPO_ROOT)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def restore_merge_time_integration_recheck(pr_number: int, previous_value: str) -> None:
+    latest = pr_meta(pr_number)
+    latest_body = str(latest.get("body") or "")
+    restored_body = set_integration_status_checked_before_merge(latest_body, previous_value)
+    if restored_body == latest_body:
+        return
+    update_pr_body(pr_number, restored_body)
+
+
+def restore_merge_time_integration_recheck_or_die(pr_number: int, previous_value: str, *, failure_context: str) -> None:
+    try:
+        restore_merge_time_integration_recheck(pr_number, previous_value)
+    except (CommandError, SystemExit) as exc:
+        raise SystemExit(f"{failure_context}，且无法恢复 `integration_status_checked_before_merge`：{exc}") from exc
 
 
 def extract_reviewer_rubric_excerpt(text: str) -> str:
@@ -284,16 +510,20 @@ def fetch_issue_context(issue_number: int) -> dict[str, object]:
         return {
             "identity": [f"- Issue: #{issue_number}", "- issue 上下文暂不可用"],
             "summary": "issue 内容暂不可用。",
+            "canonical_integration": {},
         }
 
     payload = json.loads(completed.stdout or "{}")
     body = str(payload.get("body") or "").strip()
+    canonical_integration = extract_issue_canonical_integration_fields(body)
     identity = [
         f"- Issue: #{payload.get('number', issue_number)}",
         f"- 标题: {payload.get('title', '')}",
         f"- 链接: {payload.get('url', '')}",
     ]
     sections = extract_named_markdown_sections(body, ISSUE_CONTEXT_HEADINGS)
+    if not sections:
+        sections = extract_issue_summary_sections(body)
     if sections:
         summary_parts: list[str] = []
         for heading in ISSUE_CONTEXT_HEADINGS:
@@ -304,7 +534,44 @@ def fetch_issue_context(issue_number: int) -> dict[str, object]:
         summary = "\n".join(summary_parts).strip()
     else:
         summary = body or "无 issue 正文。"
-    return {"identity": identity, "summary": summary}
+    return {"identity": identity, "summary": summary, "canonical_integration": canonical_integration}
+
+
+def issue_number_from_meta(meta: dict) -> int | None:
+    body_context = parse_item_context_from_body(str(meta.get("body") or ""))
+    issue_text = str(body_context.get("issue", "")).strip().lstrip("#")
+    if not issue_text:
+        return None
+    try:
+        return int(issue_text)
+    except ValueError:
+        return None
+
+
+def resolve_issue_canonical_integration(meta: dict) -> tuple[int | None, dict[str, str]]:
+    cached_issue_number = meta.get("_issue_canonical_issue_number")
+    cached_payload = meta.get("_issue_canonical_integration")
+    cached_error = meta.get("_issue_canonical_integration_error")
+    if isinstance(cached_payload, dict):
+        if cached_error is not None:
+            meta["_issue_canonical_integration_error"] = str(cached_error)
+        return (int(cached_issue_number) if isinstance(cached_issue_number, int) else None), {
+            str(key): str(value) for key, value in cached_payload.items()
+        }
+
+    issue_number = issue_number_from_meta(meta)
+    if issue_number is None:
+        meta["_issue_canonical_issue_number"] = None
+        meta["_issue_canonical_integration"] = {}
+        meta["_issue_canonical_integration_error"] = None
+        return None, {}
+
+    resolution = validate_issue_fetch(issue_number, allow_missing_payload=True)
+    canonical = resolution.canonical
+    meta["_issue_canonical_issue_number"] = issue_number
+    meta["_issue_canonical_integration"] = canonical
+    meta["_issue_canonical_integration_error"] = resolution.error
+    return issue_number, canonical
 
 
 def fetch_diff_stats(worktree_dir: Path, base_ref: str) -> tuple[list[str], str]:
@@ -412,15 +679,20 @@ def build_item_context_summary(meta: dict, repo_root: Path) -> tuple[dict[str, s
 
 def build_review_context(meta: dict, worktree_dir: Path) -> dict[str, object]:
     base_ref = meta["baseRefName"]
+    body = str(meta.get("body") or "")
     raw_sections = parse_all_markdown_sections(str(meta.get("body") or ""))
     sections = parse_markdown_sections(str(meta.get("body") or ""))
     changed_files, diff_stat = fetch_diff_stats(worktree_dir, base_ref)
     item_context, context_notes, related_paths = build_item_context_summary(meta, worktree_dir)
-    issue_number = 0
-    try:
-        issue_number = int(str(item_context.get("issue", "")).strip())
-    except ValueError:
-        issue_number = 0
+    issue_number, issue_canonical = resolve_issue_canonical_integration(meta)
+    issue_error = str(meta.get("_issue_canonical_integration_error") or "")
+    integration_payload = parse_pr_integration_check(body)
+    pr_integration_ref = str(integration_payload.get("integration_ref") or "").strip() if integration_payload else ""
+    issue_integration_ref = str(issue_canonical.get("integration_ref") or "").strip()
+    snapshot_ref = pr_integration_ref if integration_ref_is_checkable(pr_integration_ref) else ""
+    if not snapshot_ref and integration_ref_is_checkable(issue_integration_ref):
+        snapshot_ref = issue_integration_ref
+    integration_ref_live = fetch_integration_ref_live_state(snapshot_ref) if snapshot_ref else {}
     needs_issue_context = bool(issue_number) and not sections.get("issue_summary")
     related_paths.extend(path for path in changed_files if path.startswith("docs/specs/"))
     related_paths.extend(path for path in changed_files if path.startswith("docs/decisions/"))
@@ -435,10 +707,17 @@ def build_review_context(meta: dict, worktree_dir: Path) -> dict[str, object]:
             f"- 头部提交: {meta['headRefOid']}",
             f"- 头部分支: {meta.get('headRefName', '')}",
         ],
-        "issue_context": fetch_issue_context(issue_number) if needs_issue_context else {"identity": [], "summary": ""},
+        "issue_context": fetch_issue_context(issue_number) if needs_issue_context else {"identity": [], "summary": "", "canonical_integration": {}},
         "item_context": item_context,
         "raw_sections": raw_sections,
         "pr_sections": sections,
+        "integration_review_packet": build_review_packet(
+            body,
+            issue_number=issue_number,
+            issue_canonical=issue_canonical,
+            issue_error=issue_error,
+            integration_ref_live=integration_ref_live,
+        ),
         "changed_files": changed_files,
         "diff_stat": diff_stat,
         "related_paths": related_paths,
@@ -561,6 +840,9 @@ def build_prompt(meta: dict, worktree_dir: Path) -> str:
             str(context["diff_stat"]),
         ]
     )
+    integration_packet = context.get("integration_review_packet") or {}
+    if integration_packet:
+        lines.extend(["", "Integration Review Packet：", *render_review_packet_lines(integration_packet)])
 
     append_optional_section(lines, "PR 关联事项补充：", item_context_supplement)
     lines.extend(["", "风险摘要：", sections.get("risk", "未提供结构化风险摘要。")])
@@ -727,10 +1009,24 @@ def review_once(pr_number: int, *, post: bool, json_output: str | None) -> tuple
         cleanup(temp_dir)
 
 
-def merge_if_safe(pr_number: int, *, post: bool, delete_branch: bool, refresh_review: bool) -> int:
+def merge_if_safe(
+    pr_number: int,
+    *,
+    post: bool,
+    delete_branch: bool,
+    refresh_review: bool,
+    confirm_integration_recheck: bool = False,
+) -> int:
     require_auth()
     current = pr_meta(pr_number)
-    payload = None if refresh_review else find_latest_guardian_result(pr_number, current["headRefOid"])
+    original_body = str(current.get("body") or "")
+    reviewed_body = original_body
+    payload = None if refresh_review else find_latest_guardian_result(
+        pr_number,
+        current["headRefOid"],
+        body=original_body,
+        require_body_bound=True,
+    )
 
     if payload:
         print(f"复用已有 guardian verdict: {payload['verdict']} @ {payload['head_sha']}")
@@ -740,10 +1036,13 @@ def merge_if_safe(pr_number: int, *, post: bool, delete_branch: bool, refresh_re
             "summary": payload.get("summary", ""),
         }
         reviewed_head_sha = payload["head_sha"]
+        guardian_verdict_body_bound = payload.get("schema_version") == 2
     else:
         meta, result = review_once(pr_number, post=post, json_output=None)
         reviewed_head_sha = meta["headRefOid"]
+        reviewed_body = str(meta.get("body") or "")
         current = pr_meta(pr_number)
+        guardian_verdict_body_bound = True
 
     if result["verdict"] != "APPROVE":
         raise SystemExit("guardian 未给出 APPROVE，拒绝合并。")
@@ -754,8 +1053,101 @@ def merge_if_safe(pr_number: int, *, post: bool, delete_branch: bool, refresh_re
         raise SystemExit("PR 仍为 Draft，拒绝合并。")
     if current["headRefOid"] != reviewed_head_sha:
         raise SystemExit("审查后 PR HEAD 已变化，拒绝合并。")
+    if guardian_verdict_body_bound and str(current.get("body") or "") != reviewed_body:
+        raise SystemExit("guardian 审查后 PR 描述已变化，拒绝合并。")
     if not all_checks_pass(pr_number):
         raise SystemExit("GitHub checks 未全部通过，拒绝合并。")
+    merge_time_integration_recheck_recorded = False
+    previous_merge_recheck_value: str | None = None
+    if merge_gate_requires_integration_recheck(current):
+        if not confirm_integration_recheck:
+            raise SystemExit(
+                "`merge_gate=integration_check_required` 时，进入 `merge_pr` 必须显式传入 "
+                "`--confirm-integration-recheck`，并在该步骤记录 merge 前 integration 复核。"
+            )
+        preview_current = dict(current)
+        preview_current["body"] = set_integration_status_checked_before_merge(str(current.get("body") or ""), "yes")
+        preview_errors = integration_merge_gate_errors(preview_current, require_live_state=True)
+        if preview_errors:
+            detail = "\n".join(f"- {item}" for item in preview_errors)
+            raise SystemExit(f"integration merge gate 未满足，拒绝合并：\n{detail}")
+        current, previous_merge_recheck_value = record_merge_time_integration_recheck(pr_number, current)
+        merge_time_integration_recheck_recorded = True
+        if current["headRefOid"] != reviewed_head_sha:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="merge 前 integration 复核后 PR HEAD 已变化",
+            )
+            raise SystemExit("merge 前 integration 复核后 PR HEAD 已变化，拒绝合并。")
+    if merge_time_integration_recheck_recorded and guardian_verdict_body_bound:
+        try:
+            refreshed_meta, refreshed_result = review_once(pr_number, post=post, json_output=None)
+        except (CommandError, SystemExit) as exc:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="merge 前重跑 guardian 失败",
+            )
+            raise SystemExit(f"merge 前重跑 guardian 失败，拒绝合并：{exc}") from exc
+        if refreshed_result["verdict"] != "APPROVE":
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="merge 前重跑 guardian 未通过",
+            )
+            raise SystemExit("merge 前重跑 guardian 未给出 APPROVE，拒绝合并。")
+        if not refreshed_result["safe_to_merge"]:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="merge 前重跑 guardian 判定不安全",
+            )
+            raise SystemExit("merge 前重跑 guardian 判定不安全，拒绝合并。")
+        reviewed_head_sha = refreshed_meta["headRefOid"]
+        current = pr_meta(pr_number)
+        if current["headRefOid"] != reviewed_head_sha:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="merge 前重跑 guardian 后 PR HEAD 已变化",
+            )
+            raise SystemExit("merge 前重跑 guardian 后 PR HEAD 已变化，拒绝合并。")
+        if str(current.get("body") or "") != str(refreshed_meta.get("body") or ""):
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="merge 前重跑 guardian 后 PR 描述已变化",
+            )
+            raise SystemExit("merge 前重跑 guardian 后 PR 描述已变化，拒绝合并。")
+    integration_errors = integration_merge_gate_errors(current, require_live_state=True)
+    if integration_errors:
+        if merge_time_integration_recheck_recorded:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="integration merge gate 校验失败后无法保持 PR 元数据一致",
+            )
+        detail = "\n".join(f"- {item}" for item in integration_errors)
+        raise SystemExit(f"integration merge gate 未满足，拒绝合并：\n{detail}")
+    latest_before_merge = pr_meta(pr_number)
+    if latest_before_merge["headRefOid"] != current["headRefOid"]:
+        if merge_time_integration_recheck_recorded:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="执行 `gh pr merge` 前 PR HEAD 已变化",
+            )
+        raise SystemExit("执行 `gh pr merge` 前 PR HEAD 已变化，拒绝合并。")
+    if str(latest_before_merge.get("body") or "") != str(current.get("body") or ""):
+        if merge_time_integration_recheck_recorded:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="执行 `gh pr merge` 前 PR 描述已变化",
+            )
+        raise SystemExit("执行 `gh pr merge` 前 PR 描述已变化，拒绝合并。")
+    current = latest_before_merge
 
     command = [
         "gh",
@@ -768,7 +1160,16 @@ def merge_if_safe(pr_number: int, *, post: bool, delete_branch: bool, refresh_re
     ]
     if delete_branch:
         command.append("--delete-branch")
-    run(command, cwd=REPO_ROOT)
+    try:
+        run(command, cwd=REPO_ROOT)
+    except CommandError:
+        if merge_time_integration_recheck_recorded:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="`gh pr merge` 失败",
+            )
+        raise
     return 0
 
 
@@ -782,6 +1183,7 @@ def main(argv: list[str] | None = None) -> int:
         post=args.post_review,
         delete_branch=args.delete_branch,
         refresh_review=args.refresh_review,
+        confirm_integration_recheck=args.confirm_integration_recheck,
     )
 
 

--- a/scripts/pr_guardian.py
+++ b/scripts/pr_guardian.py
@@ -413,9 +413,16 @@ def record_merge_time_integration_recheck(pr_number: int, meta: dict) -> tuple[d
         try:
             latest = pr_meta(pr_number)
         except (CommandError, SystemExit):
+            try:
+                update_pr_body(pr_number, latest_body)
+            except (CommandError, SystemExit) as restore_exc:
+                raise SystemExit(
+                    "merge 前写入 `integration_status_checked_before_merge=yes` 后，无法重新读取最新 PR 描述，"
+                    f"且恢复旧值失败：{restore_exc}"
+                ) from restore_exc
             raise SystemExit(
-                "merge 前写入 `integration_status_checked_before_merge=yes` 后，无法重新读取最新 PR 描述；"
-                "为避免覆盖并发编辑，当前不会尝试自动恢复，请人工复核 PR 正文。"
+                "merge 前写入 `integration_status_checked_before_merge=yes` 后，无法重新读取最新 PR 描述，"
+                "已回滚到旧值，请人工复核后重试。"
             )
     return latest, previous_value
 
@@ -501,7 +508,7 @@ def extract_named_markdown_sections(body: str, headings: tuple[str, ...]) -> dic
 
 def fetch_issue_context(issue_number: int) -> dict[str, object]:
     completed = run(
-        ["gh", "issue", "view", str(issue_number), "--json", "number,title,body,url"],
+        ["gh", "issue", "view", str(issue_number), "--repo", default_github_repo(), "--json", "number,title,body,url"],
         cwd=REPO_ROOT,
         check=False,
     )
@@ -1139,6 +1146,14 @@ def merge_if_safe(
             )
         raise SystemExit("执行 `gh pr merge` 前 PR 描述已变化，拒绝合并。")
     current = latest_before_merge
+    if not all_checks_pass(pr_number):
+        if merge_time_integration_recheck_recorded:
+            restore_merge_time_integration_recheck_or_die(
+                pr_number,
+                previous_merge_recheck_value or "no",
+                failure_context="执行 `gh pr merge` 前 GitHub checks 已变化",
+            )
+        raise SystemExit("执行 `gh pr merge` 前 GitHub checks 未全部通过，拒绝合并。")
 
     command = [
         "gh",

--- a/scripts/pr_guardian.py
+++ b/scripts/pr_guardian.py
@@ -26,7 +26,6 @@ from scripts.common import (
     dump_json,
     ensure_parent,
     format_changed_files,
-    integration_ref_is_checkable,
     load_json,
     require_cli,
     run,
@@ -686,13 +685,6 @@ def build_review_context(meta: dict, worktree_dir: Path) -> dict[str, object]:
     item_context, context_notes, related_paths = build_item_context_summary(meta, worktree_dir)
     issue_number, issue_canonical = resolve_issue_canonical_integration(meta)
     issue_error = str(meta.get("_issue_canonical_integration_error") or "")
-    integration_payload = parse_pr_integration_check(body)
-    pr_integration_ref = str(integration_payload.get("integration_ref") or "").strip() if integration_payload else ""
-    issue_integration_ref = str(issue_canonical.get("integration_ref") or "").strip()
-    snapshot_ref = pr_integration_ref if integration_ref_is_checkable(pr_integration_ref) else ""
-    if not snapshot_ref and integration_ref_is_checkable(issue_integration_ref):
-        snapshot_ref = issue_integration_ref
-    integration_ref_live = fetch_integration_ref_live_state(snapshot_ref) if snapshot_ref else {}
     needs_issue_context = bool(issue_number) and not sections.get("issue_summary")
     related_paths.extend(path for path in changed_files if path.startswith("docs/specs/"))
     related_paths.extend(path for path in changed_files if path.startswith("docs/decisions/"))
@@ -716,7 +708,6 @@ def build_review_context(meta: dict, worktree_dir: Path) -> dict[str, object]:
             issue_number=issue_number,
             issue_canonical=issue_canonical,
             issue_error=issue_error,
-            integration_ref_live=integration_ref_live,
         ),
         "changed_files": changed_files,
         "diff_stat": diff_stat,

--- a/tests/governance/test_governance_status.py
+++ b/tests/governance/test_governance_status.py
@@ -218,6 +218,62 @@ class GovernanceStatusTests(unittest.TestCase):
         self.assertIn("integration_ref_live_errors=1", text_output)
         self.assertIn("联合验收状态未就绪", text_output)
 
+    def test_pr_status_without_integration_check_still_surfaces_issue_live_gate_failures(self) -> None:
+        pr_body = "\n".join(
+            [
+                "Issue: #105",
+                "item_key: `GOV-0105-integration-governance-baseline`",
+                "item_type: `GOV`",
+                "release: `governance-baseline`",
+                "sprint: `integration-governance`",
+            ]
+        )
+        resolution = type(
+            "Resolution",
+            (),
+            {
+                "canonical": {
+                    "integration_touchpoint": "active",
+                    "shared_contract_changed": "yes",
+                    "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "external_dependency": "both",
+                    "merge_gate": "integration_check_required",
+                    "contract_surface": "runtime_modes",
+                    "joint_acceptance_needed": "yes",
+                },
+                "error": None,
+            },
+        )()
+        with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
+            with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):
+                with patch("scripts.governance_status.load_worktree_state", return_value={"worktrees": {"k": {"branch": "feature/x", "key": "k", "issue": 105}}}):
+                    with patch(
+                        "scripts.governance_status.fetch_pr_meta",
+                        return_value={"headRefOid": "sha-1", "headRefName": "feature/x", "body": pr_body},
+                    ):
+                        with patch("scripts.governance_status.find_latest_guardian_result", return_value={"verdict": "APPROVE", "head_sha": "sha-1"}):
+                            with patch("scripts.governance_status.fetch_checks_summary", return_value=[]):
+                                with patch("scripts.governance_status.validate_issue_fetch", return_value=resolution):
+                                    with patch(
+                                        "scripts.governance_status.fetch_integration_ref_live_state",
+                                        return_value={
+                                            "source": "project_item",
+                                            "status": "review",
+                                            "dependency_order": "parallel",
+                                            "joint_acceptance": "pending",
+                                            "owner_repo": "joint",
+                                            "contract_status": "reviewing",
+                                            "error": "",
+                                        },
+                                    ):
+                                        payload = governance_status.build_status_payload(pr_number=115)
+
+        self.assertEqual(
+            payload["integration"]["integration_ref_live_errors"],
+            ["`integration_ref` 联合验收状态未就绪（当前 `pending`），拒绝继续。"],
+        )
+        self.assertTrue(payload["integration"]["comparison_errors"])
+
     def test_issue_status_reports_issue_canonical_without_pr_only_errors(self) -> None:
         resolution = type(
             "Resolution",

--- a/tests/governance/test_governance_status.py
+++ b/tests/governance/test_governance_status.py
@@ -152,6 +152,115 @@ class GovernanceStatusTests(unittest.TestCase):
         self.assertEqual(payload["integration"]["integration_ref_live"]["status"], "review")
         fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
 
+    def test_pr_status_surfaces_live_integration_validation_failures(self) -> None:
+        pr_body = "\n".join(
+            [
+                "Issue: #105",
+                "item_key: `GOV-0105-integration-governance-baseline`",
+                "item_type: `GOV`",
+                "release: `governance-baseline`",
+                "sprint: `integration-governance`",
+                "## integration_check",
+                "",
+                "- integration_touchpoint: active",
+                "- shared_contract_changed: yes",
+                "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                "- external_dependency: both",
+                "- merge_gate: integration_check_required",
+                "- contract_surface: runtime_modes",
+                "- joint_acceptance_needed: yes",
+                "- integration_status_checked_before_pr: yes",
+                "- integration_status_checked_before_merge: no",
+            ]
+        )
+        resolution = type(
+            "Resolution",
+            (),
+            {
+                "canonical": {
+                    "integration_touchpoint": "active",
+                    "shared_contract_changed": "yes",
+                    "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "external_dependency": "both",
+                    "merge_gate": "integration_check_required",
+                    "contract_surface": "runtime_modes",
+                    "joint_acceptance_needed": "yes",
+                },
+                "error": None,
+            },
+        )()
+        with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
+            with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):
+                with patch("scripts.governance_status.load_worktree_state", return_value={"worktrees": {"k": {"branch": "feature/x", "key": "k", "issue": 105}}}):
+                    with patch(
+                        "scripts.governance_status.fetch_pr_meta",
+                        return_value={"headRefOid": "sha-1", "headRefName": "feature/x", "body": pr_body},
+                    ):
+                        with patch("scripts.governance_status.find_latest_guardian_result", return_value={"verdict": "APPROVE", "head_sha": "sha-1"}):
+                            with patch("scripts.governance_status.fetch_checks_summary", return_value=[]):
+                                with patch("scripts.governance_status.validate_issue_fetch", return_value=resolution):
+                                    with patch(
+                                        "scripts.governance_status.fetch_integration_ref_live_state",
+                                        return_value={
+                                            "source": "project_item",
+                                            "status": "review",
+                                            "dependency_order": "parallel",
+                                            "joint_acceptance": "pending",
+                                            "owner_repo": "joint",
+                                            "contract_status": "reviewing",
+                                            "error": "",
+                                        },
+                                    ):
+                                        payload = governance_status.build_status_payload(pr_number=115)
+
+        self.assertEqual(payload["integration"]["integration_ref_live_errors"], ["`integration_ref` 联合验收状态未就绪（当前 `pending`），拒绝继续。"])
+        text_output = governance_status.render_text(payload)
+        self.assertIn("integration_ref_live_errors=1", text_output)
+        self.assertIn("联合验收状态未就绪", text_output)
+
+    def test_issue_status_reports_issue_canonical_without_pr_only_errors(self) -> None:
+        resolution = type(
+            "Resolution",
+            (),
+            {
+                "canonical": {
+                    "integration_touchpoint": "active",
+                    "shared_contract_changed": "yes",
+                    "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "external_dependency": "both",
+                    "merge_gate": "integration_check_required",
+                    "contract_surface": "runtime_modes",
+                    "joint_acceptance_needed": "yes",
+                },
+                "error": None,
+            },
+        )()
+        with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
+            with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):
+                with patch("scripts.governance_status.load_worktree_state", return_value={"worktrees": {}}):
+                    with patch("scripts.governance_status.matching_exec_plan_for_issue", return_value={}):
+                        with patch("scripts.governance_status.validate_issue_fetch", return_value=resolution):
+                            with patch(
+                                "scripts.governance_status.fetch_integration_ref_live_state",
+                                return_value={
+                                    "source": "project_item",
+                                    "status": "review",
+                                    "dependency_order": "parallel",
+                                    "joint_acceptance": "ready",
+                                    "owner_repo": "joint",
+                                    "contract_status": "reviewing",
+                                    "error": "",
+                                },
+                            ):
+                                payload = governance_status.build_status_payload(issue_number=105)
+
+        self.assertEqual(payload["integration"]["issue_number"], 105)
+        self.assertEqual(payload["integration"]["pr_canonical"], {})
+        self.assertEqual(payload["integration"]["comparison_errors"], [])
+        self.assertEqual(payload["integration"]["merge_validation_errors"], [])
+        self.assertEqual(payload["integration"]["integration_ref_live_errors"], [])
+        self.assertEqual(payload["integration"]["merge_gate"], "integration_check_required")
+
     def test_pr_body_missing_item_context_fields_returns_empty(self) -> None:
         with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
             with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):

--- a/tests/governance/test_governance_status.py
+++ b/tests/governance/test_governance_status.py
@@ -63,6 +63,7 @@ class GovernanceStatusTests(unittest.TestCase):
             7,
             "sha-1",
             body=pr_body,
+            require_body_bound=True,
             path=governance_status.GUARDIAN_STATE_FILE,
         )
         self.assertEqual(payload["guardian"]["schema_version"], 1)

--- a/tests/governance/test_governance_status.py
+++ b/tests/governance/test_governance_status.py
@@ -43,7 +43,7 @@ class GovernanceStatusTests(unittest.TestCase):
         self.assertEqual(payload["checks"][0]["name"], "check")
         self.assertEqual(payload["item_context"]["item_key"], "GOV-0015-item-context-gate")
 
-    def test_pr_status_passes_current_body_to_guardian_lookup_and_keeps_schema_v1_payload(self) -> None:
+    def test_pr_status_passes_current_body_to_guardian_lookup_and_requires_body_bound_cache(self) -> None:
         pr_body = "Issue: #19\nitem_key: `GOV-0015-item-context-gate`\nitem_type: `GOV`\nrelease: `v0.1.0`\nsprint: `2026-S14`\n"
         with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
             with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):
@@ -54,7 +54,7 @@ class GovernanceStatusTests(unittest.TestCase):
                     ):
                         with patch(
                             "scripts.governance_status.find_latest_guardian_result",
-                            return_value={"schema_version": 1, "verdict": "APPROVE", "head_sha": "sha-1"},
+                            return_value=None,
                         ) as find_latest_guardian_result_mock:
                             with patch("scripts.governance_status.fetch_checks_summary", return_value=[]):
                                 payload = governance_status.build_status_payload(pr_number=7)
@@ -66,8 +66,7 @@ class GovernanceStatusTests(unittest.TestCase):
             require_body_bound=True,
             path=governance_status.GUARDIAN_STATE_FILE,
         )
-        self.assertEqual(payload["guardian"]["schema_version"], 1)
-        self.assertEqual(payload["guardian"]["verdict"], "APPROVE")
+        self.assertEqual(payload["guardian"], {})
 
     def test_pr_status_exposes_integration_contract_and_live_state(self) -> None:
         pr_body = "\n".join(

--- a/tests/governance/test_governance_status.py
+++ b/tests/governance/test_governance_status.py
@@ -43,6 +43,31 @@ class GovernanceStatusTests(unittest.TestCase):
         self.assertEqual(payload["checks"][0]["name"], "check")
         self.assertEqual(payload["item_context"]["item_key"], "GOV-0015-item-context-gate")
 
+    def test_pr_status_passes_current_body_to_guardian_lookup_and_keeps_schema_v1_payload(self) -> None:
+        pr_body = "Issue: #19\nitem_key: `GOV-0015-item-context-gate`\nitem_type: `GOV`\nrelease: `v0.1.0`\nsprint: `2026-S14`\n"
+        with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
+            with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):
+                with patch("scripts.governance_status.load_worktree_state", return_value={"worktrees": {"k": {"branch": "feature/x", "key": "k", "issue": 19}}}):
+                    with patch(
+                        "scripts.governance_status.fetch_pr_meta",
+                        return_value={"headRefOid": "sha-1", "headRefName": "feature/x", "body": pr_body},
+                    ):
+                        with patch(
+                            "scripts.governance_status.find_latest_guardian_result",
+                            return_value={"schema_version": 1, "verdict": "APPROVE", "head_sha": "sha-1"},
+                        ) as find_latest_guardian_result_mock:
+                            with patch("scripts.governance_status.fetch_checks_summary", return_value=[]):
+                                payload = governance_status.build_status_payload(pr_number=7)
+
+        find_latest_guardian_result_mock.assert_called_once_with(
+            7,
+            "sha-1",
+            body=pr_body,
+            path=governance_status.GUARDIAN_STATE_FILE,
+        )
+        self.assertEqual(payload["guardian"]["schema_version"], 1)
+        self.assertEqual(payload["guardian"]["verdict"], "APPROVE")
+
     def test_pr_body_missing_item_context_fields_returns_empty(self) -> None:
         with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
             with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):

--- a/tests/governance/test_governance_status.py
+++ b/tests/governance/test_governance_status.py
@@ -273,6 +273,10 @@ class GovernanceStatusTests(unittest.TestCase):
             ["`integration_ref` 联合验收状态未就绪（当前 `pending`），拒绝继续。"],
         )
         self.assertTrue(payload["integration"]["comparison_errors"])
+        self.assertEqual(payload["integration"]["merge_gate"], "integration_check_required")
+        self.assertTrue(payload["integration"]["merge_gate_requires_recheck"])
+        text_output = governance_status.render_text(payload)
+        self.assertIn("merge_gate=integration_check_required", text_output)
 
     def test_issue_status_reports_issue_canonical_without_pr_only_errors(self) -> None:
         resolution = type(

--- a/tests/governance/test_governance_status.py
+++ b/tests/governance/test_governance_status.py
@@ -68,6 +68,90 @@ class GovernanceStatusTests(unittest.TestCase):
         self.assertEqual(payload["guardian"]["schema_version"], 1)
         self.assertEqual(payload["guardian"]["verdict"], "APPROVE")
 
+    def test_pr_status_exposes_integration_contract_and_live_state(self) -> None:
+        pr_body = "\n".join(
+            [
+                "Issue: #105",
+                "item_key: `GOV-0105-integration-governance-baseline`",
+                "item_type: `GOV`",
+                "release: `governance-baseline`",
+                "sprint: `integration-governance`",
+                "## integration_check",
+                "",
+                "- integration_touchpoint: active",
+                "- shared_contract_changed: yes",
+                "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                "- external_dependency: both",
+                "- merge_gate: integration_check_required",
+                "- contract_surface: runtime_modes",
+                "- joint_acceptance_needed: yes",
+                "- integration_status_checked_before_pr: yes",
+                "- integration_status_checked_before_merge: no",
+            ]
+        )
+        with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
+            with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):
+                with patch("scripts.governance_status.load_worktree_state", return_value={"worktrees": {"k": {"branch": "feature/x", "key": "k", "issue": 105}}}):
+                    with patch(
+                        "scripts.governance_status.fetch_pr_meta",
+                        return_value={"headRefOid": "sha-1", "headRefName": "feature/x", "body": pr_body},
+                    ):
+                        with patch("scripts.governance_status.find_latest_guardian_result", return_value={"verdict": "APPROVE", "head_sha": "sha-1"}):
+                            with patch("scripts.governance_status.fetch_checks_summary", return_value=[]):
+                                with patch(
+                                    "scripts.governance_status.load_item_context_from_exec_plan",
+                                    return_value={
+                                        "Issue": "105",
+                                        "item_key": "GOV-0105-integration-governance-baseline",
+                                        "item_type": "GOV",
+                                        "release": "governance-baseline",
+                                        "sprint": "integration-governance",
+                                        "exec_plan": "docs/exec-plans/GOV-0105-integration-governance-baseline.md",
+                                    },
+                                ):
+                                    with patch(
+                                        "scripts.governance_status.active_exec_plans_for_issue",
+                                        return_value=[{"item_key": "GOV-0105-integration-governance-baseline"}],
+                                    ):
+                                        with patch(
+                                            "scripts.governance_status.validate_issue_fetch",
+                                            return_value=type(
+                                                "Resolution",
+                                                (),
+                                                {
+                                                    "canonical": {
+                                                        "integration_touchpoint": "active",
+                                                        "shared_contract_changed": "yes",
+                                                        "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                                                        "external_dependency": "both",
+                                                        "merge_gate": "integration_check_required",
+                                                        "contract_surface": "runtime_modes",
+                                                        "joint_acceptance_needed": "yes",
+                                                    },
+                                                    "error": None,
+                                                },
+                                            )(),
+                                        ):
+                                            with patch(
+                                                "scripts.governance_status.fetch_integration_ref_live_state",
+                                                return_value={
+                                                    "source": "project_item",
+                                                    "status": "review",
+                                                    "dependency_order": "parallel",
+                                                    "joint_acceptance": "ready",
+                                                    "owner_repo": "joint",
+                                                    "contract_status": "reviewing",
+                                                    "error": "",
+                                                },
+                                            ) as fetch_live_mock:
+                                                payload = governance_status.build_status_payload(pr_number=115)
+
+        self.assertEqual(payload["integration"]["issue_number"], 105)
+        self.assertEqual(payload["integration"]["merge_gate"], "integration_check_required")
+        self.assertEqual(payload["integration"]["pr_canonical"]["integration_ref"], "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+        self.assertEqual(payload["integration"]["integration_ref_live"]["status"], "review")
+        fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+
     def test_pr_body_missing_item_context_fields_returns_empty(self) -> None:
         with patch("scripts.governance_status.load_guardian_state", return_value={"prs": {}}):
             with patch("scripts.governance_status.load_review_poller_state", return_value={"prs": {}}):

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -191,7 +191,7 @@ class IntegrationContractTests(unittest.TestCase):
             "error": "",
         },
     )
-    def test_build_review_packet_collapses_equivalent_issue_and_project_item_refs(self, fetch_live_mock) -> None:
+    def test_build_review_packet_keeps_cross_form_integration_ref_mismatch_local_only(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -221,16 +221,19 @@ class IntegrationContractTests(unittest.TestCase):
             issue_error="",
         )
 
-        self.assertEqual(packet["comparison_errors"], [])
+        self.assertEqual(
+            packet["comparison_errors"],
+            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
+        )
         self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
-        self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
-        self.assertGreaterEqual(fetch_live_mock.call_count, 1)
+        self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
+        fetch_live_mock.assert_not_called()
 
     @patch(
         "scripts.integration_contract.fetch_integration_ref_live_state",
         return_value={"source": "project_item", "error": "lookup failed"},
     )
-    def test_build_review_packet_fail_closed_when_cross_form_ref_cannot_be_resolved(self, fetch_live_mock) -> None:
+    def test_build_review_packet_keeps_unresolved_cross_form_ref_comparison_local_only(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -264,7 +267,7 @@ class IntegrationContractTests(unittest.TestCase):
             packet["comparison_errors"],
             ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
         )
-        self.assertGreaterEqual(fetch_live_mock.call_count, 1)
+        fetch_live_mock.assert_not_called()
 
     def test_default_github_repo_uses_repo_root_name_when_env_missing(self) -> None:
         default_github_repo.cache_clear()

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -692,6 +692,9 @@ class IntegrationContractTests(unittest.TestCase):
         self.assertEqual(payload["joint_acceptance"], "ready")
         self.assertEqual(payload["project_url"], "https://github.com/orgs/MC-and-his-Agents/projects/3")
         self.assertEqual(payload["title"], "integration baseline")
+        self.assertEqual(payload["content_type"], "issue")
+        self.assertEqual(payload["content_repo"], "MC-and-his-Agents/Syvert")
+        self.assertEqual(payload["content_issue_number"], "105")
 
     def test_fetch_integration_ref_live_state_rejects_issue_without_integration_project_item(self) -> None:
         graphql_payload = {

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -191,7 +191,7 @@ class IntegrationContractTests(unittest.TestCase):
             "error": "",
         },
     )
-    def test_build_review_packet_accepts_cross_form_integration_ref_without_live_resolution(self, fetch_live_mock) -> None:
+    def test_build_review_packet_rejects_cross_form_integration_ref_without_live_resolution(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -221,7 +221,10 @@ class IntegrationContractTests(unittest.TestCase):
             issue_error="",
         )
 
-        self.assertEqual(packet["comparison_errors"], [])
+        self.assertEqual(
+            packet["comparison_errors"],
+            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
+        )
         self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
         self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
         fetch_live_mock.assert_not_called()
@@ -230,7 +233,7 @@ class IntegrationContractTests(unittest.TestCase):
         "scripts.integration_contract.fetch_integration_ref_live_state",
         return_value={"source": "project_item", "error": "lookup failed"},
     )
-    def test_build_review_packet_defers_unresolved_cross_form_ref_to_live_validators(self, fetch_live_mock) -> None:
+    def test_build_review_packet_rejects_unresolved_cross_form_ref_without_live_resolution(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -260,7 +263,10 @@ class IntegrationContractTests(unittest.TestCase):
             issue_error="",
         )
 
-        self.assertEqual(packet["comparison_errors"], [])
+        self.assertEqual(
+            packet["comparison_errors"],
+            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
+        )
         fetch_live_mock.assert_not_called()
 
     def test_default_github_repo_uses_repo_root_name_when_env_missing(self) -> None:

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -613,6 +613,25 @@ class IntegrationContractTests(unittest.TestCase):
 
         self.assertIn("无法解析", resolution.error or "")
 
+    @patch("scripts.integration_contract.default_github_repo", return_value="MC-and-his-Agents/Syvert")
+    def test_validate_issue_fetch_binds_issue_reads_to_canonical_repo(self, default_repo_mock) -> None:
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value = subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=0,
+                stdout=json.dumps({"body": "### integration_touchpoint\n\nnone\n"}),
+                stderr="",
+            )
+
+            validate_issue_fetch(105, allow_missing_payload=True)
+
+        run_mock.assert_called_once_with(
+            ["gh", "issue", "view", "105", "--repo", "MC-and-his-Agents/Syvert", "--json", "body"],
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        default_repo_mock.assert_called_once_with()
+
     def test_integration_ref_is_checkable_matches_project_item_parser_shape(self) -> None:
         self.assertFalse(
             integration_ref_is_checkable("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&foo=itemId=PVTI_test")

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -1016,7 +1016,7 @@ class IntegrationContractTests(unittest.TestCase):
         self.assertEqual(payload["source"], "project_item")
         self.assertIn("canonical integration project item", payload["error"])
 
-    def test_fetch_integration_ref_live_state_rejects_project_item_without_issue_content(self) -> None:
+    def test_fetch_integration_ref_live_state_accepts_project_item_with_draft_issue_content(self) -> None:
         graphql_payload = {
             "data": {
                 "node": {
@@ -1059,6 +1059,8 @@ class IntegrationContractTests(unittest.TestCase):
                     },
                     "content": {
                         "__typename": "DraftIssue",
+                        "title": "Syvert × WebEnvoy integration governance baseline",
+                        "body": "跨仓协调主题；以 Integration Project 为协调真相源。",
                     },
                 }
             }
@@ -1071,7 +1073,68 @@ class IntegrationContractTests(unittest.TestCase):
             payload = fetch_integration_ref_live_state("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
 
         self.assertEqual(payload["source"], "project_item")
-        self.assertIn("必须绑定到可核查的 Issue 内容", payload["error"])
+        self.assertEqual(payload["error"], "")
+        self.assertEqual(payload["content_type"], "draft_issue")
+        self.assertEqual(payload["content_title"], "Syvert × WebEnvoy integration governance baseline")
+        self.assertEqual(payload["status"], "review")
+        self.assertEqual(payload["joint_acceptance"], "ready")
+
+    def test_fetch_integration_ref_live_state_rejects_project_item_without_supported_content(self) -> None:
+        graphql_payload = {
+            "data": {
+                "node": {
+                    "__typename": "ProjectV2Item",
+                    "isArchived": False,
+                    "fieldValues": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "Review",
+                                "field": {"name": "Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "parallel",
+                                "field": {"name": "Dependency Order"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "ready",
+                                "field": {"name": "Joint Acceptance"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "reviewing",
+                                "field": {"name": "Contract Status"},
+                            },
+                            {
+                                "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                "name": "joint",
+                                "field": {"name": "Owner Repo"},
+                            },
+                        ]
+                    },
+                    "project": {
+                        "url": "https://github.com/orgs/MC-and-his-Agents/projects/3",
+                        "number": 3,
+                        "title": "Syvert × WebEnvoy Integration",
+                        "owner": {"login": "MC-and-his-Agents"},
+                    },
+                    "content": {
+                        "__typename": "PullRequest",
+                    },
+                }
+            }
+        }
+        with patch("scripts.integration_contract.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = json.dumps(graphql_payload)
+            run_mock.return_value.stderr = ""
+
+            payload = fetch_integration_ref_live_state("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test")
+
+        self.assertEqual(payload["source"], "project_item")
+        self.assertIn("Issue / DraftIssue 内容", payload["error"])
 
     def test_fetch_integration_ref_live_state_rejects_non_canonical_project_item(self) -> None:
         graphql_payload = {

--- a/tests/governance/test_integration_contract.py
+++ b/tests/governance/test_integration_contract.py
@@ -191,7 +191,7 @@ class IntegrationContractTests(unittest.TestCase):
             "error": "",
         },
     )
-    def test_build_review_packet_keeps_cross_form_integration_ref_mismatch_local_only(self, fetch_live_mock) -> None:
+    def test_build_review_packet_accepts_cross_form_integration_ref_without_live_resolution(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -221,10 +221,7 @@ class IntegrationContractTests(unittest.TestCase):
             issue_error="",
         )
 
-        self.assertEqual(
-            packet["comparison_errors"],
-            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
-        )
+        self.assertEqual(packet["comparison_errors"], [])
         self.assertEqual(packet["normalized_issue_canonical"]["integration_ref"], "issue:mc-and-his-agents/syvert#12")
         self.assertEqual(packet["normalized_pr_canonical"]["integration_ref"], "project-item:mc-and-his-agents/3#PVTI_same")
         fetch_live_mock.assert_not_called()
@@ -233,7 +230,7 @@ class IntegrationContractTests(unittest.TestCase):
         "scripts.integration_contract.fetch_integration_ref_live_state",
         return_value={"source": "project_item", "error": "lookup failed"},
     )
-    def test_build_review_packet_keeps_unresolved_cross_form_ref_comparison_local_only(self, fetch_live_mock) -> None:
+    def test_build_review_packet_defers_unresolved_cross_form_ref_to_live_validators(self, fetch_live_mock) -> None:
         packet = build_review_packet(
             "\n".join(
                 [
@@ -263,10 +260,7 @@ class IntegrationContractTests(unittest.TestCase):
             issue_error="",
         )
 
-        self.assertEqual(
-            packet["comparison_errors"],
-            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
-        )
+        self.assertEqual(packet["comparison_errors"], [])
         fetch_live_mock.assert_not_called()
 
     def test_default_github_repo_uses_repo_root_name_when_env_missing(self) -> None:

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from scripts.common import CommandError, default_github_repo, normalize_integration_ref_for_comparison, parse_github_repo_from_remote_url
 from scripts.open_pr import (
@@ -804,6 +804,25 @@ class OpenPrPreflightTests(unittest.TestCase):
         self.assertIn("## Goal", summary)
         self.assertIn("## Scope", summary)
         self.assertIn("## Out of Scope", summary)
+
+    @patch("scripts.open_pr.default_github_repo", return_value="MC-and-his-Agents/Syvert")
+    @patch("scripts.open_pr.run")
+    def test_build_issue_summary_binds_issue_reads_to_canonical_repo(self, run_mock, default_repo_mock) -> None:
+        run_mock.return_value = type(
+            "Completed",
+            (),
+            {"returncode": 0, "stdout": json.dumps({"body": "## Goal\n\n- 对齐 contract"}), "stderr": ""},
+        )()
+
+        summary = build_issue_summary(25)
+
+        self.assertIn("## Goal", summary)
+        run_mock.assert_called_once_with(
+            ["gh", "issue", "view", "25", "--repo", "MC-and-his-Agents/Syvert", "--json", "body"],
+            cwd=ANY,
+            check=False,
+        )
+        default_repo_mock.assert_called_once_with()
 
     def test_extract_issue_summary_sections_supports_issue_form_heading_aliases(self) -> None:
         body = "\n".join(

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -744,7 +744,7 @@ class OpenPrPreflightTests(unittest.TestCase):
             stderr="",
         ),
     )
-    def test_validate_integration_args_rejects_cross_form_issue_and_project_item_refs(self, run_mock, fetch_live_mock) -> None:
+    def test_validate_integration_args_accepts_equivalent_issue_and_project_item_refs(self, run_mock, fetch_live_mock) -> None:
         args = parse_args(
             [
                 "--class",
@@ -772,12 +772,9 @@ class OpenPrPreflightTests(unittest.TestCase):
 
         errors = validate_integration_args(args)
 
-        self.assertEqual(
-            errors,
-            ["`--integration-ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
-        )
+        self.assertEqual(errors, [])
         self.assertGreaterEqual(run_mock.call_count, 1)
-        fetch_live_mock.assert_not_called()
+        self.assertGreaterEqual(fetch_live_mock.call_count, 2)
 
     def test_build_issue_summary_extracts_minimal_high_value_issue_context(self) -> None:
         payload = {

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -978,6 +978,63 @@ class OpenPrPreflightTests(unittest.TestCase):
         self.assertIn("- merge_gate: integration_check_required", body)
         self.assertIn("- contract_surface: runtime_modes", body)
 
+    @patch(
+        "scripts.open_pr.resolve_issue_canonical_integration",
+        return_value=(
+            {
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "MC-and-his-Agents/Syvert#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+            None,
+        ),
+    )
+    @patch(
+        "scripts.open_pr.semantic_integration_ref_identity",
+        side_effect=[
+            ("issue:mc-and-his-agents/syvert#12", True, "issue:mc-and-his-agents/syvert#12"),
+            ("issue:mc-and-his-agents/syvert#12", True, "project-item:mc-and-his-agents/3#PVTI_same"),
+        ],
+    )
+    def test_build_body_canonicalizes_equivalent_integration_ref_to_issue_carrier(self, semantic_identity_mock, resolve_issue_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+                "--integration-status-checked-before-merge",
+                "no",
+            ]
+        )
+
+        body = build_body(args, [])
+
+        self.assertIn("- integration_ref: MC-and-his-Agents/Syvert#12", body)
+        self.assertNotIn("PVTI_same", body)
+        resolve_issue_mock.assert_called_once_with(105)
+        self.assertEqual(semantic_identity_mock.call_count, 2)
+
     def test_inactive_exec_plan_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo = Path(temp_dir)

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -785,6 +785,97 @@ class OpenPrPreflightTests(unittest.TestCase):
         fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same")
 
     @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        return_value={
+            "item_id": "PVTI_same",
+            "organization": "mc-and-his-agents",
+            "project_number": "3",
+            "content_repo": "MC-and-his-Agents/Syvert",
+            "content_issue_number": "12",
+            "error": "",
+        },
+    )
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "body": "\n".join(
+                        [
+                            "### integration_touchpoint",
+                            "",
+                            "active",
+                            "",
+                            "### shared_contract_changed",
+                            "",
+                            "no",
+                            "",
+                            "### integration_ref",
+                            "",
+                            "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same",
+                            "",
+                            "### external_dependency",
+                            "",
+                            "both",
+                            "",
+                            "### merge_gate",
+                            "",
+                            "integration_check_required",
+                            "",
+                            "### contract_surface",
+                            "",
+                            "runtime_modes",
+                            "",
+                            "### joint_acceptance_needed",
+                            "",
+                            "yes",
+                        ]
+                    )
+                }
+            ),
+            stderr="",
+        ),
+    )
+    def test_validate_integration_args_accepts_equivalent_issue_ref_for_project_item_canonical(
+        self, run_mock, fetch_live_mock
+    ) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "MC-and-his-Agents/Syvert#12",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            args.integration_ref,
+            "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same",
+        )
+        fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same")
+
+    @patch(
         "scripts.integration_contract.run",
         return_value=subprocess.CompletedProcess(
             args=["gh"],
@@ -1119,6 +1210,67 @@ class OpenPrPreflightTests(unittest.TestCase):
 
         self.assertIn("- integration_ref: MC-and-his-Agents/Syvert#12", body)
         self.assertNotIn("PVTI_same", body)
+        resolve_issue_mock.assert_called_once_with(105)
+        fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same")
+
+    @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        return_value={
+            "item_id": "PVTI_same",
+            "organization": "mc-and-his-agents",
+            "project_number": "3",
+            "content_repo": "MC-and-his-Agents/Syvert",
+            "content_issue_number": "12",
+            "error": "",
+        },
+    )
+    @patch(
+        "scripts.open_pr.resolve_issue_canonical_integration",
+        return_value=(
+            {
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+            None,
+        ),
+    )
+    def test_build_body_canonicalizes_equivalent_issue_ref_to_project_item_carrier(self, resolve_issue_mock, fetch_live_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "MC-and-his-Agents/Syvert#12",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+                "--integration-status-checked-before-merge",
+                "no",
+            ]
+        )
+
+        body = build_body(args, [])
+
+        self.assertIn("- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same", body)
+        self.assertNotIn("- integration_ref: MC-and-his-Agents/Syvert#12", body)
         resolve_issue_mock.assert_called_once_with(105)
         fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same")
 

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -744,7 +744,7 @@ class OpenPrPreflightTests(unittest.TestCase):
             stderr="",
         ),
     )
-    def test_validate_integration_args_accepts_equivalent_issue_and_project_item_refs(self, run_mock, fetch_live_mock) -> None:
+    def test_validate_integration_args_rejects_cross_form_issue_and_project_item_refs(self, run_mock, fetch_live_mock) -> None:
         args = parse_args(
             [
                 "--class",
@@ -772,9 +772,12 @@ class OpenPrPreflightTests(unittest.TestCase):
 
         errors = validate_integration_args(args)
 
-        self.assertEqual(errors, [])
+        self.assertEqual(
+            errors,
+            ["`--integration-ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
+        )
         self.assertGreaterEqual(run_mock.call_count, 1)
-        self.assertGreaterEqual(fetch_live_mock.call_count, 2)
+        fetch_live_mock.assert_not_called()
 
     def test_build_issue_summary_extracts_minimal_high_value_issue_context(self) -> None:
         payload = {

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -699,7 +699,14 @@ class OpenPrPreflightTests(unittest.TestCase):
 
     @patch(
         "scripts.integration_contract.fetch_integration_ref_live_state",
-        return_value={"item_id": "PVTI_same", "organization": "mc-and-his-agents", "project_number": "3", "error": ""},
+        return_value={
+            "item_id": "PVTI_same",
+            "organization": "mc-and-his-agents",
+            "project_number": "3",
+            "content_repo": "MC-and-his-Agents/Syvert",
+            "content_issue_number": "12",
+            "error": "",
+        },
     )
     @patch(
         "scripts.integration_contract.run",
@@ -775,7 +782,82 @@ class OpenPrPreflightTests(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertGreaterEqual(run_mock.call_count, 1)
         self.assertEqual(args.integration_ref, "MC-and-his-Agents/Syvert#12")
-        fetch_live_mock.assert_not_called()
+        fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same")
+
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "body": "\n".join(
+                        [
+                            "### integration_touchpoint",
+                            "",
+                            "active",
+                            "",
+                            "### shared_contract_changed",
+                            "",
+                            "no",
+                            "",
+                            "### integration_ref",
+                            "",
+                            "MC-and-his-Agents/Syvert#12",
+                            "",
+                            "### external_dependency",
+                            "",
+                            "both",
+                            "",
+                            "### merge_gate",
+                            "",
+                            "integration_check_required",
+                            "",
+                            "### contract_surface",
+                            "",
+                            "runtime_modes",
+                            "",
+                            "### joint_acceptance_needed",
+                            "",
+                            "yes",
+                        ]
+                    )
+                }
+            ),
+            stderr="",
+        ),
+    )
+    def test_validate_integration_args_rejects_non_equivalent_integration_ref_without_rewriting_input(self, run_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "https://github.com/MC-and-his-Agents/WebEnvoy/issues/999",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertIn("`--integration-ref` 与 Issue #105 中的 canonical integration 元数据不一致。", errors)
+        self.assertEqual(args.integration_ref, "https://github.com/MC-and-his-Agents/WebEnvoy/issues/999")
+        self.assertGreaterEqual(run_mock.call_count, 1)
 
     def test_build_issue_summary_extracts_minimal_high_value_issue_context(self) -> None:
         payload = {
@@ -994,7 +1076,18 @@ class OpenPrPreflightTests(unittest.TestCase):
             None,
         ),
     )
-    def test_build_body_canonicalizes_equivalent_integration_ref_to_issue_carrier(self, resolve_issue_mock) -> None:
+    @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        return_value={
+            "item_id": "PVTI_same",
+            "organization": "mc-and-his-agents",
+            "project_number": "3",
+            "content_repo": "MC-and-his-Agents/Syvert",
+            "content_issue_number": "12",
+            "error": "",
+        },
+    )
+    def test_build_body_canonicalizes_equivalent_integration_ref_to_issue_carrier(self, fetch_live_mock, resolve_issue_mock) -> None:
         args = parse_args(
             [
                 "--class",
@@ -1027,6 +1120,7 @@ class OpenPrPreflightTests(unittest.TestCase):
         self.assertIn("- integration_ref: MC-and-his-Agents/Syvert#12", body)
         self.assertNotIn("PVTI_same", body)
         resolve_issue_mock.assert_called_once_with(105)
+        fetch_live_mock.assert_called_once_with("https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same")
 
     def test_inactive_exec_plan_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
+import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
 from unittest.mock import patch
 
-from scripts.common import CommandError
-from scripts.open_pr import build_body, build_issue_summary, parse_args, validate_current_worktree_binding, validate_pr_preflight
+from scripts.common import CommandError, default_github_repo, normalize_integration_ref_for_comparison, parse_github_repo_from_remote_url
+from scripts.open_pr import (
+    build_body,
+    build_issue_summary,
+    extract_issue_canonical_integration_fields,
+    extract_issue_summary_sections,
+    parse_args,
+    validate_current_worktree_binding,
+    validate_integration_args,
+    validate_pr_preflight,
+)
 
 
 def write_exec_plan(
@@ -134,6 +145,637 @@ def write_decision(repo: Path, path: str, *, issue: str, item_key: str) -> None:
 
 
 class OpenPrPreflightTests(unittest.TestCase):
+    def test_parse_github_repo_from_remote_url_supports_https_and_ssh(self) -> None:
+        self.assertEqual(
+            parse_github_repo_from_remote_url("https://github.com/MC-and-his-Agents/Syvert.git"),
+            "MC-and-his-Agents/Syvert",
+        )
+        self.assertEqual(
+            parse_github_repo_from_remote_url("git@github.com:MC-and-his-Agents/Syvert.git"),
+            "MC-and-his-Agents/Syvert",
+        )
+        self.assertEqual(
+            parse_github_repo_from_remote_url("ssh://git@github.com/MC-and-his-Agents/Syvert.git"),
+            "MC-and-his-Agents/Syvert",
+        )
+
+    @patch("scripts.common.default_github_repo", return_value="MC-and-his-Agents/Syvert")
+    def test_normalize_integration_ref_for_comparison_resolves_local_issue_against_repo_slug(self, default_repo_mock) -> None:
+        normalized = normalize_integration_ref_for_comparison("#12")
+
+        self.assertEqual(normalized, "issue:mc-and-his-agents/syvert#12")
+        default_repo_mock.assert_called_once_with()
+
+    @patch("scripts.common.run")
+    def test_default_github_repo_ignores_env_and_remote_drift_without_explicit_override(self, run_mock) -> None:
+        default_github_repo.cache_clear()
+        try:
+            with patch.dict(
+                "scripts.common.os.environ",
+                {"GITHUB_REPOSITORY": "fork-owner/Syvert", "SYVERT_GITHUB_REPO": ""},
+                clear=True,
+            ):
+                run_mock.return_value = subprocess.CompletedProcess(
+                    args=["git", "config", "--get", "remote.origin.url"],
+                    returncode=0,
+                    stdout="git@github.com:MC-and-his-Agents/WebEnvoy.git\n",
+                    stderr="",
+                )
+                self.assertEqual(default_github_repo(), "MC-and-his-Agents/Syvert")
+        finally:
+            default_github_repo.cache_clear()
+
+        run_mock.assert_not_called()
+
+    def test_default_github_repo_accepts_explicit_syvert_override(self) -> None:
+        default_github_repo.cache_clear()
+        try:
+            with patch.dict(
+                "scripts.common.os.environ",
+                {"SYVERT_GITHUB_REPO": "MC-and-his-Agents/Syvert-Shadow"},
+                clear=True,
+            ):
+                self.assertEqual(default_github_repo(), "MC-and-his-Agents/Syvert-Shadow")
+        finally:
+            default_github_repo.cache_clear()
+
+    def test_normalize_integration_ref_for_comparison_normalizes_project_item_variants(self) -> None:
+        with_view = "https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test"
+        reordered_query = "https://github.com/orgs/MC-and-his-Agents/projects/3?itemId=PVTI_test&pane=issue"
+
+        self.assertEqual(
+            normalize_integration_ref_for_comparison(with_view),
+            "project-item:mc-and-his-agents/3#PVTI_test",
+        )
+        self.assertEqual(
+            normalize_integration_ref_for_comparison(with_view),
+            normalize_integration_ref_for_comparison(reordered_query),
+        )
+
+    def test_validate_integration_args_rejects_empty_ref_for_gated_pr(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "active",
+                "--integration-ref",
+                "",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(any("`integration_ref` 不能为空" in error for error in errors))
+
+    def test_validate_integration_args_requires_gate_for_shared_contract_surface(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "none",
+                "--integration-ref",
+                "none",
+                "--external-dependency",
+                "none",
+                "--merge-gate",
+                "local_only",
+                "--contract-surface",
+                "errors",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(any("`merge_gate` 必须为 `integration_check_required`" in error for error in errors))
+        self.assertTrue(any("`integration_touchpoint` 不能为 `none`" in error for error in errors))
+
+    def test_validate_integration_args_requires_gate_for_shared_contract_change(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "none",
+                "--shared-contract-changed",
+                "yes",
+                "--integration-ref",
+                "none",
+                "--external-dependency",
+                "none",
+                "--merge-gate",
+                "local_only",
+                "--contract-surface",
+                "none",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(any("共享契约" in error and "`integration_check_required`" in error for error in errors))
+
+    def test_validate_integration_args_rejects_dependency_with_none_touchpoint(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "none",
+                "--integration-ref",
+                "https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "none",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(any("`integration_touchpoint` 不能为 `none`" in error for error in errors))
+
+    def test_validate_integration_args_requires_touchpoint_for_gated_pr(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "none",
+                "--integration-ref",
+                "https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "--external-dependency",
+                "none",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "none",
+                "--joint-acceptance-needed",
+                "no",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(
+            any("`merge_gate=integration_check_required` 时，`integration_touchpoint` 不能为 `none`" in error for error in errors)
+        )
+
+    def test_validate_integration_args_rejects_uncheckable_integration_ref(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "active",
+                "--integration-ref",
+                "later",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(any("可核查的具体 integration issue / item" in error for error in errors))
+
+    def test_validate_integration_args_rejects_merge_recheck_at_open_pr_time(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "yes",
+                "--integration-ref",
+                "https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+                "--integration-status-checked-before-merge",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(any("`open_pr` 阶段不得把 `integration_status_checked_before_merge` 设为 `yes`" in error for error in errors))
+
+    def test_validate_integration_args_rejects_local_only_external_integration_ref(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "none",
+                "--integration-ref",
+                "https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "--external-dependency",
+                "none",
+                "--merge-gate",
+                "local_only",
+                "--contract-surface",
+                "none",
+                "--joint-acceptance-needed",
+                "no",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertTrue(any("纯本仓库事项必须显式使用 `integration_ref=none`" in error for error in errors))
+
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "body": "\n".join(
+                        [
+                            "### integration_touchpoint",
+                            "",
+                            "active",
+                            "",
+                            "### shared_contract_changed",
+                            "",
+                            "yes",
+                            "",
+                            "### integration_ref",
+                            "",
+                            "https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test",
+                            "",
+                            "### external_dependency",
+                            "",
+                            "both",
+                            "",
+                            "### merge_gate",
+                            "",
+                            "integration_check_required",
+                            "",
+                            "### contract_surface",
+                            "",
+                            "runtime_modes",
+                            "",
+                            "### joint_acceptance_needed",
+                            "",
+                            "yes",
+                        ]
+                    )
+                }
+            ),
+            stderr="",
+        ),
+    )
+    def test_validate_integration_args_rejects_issue_canonical_mismatch(self, run_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertIn("`--shared-contract-changed` 与 Issue #105 中的 canonical integration 元数据不一致。", errors)
+        self.assertGreaterEqual(run_mock.call_count, 1)
+
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=json.dumps({"body": "### 摘要\n\n- no metadata"}), stderr=""),
+    )
+    def test_validate_integration_args_allows_legacy_issue_without_canonical_integration_metadata(self, run_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "none",
+                "--integration-ref",
+                "none",
+                "--external-dependency",
+                "none",
+                "--merge-gate",
+                "local_only",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertEqual(errors, [])
+        run_mock.assert_called_once()
+
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(args=["gh"], returncode=1, stdout="", stderr="boom"),
+    )
+    def test_validate_integration_args_rejects_issue_fetch_failure_for_canonical_integration(self, run_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "none",
+                "--integration-ref",
+                "none",
+                "--external-dependency",
+                "none",
+                "--merge-gate",
+                "local_only",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertIn("无法读取 Issue #105 的 canonical integration 元数据", errors[0])
+        run_mock.assert_called_once()
+
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "body": "\n".join(
+                        [
+                            "### integration_touchpoint",
+                            "",
+                            "active",
+                            "",
+                            "### shared_contract_changed",
+                            "",
+                            "no",
+                            "",
+                            "### integration_ref",
+                            "",
+                            "#12",
+                            "",
+                            "### external_dependency",
+                            "",
+                            "both",
+                            "",
+                            "### merge_gate",
+                            "",
+                            "integration_check_required",
+                            "",
+                            "### contract_surface",
+                            "",
+                            "runtime_modes",
+                            "",
+                            "### joint_acceptance_needed",
+                            "",
+                            "yes",
+                        ]
+                    )
+                }
+            ),
+            stderr="",
+        ),
+    )
+    @patch("scripts.common.default_github_repo", return_value="MC-and-his-Agents/Syvert")
+    def test_validate_integration_args_accepts_equivalent_issue_ref_forms(self, default_repo_mock, run_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "https://github.com/MC-and-his-Agents/Syvert/issues/12",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertEqual(errors, [])
+        self.assertGreaterEqual(run_mock.call_count, 1)
+        self.assertGreaterEqual(default_repo_mock.call_count, 1)
+
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "body": "\n".join(
+                        [
+                            "### integration_touchpoint",
+                            "",
+                            "active",
+                            "",
+                            "### shared_contract_changed",
+                            "",
+                            "no",
+                            "",
+                            "### integration_ref",
+                            "",
+                            "https://github.com/orgs/MC-and-his-Agents/projects/3?itemId=PVTI_test&pane=issue",
+                            "",
+                            "### external_dependency",
+                            "",
+                            "both",
+                            "",
+                            "### merge_gate",
+                            "",
+                            "integration_check_required",
+                            "",
+                            "### contract_surface",
+                            "",
+                            "runtime_modes",
+                            "",
+                            "### joint_acceptance_needed",
+                            "",
+                            "yes",
+                        ]
+                    )
+                }
+            ),
+            stderr="",
+        ),
+    )
+    def test_validate_integration_args_accepts_equivalent_project_item_urls(self, run_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertEqual(errors, [])
+        self.assertGreaterEqual(run_mock.call_count, 1)
+
+    @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        return_value={"item_id": "PVTI_same", "organization": "mc-and-his-agents", "project_number": "3", "error": ""},
+    )
+    @patch(
+        "scripts.integration_contract.run",
+        return_value=subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "body": "\n".join(
+                        [
+                            "### integration_touchpoint",
+                            "",
+                            "active",
+                            "",
+                            "### shared_contract_changed",
+                            "",
+                            "no",
+                            "",
+                            "### integration_ref",
+                            "",
+                            "MC-and-his-Agents/Syvert#12",
+                            "",
+                            "### external_dependency",
+                            "",
+                            "both",
+                            "",
+                            "### merge_gate",
+                            "",
+                            "integration_check_required",
+                            "",
+                            "### contract_surface",
+                            "",
+                            "runtime_modes",
+                            "",
+                            "### joint_acceptance_needed",
+                            "",
+                            "yes",
+                        ]
+                    )
+                }
+            ),
+            stderr="",
+        ),
+    )
+    def test_validate_integration_args_accepts_equivalent_issue_and_project_item_refs(self, run_mock, fetch_live_mock) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--issue",
+                "105",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "no",
+                "--integration-ref",
+                "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+            ]
+        )
+
+        errors = validate_integration_args(args)
+
+        self.assertEqual(errors, [])
+        self.assertGreaterEqual(run_mock.call_count, 1)
+        self.assertGreaterEqual(fetch_live_mock.call_count, 2)
+
     def test_build_issue_summary_extracts_minimal_high_value_issue_context(self) -> None:
         payload = {
             "body": "\n".join(
@@ -162,6 +804,91 @@ class OpenPrPreflightTests(unittest.TestCase):
         self.assertIn("## Goal", summary)
         self.assertIn("## Scope", summary)
         self.assertIn("## Out of Scope", summary)
+
+    def test_extract_issue_summary_sections_supports_issue_form_heading_aliases(self) -> None:
+        body = "\n".join(
+            [
+                "### 摘要",
+                "",
+                "目标：收口本轮治理改造。",
+                "",
+                "### integration_touchpoint",
+                "",
+                "none",
+                "",
+                "### 治理目标",
+                "",
+                "补齐跨仓协同插槽。",
+            ]
+        )
+
+        sections = extract_issue_summary_sections(body)
+
+        self.assertIn("Goal", sections)
+        self.assertIn("目标：收口本轮治理改造。", sections["Goal"])
+        self.assertIn("补齐跨仓协同插槽。", sections["Goal"])
+        self.assertNotIn("integration_touchpoint", sections)
+
+    def test_extract_issue_canonical_integration_fields_preserves_issue_form_metadata(self) -> None:
+        body = "\n".join(
+            [
+                "### integration_touchpoint",
+                "",
+                "active",
+                "",
+                "### shared_contract_changed",
+                "",
+                "yes",
+                "",
+                "### integration_ref",
+                "",
+                "owner/repo#12",
+                "",
+                "### merge_gate",
+                "",
+                "integration_check_required",
+            ]
+        )
+
+        payload = extract_issue_canonical_integration_fields(body)
+
+        self.assertEqual(payload["integration_touchpoint"], "active")
+        self.assertEqual(payload["shared_contract_changed"], "yes")
+        self.assertEqual(payload["integration_ref"], "owner/repo#12")
+        self.assertEqual(payload["merge_gate"], "integration_check_required")
+
+    def test_build_issue_summary_renders_chinese_issue_form_sections(self) -> None:
+        payload = {
+            "body": "\n".join(
+                [
+                    "### 摘要",
+                    "",
+                    "目标：统一执行入口。",
+                    "",
+                    "### 影响载体",
+                    "",
+                    "- WORKFLOW.md",
+                    "",
+                    "### Formal Spec 套件",
+                    "",
+                    "- spec.md",
+                ]
+            )
+        }
+
+        with patch(
+            "scripts.open_pr.run",
+            return_value=type("Completed", (), {"returncode": 0, "stdout": __import__("json").dumps(payload)})(),
+        ):
+            summary = build_issue_summary(105)
+
+        self.assertIn("## Goal", summary)
+        self.assertIn("## Scope", summary)
+        self.assertIn("## Required Outcomes", summary)
+        self.assertIn("目标：统一执行入口。", summary)
+        self.assertIn("- WORKFLOW.md", summary)
+        self.assertIn("- spec.md", summary)
+
     def test_legacy_filename_exec_plan_is_accepted(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo = Path(temp_dir)
@@ -197,6 +924,40 @@ class OpenPrPreflightTests(unittest.TestCase):
                 repo_root=repo,
             )
         self.assertEqual(errors, [])
+
+    def test_build_body_populates_integration_check_fields(self) -> None:
+        args = parse_args(
+            [
+                "--class",
+                "governance",
+                "--integration-touchpoint",
+                "active",
+                "--shared-contract-changed",
+                "yes",
+                "--integration-ref",
+                "https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "--external-dependency",
+                "both",
+                "--merge-gate",
+                "integration_check_required",
+                "--contract-surface",
+                "runtime_modes",
+                "--joint-acceptance-needed",
+                "yes",
+                "--integration-status-checked-before-pr",
+                "yes",
+                "--integration-status-checked-before-merge",
+                "no",
+            ]
+        )
+
+        body = build_body(args, [])
+
+        self.assertIn("- integration_touchpoint: active", body)
+        self.assertIn("- shared_contract_changed: yes", body)
+        self.assertIn("- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466", body)
+        self.assertIn("- merge_gate: integration_check_required", body)
+        self.assertIn("- contract_surface: runtime_modes", body)
 
     def test_inactive_exec_plan_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/governance/test_open_pr.py
+++ b/tests/governance/test_open_pr.py
@@ -774,7 +774,8 @@ class OpenPrPreflightTests(unittest.TestCase):
 
         self.assertEqual(errors, [])
         self.assertGreaterEqual(run_mock.call_count, 1)
-        self.assertGreaterEqual(fetch_live_mock.call_count, 2)
+        self.assertEqual(args.integration_ref, "MC-and-his-Agents/Syvert#12")
+        fetch_live_mock.assert_not_called()
 
     def test_build_issue_summary_extracts_minimal_high_value_issue_context(self) -> None:
         payload = {
@@ -993,14 +994,7 @@ class OpenPrPreflightTests(unittest.TestCase):
             None,
         ),
     )
-    @patch(
-        "scripts.open_pr.semantic_integration_ref_identity",
-        side_effect=[
-            ("issue:mc-and-his-agents/syvert#12", True, "issue:mc-and-his-agents/syvert#12"),
-            ("issue:mc-and-his-agents/syvert#12", True, "project-item:mc-and-his-agents/3#PVTI_same"),
-        ],
-    )
-    def test_build_body_canonicalizes_equivalent_integration_ref_to_issue_carrier(self, semantic_identity_mock, resolve_issue_mock) -> None:
+    def test_build_body_canonicalizes_equivalent_integration_ref_to_issue_carrier(self, resolve_issue_mock) -> None:
         args = parse_args(
             [
                 "--class",
@@ -1033,7 +1027,6 @@ class OpenPrPreflightTests(unittest.TestCase):
         self.assertIn("- integration_ref: MC-and-his-Agents/Syvert#12", body)
         self.assertNotIn("PVTI_same", body)
         resolve_issue_mock.assert_called_once_with(105)
-        self.assertEqual(semantic_identity_mock.call_count, 2)
 
     def test_inactive_exec_plan_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -2242,7 +2242,8 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         review_once_mock.assert_not_called()
         require_auth_mock.assert_called_once()
-        all_checks_mock.assert_called_once_with(1)
+        self.assertEqual(all_checks_mock.call_count, 2)
+        all_checks_mock.assert_called_with(1)
         run_mock.assert_called_once_with(
             ["gh", "pr", "merge", "1", "--squash", "--match-head-commit", "sha-1"],
             cwd=ANY,
@@ -2302,7 +2303,8 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         review_once_mock.assert_called_once_with(1, post=False, json_output=None)
         require_auth_mock.assert_called_once()
-        all_checks_mock.assert_called_once_with(1)
+        self.assertEqual(all_checks_mock.call_count, 2)
+        all_checks_mock.assert_called_with(1)
         run_mock.assert_called_once_with(
             ["gh", "pr", "merge", "1", "--squash", "--match-head-commit", "sha-2", "--delete-branch"],
             cwd=ANY,
@@ -2415,7 +2417,8 @@ class MergeIfSafeTests(unittest.TestCase):
         find_result_mock.assert_not_called()
         review_once_mock.assert_called_once_with(1, post=False, json_output=None)
         require_auth_mock.assert_called_once()
-        all_checks_mock.assert_called_once_with(1)
+        self.assertEqual(all_checks_mock.call_count, 2)
+        all_checks_mock.assert_called_with(1)
 
     @patch("scripts.pr_guardian.run")
     @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
@@ -2652,7 +2655,8 @@ class MergeIfSafeTests(unittest.TestCase):
         )
         review_once_mock.assert_not_called()
         require_auth_mock.assert_called_once()
-        all_checks_mock.assert_called_once_with(1)
+        self.assertEqual(all_checks_mock.call_count, 2)
+        all_checks_mock.assert_called_with(1)
 
     @patch("scripts.pr_guardian.run")
     @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
@@ -2755,7 +2759,8 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertEqual(run_mock.call_count, 2)
         self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "merge", "1"])
         require_auth_mock.assert_called_once()
-        all_checks_mock.assert_called_once_with(1)
+        self.assertEqual(all_checks_mock.call_count, 2)
+        all_checks_mock.assert_called_with(1)
 
     @patch("scripts.pr_guardian.restore_merge_time_integration_recheck_or_die")
     @patch("scripts.pr_guardian.run")
@@ -2976,9 +2981,10 @@ class MergeIfSafeTests(unittest.TestCase):
             )
 
         self.assertIn("无法重新读取最新 PR 描述", str(ctx.exception))
-        self.assertEqual(run_mock.call_count, 1)
-        self.assertEqual(len(edited_bodies), 1)
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(len(edited_bodies), 2)
         self.assertIn("- integration_status_checked_before_merge: yes", edited_bodies[0])
+        self.assertIn("- integration_status_checked_before_merge: no", edited_bodies[1])
         review_once_mock.assert_not_called()
         require_auth_mock.assert_called_once()
         all_checks_mock.assert_called_once_with(1)
@@ -3046,9 +3052,10 @@ class MergeIfSafeTests(unittest.TestCase):
                 confirm_integration_recheck=True,
             )
 
-        self.assertIn("不会尝试自动恢复", str(ctx.exception))
-        self.assertEqual(run_mock.call_count, 1)
-        self.assertEqual(len(edited_bodies), 1)
+        self.assertIn("已回滚到旧值", str(ctx.exception))
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(len(edited_bodies), 2)
+        self.assertIn("- integration_status_checked_before_merge: no", edited_bodies[1])
         review_once_mock.assert_not_called()
         require_auth_mock.assert_called_once()
         all_checks_mock.assert_called_once_with(1)
@@ -3290,7 +3297,8 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertEqual(run_mock.call_args_list[2].args[0][:4], ["gh", "pr", "edit", "1"])
         review_once_mock.assert_not_called()
         require_auth_mock.assert_called_once()
-        all_checks_mock.assert_called_once_with(1)
+        self.assertEqual(all_checks_mock.call_count, 2)
+        all_checks_mock.assert_called_with(1)
 
     @patch("scripts.pr_guardian.run")
     @patch("scripts.pr_guardian.all_checks_pass", return_value=True)

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -1626,34 +1626,19 @@ class CodexReviewExecutionTests(unittest.TestCase):
                         "scripts.pr_guardian.fetch_issue_context",
                         return_value={"identity": [], "summary": "", "canonical_integration": {}},
                     ):
-                        with patch(
-                            "scripts.pr_guardian.fetch_integration_ref_live_state",
-                            return_value={
-                                "source": "project_item",
-                                "status": "in_progress",
-                                "dependency_order": "parallel",
-                                "joint_acceptance": "pending",
-                                "owner_repo": "joint",
-                                "contract_status": "reviewing",
-                                "error": "",
-                            },
-                        ) as fetch_live_mock:
+                        with patch("scripts.pr_guardian.fetch_integration_ref_live_state") as fetch_live_mock:
                             with patch(
                                 "scripts.pr_guardian.build_review_packet",
                                 return_value={"issue_number": 24},
                             ) as build_review_packet_mock:
                                 build_review_context(meta, Path("/tmp/pr-worktree"))
 
-        fetch_live_mock.assert_called_once_with(
-            "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test"
-        )
+        fetch_live_mock.assert_not_called()
         build_review_packet_mock.assert_called_once()
         kwargs = build_review_packet_mock.call_args.kwargs
-        self.assertIn("integration_ref_live", kwargs)
-        self.assertEqual(kwargs["integration_ref_live"]["source"], "project_item")
-        self.assertEqual(kwargs["integration_ref_live"]["joint_acceptance"], "pending")
+        self.assertNotIn("integration_ref_live", kwargs)
 
-    def test_build_review_context_falls_back_to_issue_canonical_integration_ref_for_live_snapshot(self) -> None:
+    def test_build_review_context_does_not_fetch_live_snapshot_from_issue_canonical_fallback(self) -> None:
         meta = {
             "number": 24,
             "title": "治理: integration live snapshot fallback",
@@ -1688,28 +1673,16 @@ class CodexReviewExecutionTests(unittest.TestCase):
                         "scripts.pr_guardian.fetch_issue_context",
                         return_value={"identity": ["- Issue: #24"], "summary": "issue summary", "canonical_integration": {}},
                     ):
-                        with patch(
-                            "scripts.pr_guardian.fetch_integration_ref_live_state",
-                            return_value={
-                                "source": "project_item",
-                                "status": "in_progress",
-                                "dependency_order": "parallel",
-                                "joint_acceptance": "ready",
-                                "owner_repo": "joint",
-                                "contract_status": "reviewing",
-                            },
-                        ) as fetch_live_mock:
+                        with patch("scripts.pr_guardian.fetch_integration_ref_live_state") as fetch_live_mock:
                             with patch(
                                 "scripts.pr_guardian.build_review_packet",
                                 return_value={"issue_number": 24},
                             ) as build_review_packet_mock:
                                 build_review_context(meta, Path("/tmp/pr-worktree"))
 
-        fetch_live_mock.assert_called_once_with(
-            "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test"
-        )
+        fetch_live_mock.assert_not_called()
         kwargs = build_review_packet_mock.call_args.kwargs
-        self.assertEqual(kwargs["integration_ref_live"]["source"], "project_item")
+        self.assertNotIn("integration_ref_live", kwargs)
 
     def test_build_review_context_skips_live_fetch_for_local_only_integration_ref_none(self) -> None:
         meta = {
@@ -1759,7 +1732,7 @@ class CodexReviewExecutionTests(unittest.TestCase):
 
         fetch_live_mock.assert_not_called()
         kwargs = build_review_packet_mock.call_args.kwargs
-        self.assertEqual(kwargs["integration_ref_live"], {})
+        self.assertNotIn("integration_ref_live", kwargs)
 
     def test_build_review_context_keeps_nested_issue_summary_from_pr_body(self) -> None:
         meta = {

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -84,6 +84,19 @@ INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY = "\n".join(
 )
 
 
+def cached_guardian_result(head_sha: str, body: str, *, verdict: str = "APPROVE", safe_to_merge: bool = True, summary: str = "cached") -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "pr_number": 1,
+        "head_sha": head_sha,
+        "body_fingerprint": guardian_body_fingerprint(body),
+        "verdict": verdict,
+        "safe_to_merge": safe_to_merge,
+        "summary": summary,
+        "reviewed_at": "2026-03-28T10:00:00Z",
+    }
+
+
 class GuardianStateTests(unittest.TestCase):
     def test_load_guardian_state_falls_back_to_legacy_file(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -2113,15 +2126,13 @@ class MergeIfSafeTests(unittest.TestCase):
             "isDraft": False,
             "headRefOid": "sha-request-changes",
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-request-changes",
-            "verdict": "REQUEST_CHANGES",
-            "safe_to_merge": False,
-            "summary": "blocked",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-request-changes",
+            "",
+            verdict="REQUEST_CHANGES",
+            safe_to_merge=False,
+            summary="blocked",
+        )
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
@@ -2149,15 +2160,12 @@ class MergeIfSafeTests(unittest.TestCase):
             "isDraft": False,
             "headRefOid": "sha-safe-false",
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-safe-false",
-            "verdict": "APPROVE",
-            "safe_to_merge": False,
-            "summary": "blocked",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-safe-false",
+            "",
+            safe_to_merge=False,
+            summary="blocked",
+        )
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
@@ -2226,15 +2234,7 @@ class MergeIfSafeTests(unittest.TestCase):
             "headRefOid": "sha-1",
             "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-1",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result("sha-1", LOCAL_ONLY_INTEGRATION_CHECK_BODY)
         run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
 
         exit_code = merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
@@ -2440,15 +2440,7 @@ class MergeIfSafeTests(unittest.TestCase):
             "isDraft": False,
             "headRefOid": "sha-current",
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result("sha-reviewed", "")
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
@@ -2479,15 +2471,7 @@ class MergeIfSafeTests(unittest.TestCase):
             "isDraft": False,
             "headRefOid": "sha-green-check",
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-green-check",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result("sha-green-check", "")
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
@@ -2519,15 +2503,10 @@ class MergeIfSafeTests(unittest.TestCase):
             "headRefOid": "sha-integration-contradiction",
             "body": CONTRADICTORY_LOCAL_ONLY_INTEGRATION_CHECK_BODY,
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-integration-contradiction",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-integration-contradiction",
+            CONTRADICTORY_LOCAL_ONLY_INTEGRATION_CHECK_BODY,
+        )
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
@@ -2560,15 +2539,10 @@ class MergeIfSafeTests(unittest.TestCase):
             "headRefOid": "sha-needs-recheck",
             "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-needs-recheck",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-needs-recheck",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
@@ -2623,16 +2597,29 @@ class MergeIfSafeTests(unittest.TestCase):
                 "headRefOid": "sha-needs-recheck",
                 "body": updated_body,
             },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-needs-recheck",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-needs-recheck",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
+        review_once_mock.return_value = (
+            {
+                "number": 1,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+            {
+                "verdict": "APPROVE",
+                "safe_to_merge": True,
+                "summary": "fresh-for-final-body",
+            },
+        )
         run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
 
         exit_code = merge_if_safe(
@@ -2653,7 +2640,7 @@ class MergeIfSafeTests(unittest.TestCase):
             merge_command,
             ["gh", "pr", "merge", "1", "--squash", "--match-head-commit", "sha-needs-recheck"],
         )
-        review_once_mock.assert_not_called()
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
         require_auth_mock.assert_called_once()
         self.assertEqual(all_checks_mock.call_count, 2)
         all_checks_mock.assert_called_with(1)
@@ -2886,15 +2873,10 @@ class MergeIfSafeTests(unittest.TestCase):
                 "body": concurrent_body,
             },
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-reviewed",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(
@@ -2960,15 +2942,10 @@ class MergeIfSafeTests(unittest.TestCase):
                 "body": updated_body,
             },
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-reviewed",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
         run_mock.side_effect = run_side_effect
 
         with self.assertRaises(SystemExit) as ctx:
@@ -3032,15 +3009,10 @@ class MergeIfSafeTests(unittest.TestCase):
             },
             SystemExit("refresh failed"),
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-reviewed",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
         run_mock.side_effect = run_side_effect
 
         with self.assertRaises(SystemExit) as ctx:
@@ -3112,15 +3084,22 @@ class MergeIfSafeTests(unittest.TestCase):
                 "body": concurrent_body,
             },
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-reviewed",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
+        review_once_mock.return_value = (
+            {
+                "number": 1,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+            {
+                "verdict": "APPROVE",
+                "safe_to_merge": True,
+                "summary": "fresh-for-final-body",
+            },
+        )
         run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
 
         with self.assertRaises(SystemExit) as ctx:
@@ -3132,11 +3111,11 @@ class MergeIfSafeTests(unittest.TestCase):
                 confirm_integration_recheck=True,
             )
 
-        self.assertIn("执行 `gh pr merge` 前 PR 描述已变化", str(ctx.exception))
+        self.assertIn("merge 前重跑 guardian 后 PR 描述已变化", str(ctx.exception))
         self.assertEqual(run_mock.call_count, 2)
         self.assertEqual(run_mock.call_args_list[0].args[0][:4], ["gh", "pr", "edit", "1"])
         self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "edit", "1"])
-        review_once_mock.assert_not_called()
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
         require_auth_mock.assert_called_once()
         all_checks_mock.assert_called_once_with(1)
 
@@ -3188,15 +3167,10 @@ class MergeIfSafeTests(unittest.TestCase):
                 ),
             },
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-reviewed",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
         run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
 
         with self.assertRaises(SystemExit) as ctx:
@@ -3264,18 +3238,31 @@ class MergeIfSafeTests(unittest.TestCase):
                 "number": 1,
                 "isDraft": False,
                 "headRefOid": "sha-reviewed",
-                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
             },
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-reviewed",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
+        review_once_mock.return_value = (
+            {
+                "number": 1,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+            {
+                "verdict": "APPROVE",
+                "safe_to_merge": True,
+                "summary": "fresh-for-final-body",
+            },
+        )
         run_mock.side_effect = [
             subprocess.CompletedProcess(args=["gh", "pr", "edit"], returncode=0, stdout="", stderr=""),
             CommandError(["gh", "pr", "merge", "1"], "命令失败", "", "merge failed"),
@@ -3295,7 +3282,7 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertEqual(run_mock.call_args_list[0].args[0][:4], ["gh", "pr", "edit", "1"])
         self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "merge", "1"])
         self.assertEqual(run_mock.call_args_list[2].args[0][:4], ["gh", "pr", "edit", "1"])
-        review_once_mock.assert_not_called()
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
         require_auth_mock.assert_called_once()
         self.assertEqual(all_checks_mock.call_count, 2)
         all_checks_mock.assert_called_with(1)
@@ -3352,15 +3339,22 @@ class MergeIfSafeTests(unittest.TestCase):
                 "body": concurrent_body,
             },
         ]
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-reviewed",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-reviewed",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
+        review_once_mock.return_value = (
+            {
+                "number": 1,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+            {
+                "verdict": "APPROVE",
+                "safe_to_merge": True,
+                "summary": "fresh-for-final-body",
+            },
+        )
         edited_bodies: list[str] = []
 
         def run_side_effect(command, cwd=None, check=True):
@@ -3383,14 +3377,14 @@ class MergeIfSafeTests(unittest.TestCase):
                 confirm_integration_recheck=True,
             )
 
-        self.assertIn("执行 `gh pr merge` 前 PR 描述已变化", str(ctx.exception))
+        self.assertIn("merge 前重跑 guardian 后 PR 描述已变化", str(ctx.exception))
         self.assertEqual(run_mock.call_count, 2)
         self.assertEqual(run_mock.call_args_list[0].args[0][:4], ["gh", "pr", "edit", "1"])
         self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "edit", "1"])
         self.assertEqual(len(edited_bodies), 2)
         self.assertIn("其他人已更新 PR 描述", edited_bodies[1])
         self.assertIn("- integration_status_checked_before_merge: no", edited_bodies[1])
-        review_once_mock.assert_not_called()
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
         require_auth_mock.assert_called_once()
         all_checks_mock.assert_called_once_with(1)
 
@@ -3430,15 +3424,10 @@ class MergeIfSafeTests(unittest.TestCase):
             "headRefOid": "sha-invalid-before-record",
             "body": invalid_body,
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-invalid-before-record",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-invalid-before-record",
+            invalid_body,
+        )
 
         with self.assertRaises(SystemExit) as ctx:
             merge_if_safe(
@@ -3478,15 +3467,10 @@ class MergeIfSafeTests(unittest.TestCase):
             "headRefOid": "sha-live-not-ready",
             "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-live-not-ready",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-live-not-ready",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
         fetch_live_mock.return_value = {
             "source": "project_item",
             "status": "review",
@@ -3510,7 +3494,7 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertIn("联合验收状态未就绪", str(ctx.exception))
         run_mock.assert_not_called()
         review_once_mock.assert_not_called()
-        fetch_live_mock.assert_called_once()
+        fetch_live_mock.assert_called_once_with("https://github.com/MC-and-his-Agents/WebEnvoy/issues/466")
         require_auth_mock.assert_called_once()
         all_checks_mock.assert_called_once_with(1)
 
@@ -3537,15 +3521,10 @@ class MergeIfSafeTests(unittest.TestCase):
             "headRefOid": "sha-live-unreadable",
             "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
         }
-        find_result_mock.return_value = {
-            "schema_version": 1,
-            "pr_number": 1,
-            "head_sha": "sha-live-unreadable",
-            "verdict": "APPROVE",
-            "safe_to_merge": True,
-            "summary": "cached",
-            "reviewed_at": "2026-03-28T10:00:00Z",
-        }
+        find_result_mock.return_value = cached_guardian_result(
+            "sha-live-unreadable",
+            INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        )
         fetch_live_mock.return_value = {
             "source": "project_item",
             "error": "无法读取 `integration_ref` 指向的 project item `PVTI_test`，拒绝继续。",
@@ -3563,7 +3542,7 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertIn("无法读取 `integration_ref` 指向的 project item", str(ctx.exception))
         run_mock.assert_not_called()
         review_once_mock.assert_not_called()
-        fetch_live_mock.assert_called_once()
+        fetch_live_mock.assert_called_once_with("https://github.com/MC-and-his-Agents/WebEnvoy/issues/466")
         require_auth_mock.assert_called_once()
         all_checks_mock.assert_called_once_with(1)
 

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -865,7 +865,7 @@ class CodexReviewExecutionTests(unittest.TestCase):
             },
         ),
     )
-    def test_integration_merge_gate_errors_rejects_cross_form_issue_and_project_item_refs(
+    def test_integration_merge_gate_errors_accepts_equivalent_issue_and_project_item_refs(
         self,
         resolve_issue_mock,
         fetch_live_mock,
@@ -890,12 +890,9 @@ class CodexReviewExecutionTests(unittest.TestCase):
 
         errors = integration_merge_gate_errors(meta)
 
-        self.assertEqual(
-            errors,
-            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
-        )
+        self.assertEqual(errors, [])
         resolve_issue_mock.assert_called_once_with(meta)
-        fetch_live_mock.assert_not_called()
+        self.assertEqual(fetch_live_mock.call_count, 2)
 
     def test_integration_merge_gate_errors_rejects_local_only_external_integration_ref(self) -> None:
         meta = {

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -6,20 +6,81 @@ import unittest
 from pathlib import Path
 from unittest.mock import ANY, patch
 
+from scripts.common import CommandError
 from scripts.pr_guardian import (
     build_item_context_summary,
     build_prompt,
     build_review_context,
     codex_review_timeout_seconds,
     extract_reviewer_rubric_excerpt,
+    fetch_issue_context,
     find_latest_guardian_result,
+    integration_merge_gate_errors,
     load_guardian_state,
     load_reviewer_rubric_excerpt,
     merge_if_safe,
+    parse_bullet_kv_section,
+    parse_integration_check_payload,
+    guardian_body_fingerprint,
+    integration_status_checked_before_merge_value,
     render_item_context_supplement,
     review_once,
     run_codex_review,
     save_guardian_result,
+    set_integration_status_checked_before_merge,
+)
+
+
+LOCAL_ONLY_INTEGRATION_CHECK_BODY = "\n".join(
+    [
+        "## integration_check",
+        "",
+        "- integration_touchpoint: none",
+        "- shared_contract_changed: no",
+        "- integration_ref: none",
+        "- external_dependency: none",
+        "- merge_gate: local_only",
+        "- contract_surface: none",
+        "- joint_acceptance_needed: no",
+        "- integration_status_checked_before_pr: no",
+        "- integration_status_checked_before_merge: no",
+    ]
+)
+
+CONTRADICTORY_LOCAL_ONLY_INTEGRATION_CHECK_BODY = "\n".join(
+    [
+        "## integration_check",
+        "",
+        "- integration_touchpoint: active",
+        "- shared_contract_changed: no",
+        "- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+        "- external_dependency: both",
+        "- merge_gate: local_only",
+        "- contract_surface: runtime_modes",
+        "- joint_acceptance_needed: yes",
+        "- integration_status_checked_before_pr: yes",
+        "- integration_status_checked_before_merge: yes",
+    ]
+)
+
+INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY = "\n".join(
+    [
+        "## integration_check",
+        "",
+        "- integration_touchpoint: active",
+        "- shared_contract_changed: no",
+        "- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+        "- external_dependency: both",
+        "- merge_gate: integration_check_required",
+        "- contract_surface: runtime_modes",
+        "- joint_acceptance_needed: yes",
+        "- integration_status_checked_before_pr: yes",
+        "- integration_status_checked_before_merge: no",
+        "",
+        "补充说明：",
+        "",
+        "- merge 前仍需再次核对 integration 状态",
+    ]
 )
 
 
@@ -59,6 +120,60 @@ class GuardianStateTests(unittest.TestCase):
             self.assertIsNotNone(payload)
             self.assertEqual(payload["head_sha"], "sha-1")
 
+    def test_find_latest_guardian_result_accepts_schema_v1_when_body_is_provided(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "guardian.json"
+            save_guardian_result(
+                1,
+                {
+                    "schema_version": 1,
+                    "pr_number": 1,
+                    "head_sha": "sha-1",
+                    "verdict": "APPROVE",
+                    "safe_to_merge": True,
+                    "summary": "cached",
+                    "reviewed_at": "2026-03-28T10:00:00Z",
+                },
+                path=state_path,
+            )
+
+            payload = find_latest_guardian_result(
+                1,
+                "sha-1",
+                body="## integration_check\n\n- integration_status_checked_before_pr: yes\n",
+                path=state_path,
+            )
+
+            self.assertIsNotNone(payload)
+            self.assertEqual(payload["head_sha"], "sha-1")
+
+    def test_find_latest_guardian_result_rejects_schema_v1_when_body_bound_is_required(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "guardian.json"
+            save_guardian_result(
+                1,
+                {
+                    "schema_version": 1,
+                    "pr_number": 1,
+                    "head_sha": "sha-1",
+                    "verdict": "APPROVE",
+                    "safe_to_merge": True,
+                    "summary": "cached",
+                    "reviewed_at": "2026-03-28T10:00:00Z",
+                },
+                path=state_path,
+            )
+
+            payload = find_latest_guardian_result(
+                1,
+                "sha-1",
+                body="## integration_check\n\n- integration_status_checked_before_pr: yes\n",
+                require_body_bound=True,
+                path=state_path,
+            )
+
+            self.assertIsNone(payload)
+
     def test_find_latest_guardian_result_rejects_stale_head(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             state_path = Path(temp_dir) / "guardian.json"
@@ -80,8 +195,801 @@ class GuardianStateTests(unittest.TestCase):
 
             self.assertIsNone(payload)
 
+    def test_find_latest_guardian_result_rejects_body_drift_with_same_head(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "guardian.json"
+            reviewed_body = "## integration_check\n\n- integration_status_checked_before_pr: yes\n"
+            save_guardian_result(
+                1,
+                {
+                    "schema_version": 2,
+                    "pr_number": 1,
+                    "head_sha": "sha-1",
+                    "body_fingerprint": guardian_body_fingerprint(reviewed_body),
+                    "verdict": "APPROVE",
+                    "safe_to_merge": True,
+                    "summary": "cached",
+                    "reviewed_at": "2026-03-28T10:00:00Z",
+                },
+                path=state_path,
+            )
+
+            payload = find_latest_guardian_result(
+                1,
+                "sha-1",
+                body=reviewed_body + "\n补充说明：body changed\n",
+                path=state_path,
+            )
+
+            self.assertIsNone(payload)
+
 
 class CodexReviewExecutionTests(unittest.TestCase):
+    def test_set_integration_status_checked_before_merge_updates_only_integration_check_section(self) -> None:
+        body = "\n".join(
+            [
+                "## 摘要",
+                "",
+                "- integration_status_checked_before_merge: no",
+                "",
+                "## integration_check",
+                "",
+                "- integration_touchpoint: active",
+                "- shared_contract_changed: no",
+                "- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "- external_dependency: both",
+                "- merge_gate: integration_check_required",
+                "- contract_surface: runtime_modes",
+                "- joint_acceptance_needed: yes",
+                "- integration_status_checked_before_pr: yes",
+                "- integration_status_checked_before_merge: no",
+            ]
+        )
+
+        updated = set_integration_status_checked_before_merge(body, "yes")
+
+        self.assertIn("## 摘要\n\n- integration_status_checked_before_merge: no", updated)
+        self.assertIn("## integration_check", updated)
+        self.assertIn("- integration_status_checked_before_merge: yes", updated)
+        self.assertEqual(integration_status_checked_before_merge_value(updated), "yes")
+
+    def test_merge_recheck_reader_ignores_same_named_bullet_outside_integration_check_section(self) -> None:
+        body = "\n".join(
+            [
+                "## 补充说明",
+                "",
+                "- integration_status_checked_before_merge: yes",
+                "",
+                "## integration_check",
+                "",
+                "- integration_touchpoint: active",
+                "- shared_contract_changed: no",
+                "- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "- external_dependency: both",
+                "- merge_gate: integration_check_required",
+                "- contract_surface: runtime_modes",
+                "- joint_acceptance_needed: yes",
+                "- integration_status_checked_before_pr: yes",
+                "- integration_status_checked_before_merge: no",
+            ]
+        )
+
+        self.assertEqual(integration_status_checked_before_merge_value(body), "no")
+
+    def test_parse_bullet_kv_section_ignores_following_explanatory_heading(self) -> None:
+        section = "\n".join(
+            [
+                "- integration_touchpoint: active",
+                "- shared_contract_changed: no",
+                "- integration_ref:",
+                "  https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "- external_dependency: both",
+                "- merge_gate: integration_check_required",
+                "- contract_surface: runtime_modes",
+                "- joint_acceptance_needed: yes",
+                "- integration_status_checked_before_pr: yes",
+                "- integration_status_checked_before_merge: yes",
+                "",
+                "补充说明：",
+                "",
+                "- merge 前必须再次核对 integration 状态",
+            ]
+        )
+
+        payload = parse_bullet_kv_section(section)
+
+        self.assertEqual(payload["integration_status_checked_before_merge"], "yes")
+        self.assertEqual(payload["integration_ref"], "https://github.com/MC-and-his-Agents/WebEnvoy/issues/466")
+
+    def test_parse_integration_check_payload_ignores_free_form_note_bullets(self) -> None:
+        section = "\n".join(
+            [
+                "- integration_touchpoint: active",
+                "- shared_contract_changed: no",
+                "- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                "- external_dependency: both",
+                "- merge_gate: integration_check_required",
+                "- contract_surface: runtime_modes",
+                "- joint_acceptance_needed: yes",
+                "- integration_status_checked_before_pr: yes",
+                "- integration_status_checked_before_merge: no",
+                "",
+                "补充说明：",
+                "",
+                "- integration_status_checked_before_merge: yes",
+            ]
+        )
+
+        payload = parse_integration_check_payload(section)
+
+        self.assertEqual(payload["integration_status_checked_before_merge"], "no")
+
+    def test_integration_merge_gate_errors_accepts_standard_template_shape(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref:",
+                    "  https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                    "",
+                    "补充说明：",
+                    "",
+                    "- merge 前必须再次核对 integration 状态",
+                ]
+            )
+        }
+
+        self.assertEqual(integration_merge_gate_errors(meta), [])
+
+    @patch(
+        "scripts.pr_guardian.fetch_integration_ref_live_state",
+        return_value={
+            "source": "project_item",
+            "status": "blocked",
+            "dependency_order": "parallel",
+            "joint_acceptance": "ready",
+            "blocked": True,
+            "error": "",
+        },
+    )
+    def test_integration_merge_gate_errors_require_live_state_blocks_blocked_integration_ref(self, live_state_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta, require_live_state=True)
+
+        self.assertTrue(any("blocked" in item for item in errors))
+        live_state_mock.assert_called_once()
+
+    @patch(
+        "scripts.pr_guardian.fetch_integration_ref_live_state",
+        return_value={
+            "source": "project_item",
+            "error": "无法读取 `integration_ref` 指向的 project item `PVTI_test`，拒绝继续。",
+        },
+    )
+    def test_integration_merge_gate_errors_require_live_state_fail_closed_when_ref_unreadable(self, live_state_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta, require_live_state=True)
+
+        self.assertEqual(errors, ["无法读取 `integration_ref` 指向的 project item `PVTI_test`，拒绝继续。"])
+        live_state_mock.assert_called_once()
+
+    @patch(
+        "scripts.pr_guardian.fetch_integration_ref_live_state",
+        return_value={
+            "source": "project_item",
+            "status": "review",
+            "dependency_order": "parallel",
+            "joint_acceptance": "ready",
+            "owner_repo": "joint",
+            "contract_status": "reviewing",
+            "blocked": False,
+            "error": "",
+        },
+    )
+    def test_integration_merge_gate_errors_require_live_state_passes_when_ref_ready(self, live_state_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta, require_live_state=True)
+
+        self.assertEqual(errors, [])
+        live_state_mock.assert_called_once()
+
+    @patch(
+        "scripts.pr_guardian.fetch_integration_ref_live_state",
+        return_value={
+            "source": "project_item",
+            "status": "in_progress",
+            "dependency_order": "parallel",
+            "joint_acceptance": "ready",
+            "owner_repo": "joint",
+            "contract_status": "reviewing",
+            "blocked": False,
+            "error": "",
+        },
+    )
+    def test_integration_merge_gate_errors_require_live_state_rejects_in_progress_status(self, live_state_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta, require_live_state=True)
+
+        self.assertTrue(any("未进入允许合并的状态集合" in item for item in errors))
+        live_state_mock.assert_called_once()
+
+    def test_integration_merge_gate_errors_allows_missing_section_for_legacy_pr(self) -> None:
+        meta = {"body": "## 摘要\n\n- 变更目的：补齐 integration gate\n"}
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, [])
+
+    @patch("scripts.pr_guardian.resolve_issue_canonical_integration", return_value=(105, {"merge_gate": "integration_check_required"}))
+    def test_integration_merge_gate_errors_rejects_missing_section_when_issue_declares_canonical_metadata(self, resolve_issue_mock) -> None:
+        meta = {"body": "## 摘要\n\n- 变更目的：补齐 integration gate\n"}
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, ["PR 对应的 Issue #105 已声明 canonical integration 元数据，PR 描述缺少 canonical `integration_check` 段落。"])
+        resolve_issue_mock.assert_called_once_with(meta)
+
+    @patch("scripts.pr_guardian.resolve_issue_canonical_integration", return_value=(105, {}))
+    def test_integration_merge_gate_errors_allows_legacy_issue_without_canonical_metadata(self, resolve_issue_mock) -> None:
+        meta = {"body": "## 摘要\n\n- 变更目的：补齐 integration gate\n"}
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, [])
+        resolve_issue_mock.assert_called_once_with(meta)
+
+    def test_integration_merge_gate_errors_rejects_issue_canonical_lookup_failure(self) -> None:
+        meta = {"body": "## 摘要\n\n- 变更目的：补齐 integration gate\n"}
+
+        def resolve_side_effect(payload):
+            payload["_issue_canonical_integration_error"] = "无法读取 Issue #105 的 canonical integration 元数据，拒绝继续。"
+            return 105, {}
+
+        with patch("scripts.pr_guardian.resolve_issue_canonical_integration", side_effect=resolve_side_effect) as resolve_issue_mock:
+            errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, ["无法读取 Issue #105 的 canonical integration 元数据，拒绝继续。"])
+        resolve_issue_mock.assert_called_once_with(meta)
+
+    def test_integration_merge_gate_errors_rejects_missing_canonical_fields(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- integration_ref: #12",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(
+            errors,
+            [
+                "PR 描述中的 `integration_check` 缺少必填字段："
+                "`integration_check.joint_acceptance_needed`、`integration_check.shared_contract_changed`。"
+            ],
+        )
+
+    def test_integration_merge_gate_errors_rejects_unknown_merge_gate_value(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- merge_gate: experimental_mode",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(
+            errors,
+            ["PR 描述中的 `integration_check.merge_gate` 非法：`experimental_mode`（仅允许 `local_only` / `integration_check_required`）。"],
+        )
+
+    def test_integration_merge_gate_errors_requires_metadata_for_required_gate(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: none",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: no",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertIn("`merge_gate=integration_check_required` 时，`integration_ref` 必须指向具体 integration issue / item。", errors)
+        self.assertIn("`merge_gate=integration_check_required` 时，PR 描述必须记录 `integration_status_checked_before_pr=yes`。", errors)
+        self.assertIn(
+            "`merge_gate=integration_check_required` 时，进入 `merge_pr` 前必须把 `integration_status_checked_before_merge` 更新为 `yes`。",
+            errors,
+        )
+
+    def test_integration_merge_gate_errors_rejects_local_only_with_integration_invariants(self) -> None:
+        meta = {"body": CONTRADICTORY_LOCAL_ONLY_INTEGRATION_CHECK_BODY}
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(
+            errors,
+            [
+                "`merge_gate=local_only` 与当前 integration 元数据冲突："
+                "当 `integration_touchpoint != none`、`shared_contract_changed=yes`、`external_dependency != none`、"
+                "`contract_surface != none` 或 `joint_acceptance_needed=yes` 时，"
+                "`merge_gate` 必须为 `integration_check_required`。"
+            ],
+        )
+
+    def test_integration_merge_gate_errors_rejects_invalid_enum_values(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: unexpected",
+                    "- shared_contract_changed: maybe",
+                    "- integration_ref: #12",
+                    "- external_dependency: somewhere",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: typo_surface",
+                    "- joint_acceptance_needed: maybe",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertTrue(any("integration_touchpoint" in error for error in errors))
+        self.assertTrue(any("shared_contract_changed" in error for error in errors))
+        self.assertTrue(any("external_dependency" in error for error in errors))
+        self.assertTrue(any("contract_surface" in error for error in errors))
+        self.assertTrue(any("joint_acceptance_needed" in error for error in errors))
+
+    def test_integration_merge_gate_errors_rejects_invalid_status_enum_values(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: none",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: none",
+                    "- external_dependency: none",
+                    "- merge_gate: local_only",
+                    "- contract_surface: none",
+                    "- joint_acceptance_needed: no",
+                    "- integration_status_checked_before_pr: later",
+                    "- integration_status_checked_before_merge: maybe",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertTrue(any("integration_status_checked_before_pr" in error for error in errors))
+        self.assertTrue(any("integration_status_checked_before_merge" in error for error in errors))
+
+    @patch(
+        "scripts.pr_guardian.resolve_issue_canonical_integration",
+        return_value=(
+            105,
+            {
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "yes",
+                "integration_ref": "owner/repo#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+        ),
+    )
+    def test_integration_merge_gate_errors_rejects_pr_issue_canonical_mismatch(self, resolve_issue_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: owner/repo#12",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertIn("`integration_check.shared_contract_changed` 与 Issue #105 中的 canonical integration 元数据不一致。", errors)
+        resolve_issue_mock.assert_called_once_with(meta)
+
+    def test_integration_merge_gate_errors_rejects_uncheckable_integration_ref(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: later",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertTrue(any("可核查的具体 integration issue / item" in error for error in errors))
+
+    def test_integration_merge_gate_errors_accepts_project_item_url_with_view(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=123456",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, [])
+
+    @patch(
+        "scripts.pr_guardian.resolve_issue_canonical_integration",
+        return_value=(
+            105,
+            {
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "MC-and-his-Agents/Syvert#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+        ),
+    )
+    def test_integration_merge_gate_errors_accepts_equivalent_issue_ref_forms(self, resolve_issue_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/MC-and-his-Agents/Syvert/issues/12",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, [])
+        resolve_issue_mock.assert_called_once_with(meta)
+
+    @patch(
+        "scripts.pr_guardian.resolve_issue_canonical_integration",
+        return_value=(
+            105,
+            {
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?itemId=PVTI_test&pane=issue",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+        ),
+    )
+    def test_integration_merge_gate_errors_accepts_equivalent_project_item_urls(self, resolve_issue_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, [])
+        resolve_issue_mock.assert_called_once_with(meta)
+
+    @patch(
+        "scripts.integration_contract.fetch_integration_ref_live_state",
+        side_effect=[
+            {"item_id": "PVTI_same", "organization": "mc-and-his-agents", "project_number": "3", "error": ""},
+            {"item_id": "PVTI_same", "organization": "mc-and-his-agents", "project_number": "3", "error": ""},
+        ],
+    )
+    @patch(
+        "scripts.pr_guardian.resolve_issue_canonical_integration",
+        return_value=(
+            105,
+            {
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "no",
+                "integration_ref": "MC-and-his-Agents/Syvert#12",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+        ),
+    )
+    def test_integration_merge_gate_errors_accepts_equivalent_issue_and_project_item_refs(
+        self,
+        resolve_issue_mock,
+        fetch_live_mock,
+    ) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_same",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertEqual(errors, [])
+        resolve_issue_mock.assert_called_once_with(meta)
+        self.assertEqual(fetch_live_mock.call_count, 2)
+
+    def test_integration_merge_gate_errors_rejects_local_only_external_integration_ref(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: none",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+                    "- external_dependency: none",
+                    "- merge_gate: local_only",
+                    "- contract_surface: none",
+                    "- joint_acceptance_needed: no",
+                    "- integration_status_checked_before_pr: no",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertIn("纯本仓库事项必须显式使用 `integration_ref=none`，不得保留外部 integration 绑定。", errors)
+
+    def test_integration_merge_gate_errors_rejects_local_only_shared_contract_change(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: none",
+                    "- shared_contract_changed: yes",
+                    "- integration_ref: none",
+                    "- external_dependency: none",
+                    "- merge_gate: local_only",
+                    "- contract_surface: none",
+                    "- joint_acceptance_needed: no",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertTrue(any("shared_contract_changed=yes" in error for error in errors))
+
+    @patch(
+        "scripts.pr_guardian.resolve_issue_canonical_integration",
+        return_value=(
+            105,
+            {
+                "integration_touchpoint": "active",
+                "shared_contract_changed": "yes",
+                "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test",
+                "external_dependency": "both",
+                "merge_gate": "integration_check_required",
+                "contract_surface": "runtime_modes",
+                "joint_acceptance_needed": "yes",
+            },
+        ),
+    )
+    def test_integration_merge_gate_errors_rejects_local_only_issue_canonical_mismatch(self, resolve_issue_mock) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: none",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: none",
+                    "- external_dependency: none",
+                    "- merge_gate: local_only",
+                    "- contract_surface: none",
+                    "- joint_acceptance_needed: no",
+                    "- integration_status_checked_before_pr: no",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertIn("`integration_check.integration_touchpoint` 与 Issue #105 中的 canonical integration 元数据不一致。", errors)
+        self.assertIn("`integration_check.merge_gate` 与 Issue #105 中的 canonical integration 元数据不一致。", errors)
+        resolve_issue_mock.assert_called_once_with(meta)
+
+    def test_integration_merge_gate_errors_rejects_required_gate_with_touchpoint_none(self) -> None:
+        meta = {
+            "body": "\n".join(
+                [
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: none",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3/views/1?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: yes",
+                ]
+            )
+        }
+
+        errors = integration_merge_gate_errors(meta)
+
+        self.assertIn("`merge_gate=integration_check_required` 时，`integration_touchpoint` 不能为 `none`。", errors)
+
     @patch("scripts.pr_guardian.subprocess.run")
     def test_run_codex_review_falls_back_to_stdout_json(self, subprocess_run_mock) -> None:
         subprocess_run_mock.return_value = subprocess.CompletedProcess(
@@ -125,7 +1033,8 @@ class CodexReviewExecutionTests(unittest.TestCase):
                 with self.assertRaises(SystemExit) as ctx:
                     run_codex_review(Path(temp_dir), "prompt", Path(temp_dir) / "review.json")
 
-        self.assertIn("Codex 审查超时", str(ctx.exception))
+        self.assertIn("Codex 审查超时（>300 秒）", str(ctx.exception))
+        self.assertEqual(subprocess_run_mock.call_args.kwargs["timeout"], 300)
         subprocess_run_mock.assert_called_once()
 
     def test_codex_review_timeout_seconds_defaults_to_none(self) -> None:
@@ -215,6 +1124,46 @@ class CodexReviewExecutionTests(unittest.TestCase):
                     "validation": "- python3 -m unittest",
                     "rollback": "- revert PR",
                 },
+                "integration_review_packet": {
+                    "contract_sources": [
+                        "scripts/policy/integration_contract.json",
+                        "scripts/integration_contract.py",
+                    ],
+                    "issue_number": 24,
+                    "issue_error": "",
+                    "issue_canonical": {
+                        "integration_touchpoint": "active",
+                        "shared_contract_changed": "no",
+                        "integration_ref": "#24",
+                        "external_dependency": "both",
+                        "merge_gate": "integration_check_required",
+                        "contract_surface": "runtime_modes",
+                        "joint_acceptance_needed": "yes",
+                    },
+                    "normalized_issue_canonical": {
+                        "integration_ref": "issue:mc-and-his-agents/syvert#24",
+                    },
+                    "pr_canonical": {
+                        "integration_touchpoint": "active",
+                        "shared_contract_changed": "no",
+                        "integration_ref": "https://github.com/MC-and-his-Agents/Syvert/issues/24",
+                        "external_dependency": "both",
+                        "merge_gate": "integration_check_required",
+                        "contract_surface": "runtime_modes",
+                        "joint_acceptance_needed": "yes",
+                        "integration_status_checked_before_pr": "yes",
+                        "integration_status_checked_before_merge": "no",
+                    },
+                    "normalized_pr_canonical": {
+                        "integration_ref": "issue:mc-and-his-agents/syvert#24",
+                    },
+                    "comparison_errors": [],
+                    "merge_gate": "integration_check_required",
+                    "merge_gate_requires_recheck": True,
+                    "merge_validation_errors": [
+                        "`merge_gate=integration_check_required` 时，进入 `merge_pr` 前必须把 `integration_status_checked_before_merge` 更新为 `yes`。"
+                    ],
+                },
                 "checks": ["- governance: bucket=pass, state=SUCCESS"],
                 "worktree_binding": [{"key": "issue-24", "path": "/tmp/issue-24"}],
                 "changed_files": ["scripts/pr_guardian.py", "tests/governance/test_pr_guardian.py"],
@@ -235,11 +1184,79 @@ class CodexReviewExecutionTests(unittest.TestCase):
         self.assertIn("Diff Stat：", prompt)
         self.assertIn("docs/exec-plans/GOV-0024-guardian-review-context.md", prompt)
         self.assertIn("## Review Rubric", prompt)
+        self.assertIn("Integration Review Packet：", prompt)
+        self.assertIn("normalized_issue_canonical", prompt)
+        self.assertIn("integration_status_checked_before_merge", prompt)
         self.assertNotIn("PR 正文 fallback：", prompt)
         self.assertNotIn("审查输入", prompt)
         self.assertNotIn("进入 `merge-ready` 前，必须同时满足", prompt)
         self.assertNotIn("默认 Squash Merge", prompt)
         self.assertNotIn("检查清单：", prompt)
+
+    def test_build_prompt_surfaces_missing_pr_integration_check_as_blocking_packet_error(self) -> None:
+        meta = {
+            "number": 107,
+            "title": "治理: 统一 canonical integration contract",
+            "url": "https://example.test/pr/107",
+            "baseRefName": "main",
+            "headRefOid": "sha-107",
+            "headRefName": "issue-105-integration-governance-baseline",
+            "body": "## 摘要\n\n- 变更目的：统一 contract\n",
+        }
+
+        expected_error = "PR 对应的 Issue #105 已声明 canonical integration 元数据，PR 描述缺少 canonical `integration_check` 段落。"
+
+        with patch(
+            "scripts.pr_guardian.build_review_context",
+            return_value={
+                "pr_identity": ["- PR: #107", "- 标题: 治理: 统一 canonical integration contract"],
+                "issue_context": {
+                    "identity": ["- Issue: #105", "- 标题: governance: canonical integration contract"],
+                    "summary": "",
+                },
+                "item_context": {"issue": "105", "item_key": "GOV-0105-integration-governance-baseline"},
+                "raw_sections": {"摘要": "- 变更目的：统一 contract"},
+                "pr_sections": {"summary": "- 变更目的：统一 contract"},
+                "integration_review_packet": {
+                    "contract_sources": [
+                        "scripts/policy/integration_contract.json",
+                        "scripts/integration_contract.py",
+                    ],
+                    "issue_number": 105,
+                    "issue_error": "",
+                    "issue_canonical": {
+                        "integration_touchpoint": "active",
+                        "shared_contract_changed": "no",
+                        "integration_ref": "#12",
+                        "external_dependency": "both",
+                        "merge_gate": "integration_check_required",
+                        "contract_surface": "runtime_modes",
+                        "joint_acceptance_needed": "yes",
+                    },
+                    "normalized_issue_canonical": {
+                        "integration_ref": "issue:mc-and-his-agents/syvert#12",
+                    },
+                    "pr_canonical": {},
+                    "normalized_pr_canonical": {},
+                    "comparison_errors": [expected_error],
+                    "merge_gate": "none",
+                    "merge_gate_requires_recheck": False,
+                    "merge_validation_errors": [expected_error],
+                },
+                "checks": ["- governance: bucket=pass, state=SUCCESS"],
+                "worktree_binding": [{"key": "issue-105", "path": "/tmp/issue-105"}],
+                "changed_files": ["scripts/integration_contract.py"],
+                "diff_stat": "1 file changed, 10 insertions(+), 2 deletions(-)",
+                "related_paths": ["docs/exec-plans/GOV-0105-integration-governance-baseline.md"],
+                "context_notes": ["结构化事项上下文已加载。"],
+            },
+        ):
+            with patch("scripts.pr_guardian.load_reviewer_rubric_excerpt", return_value="## Review Rubric\n- contract 一致性"):
+                prompt = build_prompt(meta, Path("/tmp/worktree"))
+
+        self.assertIn(expected_error, prompt)
+        self.assertNotIn("canonical_mismatches: none", prompt)
+        self.assertNotIn("merge_gate_validation: ok", prompt)
 
     def test_extract_reviewer_rubric_excerpt_excludes_review_inputs_section(self) -> None:
         excerpt = extract_reviewer_rubric_excerpt(
@@ -506,7 +1523,7 @@ class CodexReviewExecutionTests(unittest.TestCase):
             "baseRefName": "main",
             "headRefOid": "sha-24",
             "headRefName": "issue-24-branch",
-            "body": "## Issue 摘要\n\n- Goal: 精简\n- Scope: 收敛 guardian review context\n",
+            "body": "Issue: #24\n## Issue 摘要\n\n- Goal: 精简\n- Scope: 收敛 guardian review context\n",
         }
         worktree_dir = Path("/tmp/pr-worktree")
 
@@ -515,12 +1532,234 @@ class CodexReviewExecutionTests(unittest.TestCase):
                 "scripts.pr_guardian.build_item_context_summary",
                 return_value=({"issue": "24", "item_key": "GOV-0024-guardian-review-context"}, [], []),
             ) as build_item_context_summary_mock:
-                with patch("scripts.pr_guardian.fetch_issue_context") as fetch_issue_context_mock:
-                    payload = build_review_context(meta, worktree_dir)
+                with patch(
+                    "scripts.pr_guardian.resolve_issue_canonical_integration",
+                    return_value=(24, {}),
+                ) as resolve_issue_canonical_integration_mock:
+                    with patch(
+                        "scripts.pr_guardian.build_review_packet",
+                        return_value={},
+                    ):
+                        with patch(
+                            "scripts.pr_guardian.fetch_issue_context",
+                            return_value={"identity": [], "summary": "", "canonical_integration": {}},
+                        ) as fetch_issue_context_mock:
+                            payload = build_review_context(meta, worktree_dir)
 
         build_item_context_summary_mock.assert_called_once_with(meta, worktree_dir)
+        resolve_issue_canonical_integration_mock.assert_called_once_with(meta)
         fetch_issue_context_mock.assert_not_called()
         self.assertEqual(payload["item_context"]["item_key"], "GOV-0024-guardian-review-context")
+
+    def test_build_review_context_keeps_issue_side_evidence_when_item_context_is_invalid(self) -> None:
+        meta = {
+            "number": 24,
+            "title": "治理: 精简 guardian review context",
+            "url": "https://example.test/pr/24",
+            "baseRefName": "main",
+            "headRefOid": "sha-24",
+            "headRefName": "issue-24-branch",
+            "body": "Issue: #24\n## 摘要\n\n- item context drift\n",
+        }
+
+        with patch("scripts.pr_guardian.fetch_diff_stats", return_value=(["scripts/pr_guardian.py"], "1 file changed")):
+            with patch(
+                "scripts.pr_guardian.build_item_context_summary",
+                return_value=({"item_key": "GOV-0024-guardian-review-context"}, ["item context drift"], []),
+            ):
+                with patch(
+                    "scripts.pr_guardian.resolve_issue_canonical_integration",
+                    return_value=(24, {"merge_gate": "integration_check_required"}),
+                ) as resolve_issue_canonical_integration_mock:
+                    with patch(
+                        "scripts.pr_guardian.fetch_issue_context",
+                        return_value={"identity": ["- Issue: #24"], "summary": "issue summary", "canonical_integration": {}},
+                    ) as fetch_issue_context_mock:
+                        with patch(
+                            "scripts.pr_guardian.build_review_packet",
+                            return_value={"issue_number": 24, "issue_canonical": {"merge_gate": "integration_check_required"}},
+                        ) as build_review_packet_mock:
+                            payload = build_review_context(meta, Path("/tmp/pr-worktree"))
+
+        resolve_issue_canonical_integration_mock.assert_called_once_with(meta)
+        fetch_issue_context_mock.assert_called_once_with(24)
+        build_review_packet_mock.assert_called_once()
+        self.assertEqual(payload["integration_review_packet"]["issue_number"], 24)
+        self.assertEqual(payload["context_notes"], ["item context drift"])
+
+    def test_build_review_context_passes_live_integration_ref_snapshot_to_review_packet(self) -> None:
+        meta = {
+            "number": 24,
+            "title": "治理: integration live snapshot",
+            "url": "https://example.test/pr/24",
+            "baseRefName": "main",
+            "headRefOid": "sha-24",
+            "headRefName": "issue-24-branch",
+            "body": "\n".join(
+                [
+                    "Issue: #24",
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: active",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                    "- external_dependency: both",
+                    "- merge_gate: integration_check_required",
+                    "- contract_surface: runtime_modes",
+                    "- joint_acceptance_needed: yes",
+                    "- integration_status_checked_before_pr: yes",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            ),
+        }
+
+        with patch("scripts.pr_guardian.fetch_diff_stats", return_value=(["scripts/pr_guardian.py"], "1 file changed")):
+            with patch(
+                "scripts.pr_guardian.build_item_context_summary",
+                return_value=({"issue": "24", "item_key": "GOV-0024-guardian-review-context"}, [], []),
+            ):
+                with patch(
+                    "scripts.pr_guardian.resolve_issue_canonical_integration",
+                    return_value=(24, {"merge_gate": "integration_check_required"}),
+                ):
+                    with patch(
+                        "scripts.pr_guardian.fetch_issue_context",
+                        return_value={"identity": [], "summary": "", "canonical_integration": {}},
+                    ):
+                        with patch(
+                            "scripts.pr_guardian.fetch_integration_ref_live_state",
+                            return_value={
+                                "source": "project_item",
+                                "status": "in_progress",
+                                "dependency_order": "parallel",
+                                "joint_acceptance": "pending",
+                                "owner_repo": "joint",
+                                "contract_status": "reviewing",
+                                "error": "",
+                            },
+                        ) as fetch_live_mock:
+                            with patch(
+                                "scripts.pr_guardian.build_review_packet",
+                                return_value={"issue_number": 24},
+                            ) as build_review_packet_mock:
+                                build_review_context(meta, Path("/tmp/pr-worktree"))
+
+        fetch_live_mock.assert_called_once_with(
+            "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test"
+        )
+        build_review_packet_mock.assert_called_once()
+        kwargs = build_review_packet_mock.call_args.kwargs
+        self.assertIn("integration_ref_live", kwargs)
+        self.assertEqual(kwargs["integration_ref_live"]["source"], "project_item")
+        self.assertEqual(kwargs["integration_ref_live"]["joint_acceptance"], "pending")
+
+    def test_build_review_context_falls_back_to_issue_canonical_integration_ref_for_live_snapshot(self) -> None:
+        meta = {
+            "number": 24,
+            "title": "治理: integration live snapshot fallback",
+            "url": "https://example.test/pr/24",
+            "baseRefName": "main",
+            "headRefOid": "sha-24",
+            "headRefName": "issue-24-branch",
+            "body": "Issue: #24\n## 摘要\n\n- integration_check 暂未补齐\n",
+        }
+
+        with patch("scripts.pr_guardian.fetch_diff_stats", return_value=(["scripts/pr_guardian.py"], "1 file changed")):
+            with patch(
+                "scripts.pr_guardian.build_item_context_summary",
+                return_value=({"issue": "24", "item_key": "GOV-0024-guardian-review-context"}, [], []),
+            ):
+                with patch(
+                    "scripts.pr_guardian.resolve_issue_canonical_integration",
+                    return_value=(
+                        24,
+                        {
+                            "integration_touchpoint": "active",
+                            "shared_contract_changed": "no",
+                            "integration_ref": "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test",
+                            "external_dependency": "both",
+                            "merge_gate": "integration_check_required",
+                            "contract_surface": "runtime_modes",
+                            "joint_acceptance_needed": "yes",
+                        },
+                    ),
+                ):
+                    with patch(
+                        "scripts.pr_guardian.fetch_issue_context",
+                        return_value={"identity": ["- Issue: #24"], "summary": "issue summary", "canonical_integration": {}},
+                    ):
+                        with patch(
+                            "scripts.pr_guardian.fetch_integration_ref_live_state",
+                            return_value={
+                                "source": "project_item",
+                                "status": "in_progress",
+                                "dependency_order": "parallel",
+                                "joint_acceptance": "ready",
+                                "owner_repo": "joint",
+                                "contract_status": "reviewing",
+                            },
+                        ) as fetch_live_mock:
+                            with patch(
+                                "scripts.pr_guardian.build_review_packet",
+                                return_value={"issue_number": 24},
+                            ) as build_review_packet_mock:
+                                build_review_context(meta, Path("/tmp/pr-worktree"))
+
+        fetch_live_mock.assert_called_once_with(
+            "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_test"
+        )
+        kwargs = build_review_packet_mock.call_args.kwargs
+        self.assertEqual(kwargs["integration_ref_live"]["source"], "project_item")
+
+    def test_build_review_context_skips_live_fetch_for_local_only_integration_ref_none(self) -> None:
+        meta = {
+            "number": 24,
+            "title": "治理: local-only integration snapshot",
+            "url": "https://example.test/pr/24",
+            "baseRefName": "main",
+            "headRefOid": "sha-24",
+            "headRefName": "issue-24-branch",
+            "body": "\n".join(
+                [
+                    "Issue: #24",
+                    "## integration_check",
+                    "",
+                    "- integration_touchpoint: none",
+                    "- shared_contract_changed: no",
+                    "- integration_ref: none",
+                    "- external_dependency: none",
+                    "- merge_gate: local_only",
+                    "- contract_surface: none",
+                    "- joint_acceptance_needed: no",
+                    "- integration_status_checked_before_pr: no",
+                    "- integration_status_checked_before_merge: no",
+                ]
+            ),
+        }
+
+        with patch("scripts.pr_guardian.fetch_diff_stats", return_value=(["scripts/pr_guardian.py"], "1 file changed")):
+            with patch(
+                "scripts.pr_guardian.build_item_context_summary",
+                return_value=({"issue": "24", "item_key": "GOV-0024-guardian-review-context"}, [], []),
+            ):
+                with patch(
+                    "scripts.pr_guardian.resolve_issue_canonical_integration",
+                    return_value=(24, {}),
+                ):
+                    with patch(
+                        "scripts.pr_guardian.fetch_issue_context",
+                        return_value={"identity": [], "summary": "", "canonical_integration": {}},
+                    ):
+                        with patch("scripts.pr_guardian.fetch_integration_ref_live_state") as fetch_live_mock:
+                            with patch(
+                                "scripts.pr_guardian.build_review_packet",
+                                return_value={"issue_number": 24},
+                            ) as build_review_packet_mock:
+                                build_review_context(meta, Path("/tmp/pr-worktree"))
+
+        fetch_live_mock.assert_not_called()
+        kwargs = build_review_packet_mock.call_args.kwargs
+        self.assertEqual(kwargs["integration_ref_live"], {})
 
     def test_build_review_context_keeps_nested_issue_summary_from_pr_body(self) -> None:
         meta = {
@@ -532,6 +1771,7 @@ class CodexReviewExecutionTests(unittest.TestCase):
             "headRefName": "issue-24-branch",
             "body": "\n".join(
                 [
+                    "Issue: #24",
                     "## Issue 摘要",
                     "",
                     "## Goal",
@@ -550,8 +1790,19 @@ class CodexReviewExecutionTests(unittest.TestCase):
                 "scripts.pr_guardian.build_item_context_summary",
                 return_value=({"issue": "24", "item_key": "GOV-0024-guardian-review-context"}, [], []),
             ):
-                with patch("scripts.pr_guardian.fetch_issue_context") as fetch_issue_context_mock:
-                    payload = build_review_context(meta, Path("/tmp/pr-worktree"))
+                with patch(
+                    "scripts.pr_guardian.resolve_issue_canonical_integration",
+                    return_value=(24, {}),
+                ):
+                    with patch(
+                        "scripts.pr_guardian.build_review_packet",
+                        return_value={},
+                    ):
+                        with patch(
+                            "scripts.pr_guardian.fetch_issue_context",
+                            return_value={"identity": [], "summary": "", "canonical_integration": {}},
+                        ) as fetch_issue_context_mock:
+                            payload = build_review_context(meta, Path("/tmp/pr-worktree"))
 
         fetch_issue_context_mock.assert_not_called()
         self.assertIn("## Goal", payload["pr_sections"]["issue_summary"])
@@ -850,6 +2101,27 @@ class CodexReviewExecutionTests(unittest.TestCase):
 
 
 class MergeIfSafeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._integration_live_state_patcher = patch(
+            "scripts.pr_guardian.fetch_integration_ref_live_state",
+            return_value={
+                "source": "project_item",
+                "status": "review",
+                "dependency_order": "parallel",
+                "joint_acceptance": "ready",
+                "owner_repo": "joint",
+                "contract_status": "reviewing",
+                "blocked": False,
+                "error": "",
+            },
+        )
+        self.integration_live_state_mock = self._integration_live_state_patcher.start()
+
+    def tearDown(self) -> None:
+        self._integration_live_state_patcher.stop()
+        super().tearDown()
+
     @patch("scripts.pr_guardian.run")
     @patch("scripts.pr_guardian.find_latest_guardian_result")
     @patch("scripts.pr_guardian.pr_meta")
@@ -923,6 +2195,44 @@ class MergeIfSafeTests(unittest.TestCase):
         require_auth_mock.assert_called_once()
 
     @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.find_latest_guardian_result", return_value=None)
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_uses_current_pr_body_when_checking_guardian_cache(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        run_mock,
+    ) -> None:
+        current_meta = {
+            "number": 1,
+            "isDraft": False,
+            "headRefOid": "sha-reviewed",
+            "body": "## integration_check\n\n- integration_status_checked_before_pr: yes\n",
+        }
+        pr_meta_mock.return_value = current_meta
+        review_once_mock.return_value = (
+            current_meta,
+            {
+                "verdict": "REQUEST_CHANGES",
+                "safe_to_merge": False,
+                "summary": "reran",
+            },
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
+
+        self.assertIn("guardian 未给出 APPROVE", str(ctx.exception))
+        find_result_mock.assert_called_once_with(1, "sha-reviewed", body=current_meta["body"], require_body_bound=True)
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
+        run_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+
+    @patch("scripts.pr_guardian.run")
     @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
     @patch("scripts.pr_guardian.find_latest_guardian_result")
     @patch("scripts.pr_guardian.pr_meta")
@@ -941,6 +2251,7 @@ class MergeIfSafeTests(unittest.TestCase):
             "number": 1,
             "isDraft": False,
             "headRefOid": "sha-1",
+            "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
         }
         find_result_mock.return_value = {
             "schema_version": 1,
@@ -984,17 +2295,26 @@ class MergeIfSafeTests(unittest.TestCase):
                 "number": 1,
                 "isDraft": False,
                 "headRefOid": "sha-2",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
             },
             {
                 "number": 1,
                 "isDraft": False,
                 "headRefOid": "sha-2",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-2",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
             },
         ]
         review_once_mock.return_value = (
             {
                 "number": 1,
                 "headRefOid": "sha-2",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
             },
             {
                 "verdict": "APPROVE",
@@ -1017,6 +2337,58 @@ class MergeIfSafeTests(unittest.TestCase):
 
     @patch("scripts.pr_guardian.run")
     @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result", return_value=None)
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_rejects_body_drift_after_fresh_review_when_head_is_unchanged(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        reviewed_body = LOCAL_ONLY_INTEGRATION_CHECK_BODY
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-2",
+                "body": reviewed_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-2",
+                "body": reviewed_body + "\n\n补充说明：review 后被编辑\n",
+            },
+        ]
+        review_once_mock.return_value = (
+            {
+                "number": 1,
+                "headRefOid": "sha-2",
+                "body": reviewed_body,
+            },
+            {
+                "verdict": "APPROVE",
+                "safe_to_merge": True,
+                "summary": "fresh",
+            },
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
+
+        self.assertIn("guardian 审查后 PR 描述已变化", str(ctx.exception))
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
+        all_checks_mock.assert_not_called()
+        run_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
     @patch("scripts.pr_guardian.find_latest_guardian_result")
     @patch("scripts.pr_guardian.pr_meta")
     @patch("scripts.pr_guardian.require_auth")
@@ -1035,17 +2407,26 @@ class MergeIfSafeTests(unittest.TestCase):
                 "number": 1,
                 "isDraft": False,
                 "headRefOid": "sha-3",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
             },
             {
                 "number": 1,
                 "isDraft": False,
                 "headRefOid": "sha-3",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-3",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
             },
         ]
         review_once_mock.return_value = (
             {
                 "number": 1,
                 "headRefOid": "sha-3",
+                "body": LOCAL_ONLY_INTEGRATION_CHECK_BODY,
             },
             {
                 "verdict": "APPROVE",
@@ -1138,6 +2519,1070 @@ class MergeIfSafeTests(unittest.TestCase):
         self.assertIn("GitHub checks 未全部通过", str(ctx.exception))
         review_once_mock.assert_not_called()
         run_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_rejects_contradictory_local_only_integration_metadata(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        pr_meta_mock.return_value = {
+            "number": 1,
+            "isDraft": False,
+            "headRefOid": "sha-integration-contradiction",
+            "body": CONTRADICTORY_LOCAL_ONLY_INTEGRATION_CHECK_BODY,
+        }
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-integration-contradiction",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
+
+        self.assertIn("integration merge gate 未满足", str(ctx.exception))
+        self.assertIn("`merge_gate=local_only` 与当前 integration 元数据冲突", str(ctx.exception))
+        review_once_mock.assert_not_called()
+        run_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_requires_explicit_merge_time_integration_recheck_confirmation(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        pr_meta_mock.return_value = {
+            "number": 1,
+            "isDraft": False,
+            "headRefOid": "sha-needs-recheck",
+            "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        }
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-needs-recheck",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(1, post=False, delete_branch=False, refresh_review=False)
+
+        self.assertIn("--confirm-integration-recheck", str(ctx.exception))
+        review_once_mock.assert_not_called()
+        run_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_records_merge_time_integration_recheck_before_merging(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-needs-recheck",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
+
+        exit_code = merge_if_safe(
+            1,
+            post=False,
+            delete_branch=False,
+            refresh_review=False,
+            confirm_integration_recheck=True,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(run_mock.call_count, 2)
+        edit_command = run_mock.call_args_list[0].args[0]
+        merge_command = run_mock.call_args_list[1].args[0]
+        self.assertEqual(edit_command[:4], ["gh", "pr", "edit", "1"])
+        self.assertIn("--body-file", edit_command)
+        self.assertEqual(
+            merge_command,
+            ["gh", "pr", "merge", "1", "--squash", "--match-head-commit", "sha-needs-recheck"],
+        )
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_reruns_guardian_when_cached_body_bound_verdict_becomes_stale_after_recheck(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        edited_bodies: list[str] = []
+
+        def run_side_effect(command, cwd=None, check=True):
+            if command[:4] == ["gh", "pr", "edit", "1"]:
+                body_file = Path(command[command.index("--body-file") + 1])
+                edited_bodies.append(body_file.read_text(encoding="utf-8"))
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+            if command[:4] == ["gh", "pr", "merge", "1"]:
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 2,
+            "pr_number": 1,
+            "head_sha": "sha-needs-recheck",
+            "body_fingerprint": guardian_body_fingerprint(INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY),
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        review_once_mock.return_value = (
+            {
+                "number": 1,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+            {
+                "verdict": "APPROVE",
+                "safe_to_merge": True,
+                "summary": "fresh-for-final-body",
+            },
+        )
+        run_mock.side_effect = run_side_effect
+
+        exit_code = merge_if_safe(
+            1,
+            post=False,
+            delete_branch=False,
+            refresh_review=False,
+            confirm_integration_recheck=True,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(edited_bodies), 1)
+        self.assertIn("- integration_status_checked_before_merge: yes", edited_bodies[0])
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "merge", "1"])
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.restore_merge_time_integration_recheck_or_die")
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_rejects_same_head_body_drift_after_recheck_refresh_review(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+        restore_merge_time_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        concurrent_body = updated_body + "\n\n补充说明：refresh 后被编辑\n"
+
+        def run_side_effect(command, cwd=None, check=True):
+            if command[:4] == ["gh", "pr", "edit", "1"]:
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-needs-recheck",
+                "body": concurrent_body,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 2,
+            "pr_number": 1,
+            "head_sha": "sha-needs-recheck",
+            "body_fingerprint": guardian_body_fingerprint(INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY),
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        review_once_mock.return_value = (
+            {
+                "number": 1,
+                "headRefOid": "sha-needs-recheck",
+                "body": updated_body,
+            },
+            {
+                "verdict": "APPROVE",
+                "safe_to_merge": True,
+                "summary": "fresh-for-final-body",
+            },
+        )
+        run_mock.side_effect = run_side_effect
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("merge 前重跑 guardian 后 PR 描述已变化", str(ctx.exception))
+        review_once_mock.assert_called_once_with(1, post=False, json_output=None)
+        restore_merge_time_mock.assert_called_once()
+        self.assertEqual(run_mock.call_count, 1)
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_rejects_body_drift_before_recording_merge_time_recheck(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        concurrent_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY + "\n\n补充说明：并发编辑\n"
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": concurrent_body,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-reviewed",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("PR 描述已变化", str(ctx.exception))
+        run_mock.assert_not_called()
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_restores_recheck_when_refresh_after_record_fails(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        edited_bodies: list[str] = []
+
+        def run_side_effect(command, cwd=None, check=True):
+            if command[:4] == ["gh", "pr", "edit", "1"]:
+                body_file = Path(command[command.index("--body-file") + 1])
+                edited_bodies.append(body_file.read_text(encoding="utf-8"))
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            SystemExit("refresh failed"),
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-reviewed",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        run_mock.side_effect = run_side_effect
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("无法重新读取最新 PR 描述", str(ctx.exception))
+        self.assertEqual(run_mock.call_count, 1)
+        self.assertEqual(len(edited_bodies), 1)
+        self.assertIn("- integration_status_checked_before_merge: yes", edited_bodies[0])
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_does_not_restore_body_when_refresh_after_record_fails(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        edited_bodies: list[str] = []
+
+        def run_side_effect(command, cwd=None, check=True):
+            if command[:4] == ["gh", "pr", "edit", "1"]:
+                body_file = Path(command[command.index("--body-file") + 1])
+                edited_bodies.append(body_file.read_text(encoding="utf-8"))
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            SystemExit("refresh failed"),
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-reviewed",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        run_mock.side_effect = run_side_effect
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("不会尝试自动恢复", str(ctx.exception))
+        self.assertEqual(run_mock.call_count, 1)
+        self.assertEqual(len(edited_bodies), 1)
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_rejects_pr_body_drift_after_integration_validation(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        concurrent_body = updated_body + "\n\n补充说明：merge 前又有编辑\n"
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": concurrent_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": concurrent_body,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-reviewed",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("执行 `gh pr merge` 前 PR 描述已变化", str(ctx.exception))
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(run_mock.call_args_list[0].args[0][:4], ["gh", "pr", "edit", "1"])
+        self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "edit", "1"])
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_rejects_head_change_after_recording_merge_time_recheck(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-unreviewed",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-unreviewed",
+                "body": updated_body.replace(
+                    "- integration_status_checked_before_merge: yes",
+                    "- integration_status_checked_before_merge: no",
+                ),
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-reviewed",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        run_mock.return_value = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout="", stderr="")
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("merge 前 integration 复核后 PR HEAD 已变化", str(ctx.exception))
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(run_mock.call_args_list[0].args[0][:4], ["gh", "pr", "edit", "1"])
+        self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "edit", "1"])
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_reverts_merge_time_recheck_when_merge_command_fails(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-reviewed",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        run_mock.side_effect = [
+            subprocess.CompletedProcess(args=["gh", "pr", "edit"], returncode=0, stdout="", stderr=""),
+            CommandError(["gh", "pr", "merge", "1"], "命令失败", "", "merge failed"),
+            subprocess.CompletedProcess(args=["gh", "pr", "edit"], returncode=0, stdout="", stderr=""),
+        ]
+
+        with self.assertRaises(CommandError):
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertEqual(run_mock.call_count, 3)
+        self.assertEqual(run_mock.call_args_list[0].args[0][:4], ["gh", "pr", "edit", "1"])
+        self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "merge", "1"])
+        self.assertEqual(run_mock.call_args_list[2].args[0][:4], ["gh", "pr", "edit", "1"])
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_does_not_restore_stale_body_over_concurrent_edits(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        updated_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_status_checked_before_merge: no",
+            "- integration_status_checked_before_merge: yes",
+        )
+        concurrent_body = updated_body + "\n\n补充说明：其他人已更新 PR 描述\n"
+        pr_meta_mock.side_effect = [
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": updated_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": concurrent_body,
+            },
+            {
+                "number": 1,
+                "isDraft": False,
+                "headRefOid": "sha-reviewed",
+                "body": concurrent_body,
+            },
+        ]
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-reviewed",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        edited_bodies: list[str] = []
+
+        def run_side_effect(command, cwd=None, check=True):
+            if command[:4] == ["gh", "pr", "edit", "1"]:
+                body_file = Path(command[command.index("--body-file") + 1])
+                edited_bodies.append(body_file.read_text(encoding="utf-8"))
+                return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+            if command[:4] == ["gh", "pr", "merge", "1"]:
+                raise CommandError(command, "命令失败", "", "merge failed")
+            raise AssertionError(f"unexpected command: {command}")
+
+        run_mock.side_effect = run_side_effect
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("执行 `gh pr merge` 前 PR 描述已变化", str(ctx.exception))
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(run_mock.call_args_list[0].args[0][:4], ["gh", "pr", "edit", "1"])
+        self.assertEqual(run_mock.call_args_list[1].args[0][:4], ["gh", "pr", "edit", "1"])
+        self.assertEqual(len(edited_bodies), 2)
+        self.assertIn("其他人已更新 PR 描述", edited_bodies[1])
+        self.assertIn("- integration_status_checked_before_merge: no", edited_bodies[1])
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    def test_fetch_issue_context_parses_issue_form_headings(self) -> None:
+        with patch(
+            "scripts.pr_guardian.run",
+            return_value=subprocess.CompletedProcess(args=["gh"], returncode=0, stdout='{"number": 105, "title": "治理：integration baseline", "url": "https://example.test/issues/105", "body": "### 摘要\\n\\n- 为 Syvert 保留本地执行真相源\\n\\n### 范围\\n\\n- 补齐 integration 联动插槽"}', stderr=""),
+        ):
+            context = fetch_issue_context(105)
+
+        self.assertIn("- Issue: #105", context["identity"])
+        self.assertIn("## Goal", context["summary"])
+        self.assertIn("## Scope", context["summary"])
+
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_does_not_record_recheck_before_validation_succeeds(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+    ) -> None:
+        invalid_body = INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY.replace(
+            "- integration_ref: https://github.com/MC-and-his-Agents/WebEnvoy/issues/466",
+            "- integration_ref: none",
+        )
+        pr_meta_mock.return_value = {
+            "number": 1,
+            "isDraft": False,
+            "headRefOid": "sha-invalid-before-record",
+            "body": invalid_body,
+        }
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-invalid-before-record",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("integration merge gate 未满足", str(ctx.exception))
+        run_mock.assert_not_called()
+        review_once_mock.assert_not_called()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.fetch_integration_ref_live_state")
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_blocks_when_live_integration_ref_joint_acceptance_not_ready(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+        fetch_live_mock,
+    ) -> None:
+        pr_meta_mock.return_value = {
+            "number": 1,
+            "isDraft": False,
+            "headRefOid": "sha-live-not-ready",
+            "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        }
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-live-not-ready",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        fetch_live_mock.return_value = {
+            "source": "project_item",
+            "status": "review",
+            "dependency_order": "parallel",
+            "joint_acceptance": "pending",
+            "owner_repo": "joint",
+            "contract_status": "reviewing",
+            "blocked": False,
+            "error": "",
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("联合验收状态未就绪", str(ctx.exception))
+        run_mock.assert_not_called()
+        review_once_mock.assert_not_called()
+        fetch_live_mock.assert_called_once()
+        require_auth_mock.assert_called_once()
+        all_checks_mock.assert_called_once_with(1)
+
+    @patch("scripts.pr_guardian.fetch_integration_ref_live_state")
+    @patch("scripts.pr_guardian.run")
+    @patch("scripts.pr_guardian.all_checks_pass", return_value=True)
+    @patch("scripts.pr_guardian.find_latest_guardian_result")
+    @patch("scripts.pr_guardian.pr_meta")
+    @patch("scripts.pr_guardian.require_auth")
+    @patch("scripts.pr_guardian.review_once")
+    def test_merge_blocks_when_live_integration_ref_cannot_be_read(
+        self,
+        review_once_mock,
+        require_auth_mock,
+        pr_meta_mock,
+        find_result_mock,
+        all_checks_mock,
+        run_mock,
+        fetch_live_mock,
+    ) -> None:
+        pr_meta_mock.return_value = {
+            "number": 1,
+            "isDraft": False,
+            "headRefOid": "sha-live-unreadable",
+            "body": INTEGRATION_GATED_PENDING_MERGE_RECHECK_BODY,
+        }
+        find_result_mock.return_value = {
+            "schema_version": 1,
+            "pr_number": 1,
+            "head_sha": "sha-live-unreadable",
+            "verdict": "APPROVE",
+            "safe_to_merge": True,
+            "summary": "cached",
+            "reviewed_at": "2026-03-28T10:00:00Z",
+        }
+        fetch_live_mock.return_value = {
+            "source": "project_item",
+            "error": "无法读取 `integration_ref` 指向的 project item `PVTI_test`，拒绝继续。",
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            merge_if_safe(
+                1,
+                post=False,
+                delete_branch=False,
+                refresh_review=False,
+                confirm_integration_recheck=True,
+            )
+
+        self.assertIn("无法读取 `integration_ref` 指向的 project item", str(ctx.exception))
+        run_mock.assert_not_called()
+        review_once_mock.assert_not_called()
+        fetch_live_mock.assert_called_once()
         require_auth_mock.assert_called_once()
         all_checks_mock.assert_called_once_with(1)
 

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -865,7 +865,7 @@ class CodexReviewExecutionTests(unittest.TestCase):
             },
         ),
     )
-    def test_integration_merge_gate_errors_accepts_equivalent_issue_and_project_item_refs(
+    def test_integration_merge_gate_errors_rejects_cross_form_issue_and_project_item_refs(
         self,
         resolve_issue_mock,
         fetch_live_mock,
@@ -890,9 +890,12 @@ class CodexReviewExecutionTests(unittest.TestCase):
 
         errors = integration_merge_gate_errors(meta)
 
-        self.assertEqual(errors, [])
+        self.assertEqual(
+            errors,
+            ["`integration_check.integration_ref` 与 Issue #105 中的 canonical integration 元数据不一致。"],
+        )
         resolve_issue_mock.assert_called_once_with(meta)
-        self.assertEqual(fetch_live_mock.call_count, 2)
+        fetch_live_mock.assert_not_called()
 
     def test_integration_merge_gate_errors_rejects_local_only_external_integration_ref(self) -> None:
         meta = {


### PR DESCRIPTION
## 摘要

- PR Class: `governance`
- 变更目的：将 `open_pr / pr_guardian / merge_pr / governance_status` 收口到同一条 canonical integration contract 消费链路，并把 `integration_ref` 的 carrier 语义收敛到受控入口。
- 主要改动：
  - reviewer packet 只消费 canonical contract，对比 issue / PR 元数据并保持 merge-time 复核边界
  - guardian cache 改为 body-bound schema v2 复用，读兼容 schema v1
  - `open_pr` 在受控入口只归一“可证明等价”的 `integration_ref`，并同时覆盖 issue-ref / project-item-ref 两个方向
  - `governance_status` 区分 PR / issue 视图，并在 PR 缺失 `integration_check` 时仍展示 issue 侧 live-state gate 诊断
  - direct project item live-state 允许 canonical owner project 的 `DraftIssue` 作为可核查 truth source，消除 project-item carrier 与 merge gate 的语义分裂
  - `governance_status` 在 PR 缺失 `integration_check` 但 issue 仍受 integration gate 约束时，会回显 issue-side merge gate 语义，避免状态面自相矛盾

## Issue 摘要

## Goal

补齐 `Syvert × WebEnvoy` 的跨仓治理联动插槽，让 Syvert 继续作为本地执行真相源，并在需要时能显式联动 WebEnvoy 与后续 integration project。

## 关联事项

- Issue: #105
- item_key: `GOV-0105-integration-governance-baseline`
- item_type: `GOV`
- release: `governance-baseline`
- sprint: `integration-governance`
- Closing: Refs #105

## 风险

- 风险级别：`high`
- 审查关注：
  - `integration_ref` carrier 归一必须只在受控入口发生，review / merge / status 不得再各自解释第二套 contract
  - review-time 与 merge-time 的 live-state 边界必须保持稳定，避免再次出现 reviewer packet / status / merge gate 语义漂移
  - owner-level Integration Project 的 DraftIssue-backed canonical item 必须继续受 owner/project/required-fields/status/joint-acceptance fail-closed 约束，不能被放宽成任意 project item

## 验证

- 已执行：
  - `python3 -m unittest tests.governance.test_integration_contract tests.governance.test_open_pr tests.governance.test_pr_guardian tests.governance.test_governance_status` -> `Ran 240 tests ... OK`（head `81dff3a`）
  - `python3 scripts/workflow_guard.py --mode pre-commit` -> `workflow-guard 通过`（head `81dff3a`）
  - `python3 scripts/governance_gate.py --mode ci --base-sha origin/main --head-sha HEAD --head-ref issue-105-integration-governance-baseline-consumer-wiring` -> `governance-gate 通过`（head `81dff3a`）
  - `python3 scripts/governance_status.py --pr 115` -> `comparison_errors=0 / merge_validation_errors=0 / integration_ref_live_errors=0 / merge_gate=integration_check_required`（head `81dff3a`）
- 未执行：
  - GitHub checks 仍在当前 head `81dff3a` 上刷新
  - guardian 尚未在当前 head `81dff3a` 上形成最终可复用 verdict

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。

## integration_check

- integration_touchpoint: active
- shared_contract_changed: yes
- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_lADOECSWpc4BUdmRzgpwYyM
- external_dependency: both
- merge_gate: integration_check_required
- contract_surface: runtime_modes
- joint_acceptance_needed: yes
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: no