### PR TITLE
docs(governance): 收口 GOV-0105 rollout evidence

### DIFF
--- a/docs/decisions/ADR-GOV-0105-integration-governance-baseline.md
+++ b/docs/decisions/ADR-GOV-0105-integration-governance-baseline.md
@@ -10,29 +10,26 @@
 
 ## 背景
 
-当前 owner 下已经同时推进 `Syvert` 与 `WebEnvoy`，但两个仓库此前缺少统一的跨仓治理插槽，导致共享契约、跨仓依赖与联合验收只能靠口头约定或临时同步处理。
+当前 owner 下已经同时推进 `Syvert` 与 `WebEnvoy`，仓库内需要一份稳定、单一的 canonical integration contract，来约束 issue / PR / reviewer / guardian / merge gate 的一致消费方式。
 
-`#107` 已验证单一大 PR 会把 contract 定义、消费者接线、载体对齐和 rollout evidence 一次性耦合，超出稳定审查范围。本事项改为按同一 Work Item `#105` 串行拆成多个小 PR 落地。
+在 `PR-A Contract Kernel`、`PR-B Consumer Wiring` 与 `PR-C Carrier Alignment` 合并后，仓库内运行时消费者与 carrier 已经收口到同一 contract；剩余的 owner 级 GitHub Project、labels 与 backfill 事实只应作为 rollout evidence 保留，不能继续混入 contract 主体。
 
 ## 决策
 
 - canonical integration contract 的单一真相源固定在仓库内：机器可读定义位于 `scripts/policy/integration_contract.json`，共享消费逻辑位于 `scripts/integration_contract.py`。
-- 本事项按四个串行 PR 收口：`PR-A Contract Kernel`、`PR-B Consumer Wiring`、`PR-C Carrier Alignment`、`PR-D Evidence / Rollout`。
-- 第一批必须先把 `Issue + decision + exec-plan` 的 bootstrap contract 落到 `main`，后续三个 PR 才能在同一事项上下文下继续通过受控入口推进。
-- 两个仓库的 issue / PR / review / workflow 载体最终都只消费 canonical integration contract，不再各自维护第二套 integration 枚举或组合约束。
-- `PR-C Carrier Alignment` 负责把 `WORKFLOW.md`、`code_review.md`、PR template 与 issue forms 收口到同一 carrier 集合，并明确 `Phase` 不是 canonical integration metadata carrier。
+- 仓库内所有治理消费者都只消费这一份 canonical integration contract：Issue / Work Item metadata、PR `integration_check`、reviewer、guardian、`merge_pr` 与 `governance_status` 不得再各自维护第二套 integration 字段、枚举或组合约束。
+- `WORKFLOW.md`、`code_review.md`、PR template 与 issue forms 只暴露 carrier 与消费边界，不承载第二套 contract 规则；`Phase` 不是 canonical integration metadata carrier。
 - 纯本仓库事项保持 `integration_touchpoint=none`；触及共享契约、跨仓依赖或联合验收时，必须显式绑定 integration ref。
-- 外部 GitHub Project、labels 与 issue backfill 只作为 rollout evidence，不再写入 repo 内 contract 主体。
+- 外部 GitHub Project、labels 与 issue backfill 只作为 rollout evidence，单独记录在 evidence 工件中，不再写入 repo 内 contract 主体、ADR 主体或 active `exec-plan` 主体。
 
 ## 约束
 
 - 本轮只补跨仓联动插槽，不引入自动 bot、自动同步或第三个代码仓库。
 - 本地 issue / PR 仍是执行与关闭真相源；外部 integration project 只承担协调语义，且其当前 live state 只能作为 merge gate 运行时输入。
-- 当前事项继续只使用 `Issue #105` / `item_key=GOV-0105-integration-governance-baseline`，不额外拆新的执行 issue。
 - 若后续扩张共享契约枚举、联合验收流程或 merge gate 语义，必须在新的独立治理事项中推进，不得直接扩展当前事项范围。
 
 ## 影响
 
-- 当前事项的 bootstrap contract 由 `Issue #105 + ADR-GOV-0105 + GOV-0105 exec-plan` 构成；替代链路中的各个 PR 只承担各自层级的实现与验证。
-- `#107` 保留为冻结的拆分母体和审查历史容器，不再进入 merge；替代 PR 链路全部合并后再按 superseded 关闭。
+- 仓库内治理终态收口为“一份 canonical integration contract + 多个只读 consumer/carrier”，而不是“多份分散规则文本”。
+- repo 内 contract 与 repo 外 rollout evidence 的职责彻底分离：前者决定 merge gate 与 consumer 语义，后者只保留外部系统的核验入口与 rollout 证据。
 - 后续所有触及跨仓共享契约的 Syvert / WebEnvoy PR，都必须通过 canonical integration contract 显式判断是否进入 integration merge gate。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -9,7 +9,7 @@
 - sprint：`integration-governance`
 - 关联 spec：无（治理联动事项）
 - 关联 decision：`docs/decisions/ADR-GOV-0105-integration-governance-baseline.md`
-- 关联 PR：当前 `PR-D Evidence / Rollout` docs closeout round（创建后以 GitHub PR 元数据为准）
+- 关联 PR：`#117`
 - active 收口事项：`GOV-0105-integration-governance-baseline`
 
 ## 目标
@@ -51,6 +51,12 @@
 - 已执行：`python3 scripts/workflow_guard.py --mode pre-commit`
 - 已执行：`python3 scripts/docs_guard.py --mode ci`
 - 已执行：`python3 scripts/open_pr.py --class governance --issue 105 --item-key GOV-0105-integration-governance-baseline --item-type GOV --release governance-baseline --sprint integration-governance --title "docs(governance): 收口 GOV-0105 rollout evidence" --base main --closing refs --draft --integration-touchpoint active --shared-contract-changed yes --integration-ref "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_lADOECSWpc4BUdmRzgpwYyM" --external-dependency both --merge-gate integration_check_required --contract-surface runtime_modes --joint-acceptance-needed yes --integration-status-checked-before-pr yes --integration-status-checked-before-merge no --dry-run`
+- 已执行：`gh issue view 105 --repo MC-and-his-Agents/Syvert --json url,state,labels,projectItems,body`
+- 已执行：`gh issue view 107 --repo MC-and-his-Agents/Syvert --json url,state,title`
+- 已执行：`gh pr view 114 --repo MC-and-his-Agents/Syvert --json url,mergedAt,title`
+- 已执行：`gh pr view 115 --repo MC-and-his-Agents/Syvert --json url,mergedAt,title`
+- 已执行：`gh pr view 116 --repo MC-and-his-Agents/Syvert --json url,mergedAt,title`
+- 已执行：`gh pr view 117 --repo MC-and-his-Agents/Syvert --json url,state,isDraft,title`
 
 ## 未决风险
 
@@ -65,4 +71,4 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - 最近一次完成 PR-D docs closeout 内容收口并同步最小门禁证据的 checkpoint：`25fbe5168aa6cfb8536384633e27efbdf7f48da5`
-- 当前 PR 审查态如继续产生新的 review / merge gate 元数据补充，可保留该 checkpoint，并由 guardian 与 merge gate 绑定当前 docs closeout PR 的 latest head。
+- 当前 PR 审查态如继续产生新的 review / merge gate 元数据补充，可保留该 checkpoint，并由 guardian 与 merge gate 绑定当前 docs closeout PR `#117` 的 latest head。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -48,7 +48,9 @@
 
 ## 已验证项
 
-- 待本轮 docs 变更完成后刷新。
+- 已执行：`python3 scripts/workflow_guard.py --mode pre-commit`
+- 已执行：`python3 scripts/docs_guard.py --mode ci`
+- 已执行：`python3 scripts/open_pr.py --class governance --issue 105 --item-key GOV-0105-integration-governance-baseline --item-type GOV --release governance-baseline --sprint integration-governance --title "docs(governance): 收口 GOV-0105 rollout evidence" --base main --closing refs --draft --integration-touchpoint active --shared-contract-changed yes --integration-ref "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_lADOECSWpc4BUdmRzgpwYyM" --external-dependency both --merge-gate integration_check_required --contract-surface runtime_modes --joint-acceptance-needed yes --integration-status-checked-before-pr yes --integration-status-checked-before-merge no --dry-run`
 
 ## 未决风险
 
@@ -62,5 +64,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 当前 docs closeout round 的内容 checkpoint 将在本批文档收口与最小门禁验证完成后刷新到最新 head。
-- 本轮 guardian 与 merge gate 必须绑定当前 docs closeout PR 的 latest head，不得继续复用 `#116` 收口阶段的审查态摘要。
+- 最近一次完成 PR-D docs closeout 内容收口并同步最小门禁证据的 checkpoint：`25fbe5168aa6cfb8536384633e27efbdf7f48da5`
+- 当前 PR 审查态如继续产生新的 review / merge gate 元数据补充，可保留该 checkpoint，并由 guardian 与 merge gate 绑定当前 docs closeout PR 的 latest head。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -28,13 +28,13 @@
 
 - `PR-A/#114`、`PR-B/#115`、`PR-C/#116` 已合并到 `main`，仓库内 canonical integration contract、运行时治理链路与 carrier 已经完成收口。
 - 当前剩余 repo 内动作是 `PR-D Evidence / Rollout`：把外部 GitHub rollout 事实移出 ADR / active `exec-plan` 主体，并单独落盘为 rollout evidence。
+- `PR-D/#117` 已以 Draft 形式打开，当前 docs closeout 内容、最小门禁验证与 GitHub evidence capture 已完成，停点转为 guardian / merge gate 收口。
 - `#107` 仍保持冻结的 superseded closeout 候选状态，等待替代链完全收口后补 replacement chain 并关闭。
 
 ## 下一步动作
 
-- 完成 ADR、`exec-plan` 与 rollout evidence 文档改写。
-- 运行 `python3 scripts/workflow_guard.py --mode pre-commit` 与 `python3 scripts/docs_guard.py --mode ci`。
-- 通过 `open_pr.py` 开 Draft PR，收口 checks、guardian 与 merge gate 后合并。
+- 在当前 head 上收口 guardian findings，并保持 ADR / `exec-plan` / rollout evidence 三者叙事一致。
+- 待 guardian 给出 `APPROVE + safe_to_merge=true` 且 checks 全绿后，将 `#117` 从 Draft 转为 Ready 并通过 `merge_pr.py` 受控合并。
 - PR-D 合并后，在 `#107` 补 replacement chain comment 并关闭为 superseded；必要时在 `#105` 补最终收口说明。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -70,5 +70,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 最近一次完成 PR-D docs closeout 内容收口并同步最小门禁证据的 checkpoint：`25fbe5168aa6cfb8536384633e27efbdf7f48da5`
-- 当前 PR 审查态如继续产生新的 review / merge gate 元数据补充，可保留该 checkpoint，并由 guardian 与 merge gate 绑定当前 docs closeout PR `#117` 的 latest head。
+- 最近一次完成 PR-D docs closeout 内容收口并同步外部 evidence capture 的 checkpoint：`3cbaab775acc363e39c5dff97768e6192683119a`
+- 当前 PR 审查态如继续产生 review / merge gate 元数据补充，可保留该 checkpoint，并由 guardian 与 merge gate 绑定当前 docs closeout PR `#117` 的 latest head。

--- a/docs/exec-plans/GOV-0105-integration-governance-baseline.md
+++ b/docs/exec-plans/GOV-0105-integration-governance-baseline.md
@@ -9,64 +9,58 @@
 - sprint：`integration-governance`
 - 关联 spec：无（治理联动事项）
 - 关联 decision：`docs/decisions/ADR-GOV-0105-integration-governance-baseline.md`
-- 关联 PR：`#116`
+- 关联 PR：当前 `PR-D Evidence / Rollout` docs closeout round（创建后以 GitHub PR 元数据为准）
 - active 收口事项：`GOV-0105-integration-governance-baseline`
 
 ## 目标
 
-- 把 `WORKFLOW.md`、`code_review.md`、PR template 与 issue forms 收口到仓库内唯一的 canonical integration contract 上，让 carrier 侧不再维护第二套 integration 规则。
-- 明确 `Phase` 不是 canonical integration metadata carrier，并把 integration metadata 的合法落点限制在 FR / Work Item / governance issue 与 PR `integration_check`。
-- 保持 `Syvert` 继续作为本地执行真相源，并在已完成 PR-B consumer wiring 的前提上，为后续 PR-D evidence / rollout 收口提供稳定的 carrier 基线。
+- 把 GOV-0105 的 repo 内治理终态收口到“一份 canonical integration contract + 一份独立 rollout evidence”。
+- 让 ADR 只保留 repo 内 single-source contract 决策，让 active `exec-plan` 只保留当前 docs closeout round 的停点、风险、验证与下一步。
+- 把 owner 级 GitHub Project、labels、backfill 与 replacement chain 事实集中记录到独立 evidence 文档，不再写回 contract 主体。
 
 ## 范围
 
-- 已合并的 PR-A 只纳入：`scripts/policy/integration_contract.json`、`scripts/integration_contract.py`、`scripts/common.py` 中与 integration contract 直接相关的最小辅助逻辑、`tests/governance/test_integration_contract.py`，以及当前 bootstrap contract 文档。
-- 已合并的 PR-B 纳入：`open_pr / pr_guardian / merge_pr / governance_status` 的共享消费链路、对应治理测试，以及保证该链路在独立 worktree 上可执行的最小兼容修正。
-- 当前 PR-C 纳入：`WORKFLOW.md`、`code_review.md`、PR template、issue forms 的 carrier alignment，以及保证这些 carrier 与 canonical contract 顺序 / 角色一致的最小一致性测试。
-- 后续 PR-D 再纳入：platform evidence 与本事项最终叙事收口。
-- 本次不纳入：自动 bot / 自动同步系统、新的产品仓库、跨仓实现代码、对现有 `Phase / FR / sprint` 语义做统一改造。
+- 当前 PR-D 只纳入：`docs/decisions/ADR-GOV-0105-integration-governance-baseline.md`、本 `exec-plan` 与 `docs/governance-rollouts/GOV-0105-platform-evidence.md`。
+- 本次负责：清理 ADR / `exec-plan` 中仍残留的批次叙事与外部 rollout 事实，并为外部 GitHub rollout 建立独立 evidence 入口。
+- 本次不纳入：`WORKFLOW.md`、`code_review.md`、PR template、issue forms、`open_pr / pr_guardian / merge_pr / governance_status`、共享 contract 内核、外部系统自动同步。
 
 ## 当前停点
 
-- `#107` 保持 Draft 并冻结，不再继续修 findings 或提交 guardian；它只作为拆分母体和审查历史容器保留。
-- `PR-A Contract Kernel` 已合并到 `main`，当前仓库内 canonical integration contract 已成为后续替代 PR 的 bootstrap truth source。
-- `PR-B Consumer Wiring` 已合并到 `main`，当前仓库内运行时治理链路已统一到 canonical integration contract。
-- 当前真正需要收口的是 `PR-C Carrier Alignment`，即让 `WORKFLOW.md`、`code_review.md`、PR template 与 issue forms 只暴露 canonical carrier，不再维护第二套 integration 规则，并明确 `Phase` carve-out。
-- 当前 PR-C 已以 Draft PR `#116` 打开；本地门禁与 GitHub checks 已通过，当前停点转为 reviewer / guardian 对 `#116` latest head 的收口。
+- `PR-A/#114`、`PR-B/#115`、`PR-C/#116` 已合并到 `main`，仓库内 canonical integration contract、运行时治理链路与 carrier 已经完成收口。
+- 当前剩余 repo 内动作是 `PR-D Evidence / Rollout`：把外部 GitHub rollout 事实移出 ADR / active `exec-plan` 主体，并单独落盘为 rollout evidence。
+- `#107` 仍保持冻结的 superseded closeout 候选状态，等待替代链完全收口后补 replacement chain 并关闭。
 
 ## 下一步动作
 
-- 在同一 head 上等待 reviewer 与 guardian 收口，再执行 `#116` 的受控合并。
-- `#116` 合并后，再按同一 `Issue #105` 推进 PR-D 并在最后关闭 `#107`。
+- 完成 ADR、`exec-plan` 与 rollout evidence 文档改写。
+- 运行 `python3 scripts/workflow_guard.py --mode pre-commit` 与 `python3 scripts/docs_guard.py --mode ci`。
+- 通过 `open_pr.py` 开 Draft PR，收口 checks、guardian 与 merge gate 后合并。
+- PR-D 合并后，在 `#107` 补 replacement chain comment 并关闭为 superseded；必要时在 `#105` 补最终收口说明。
 
 ## 当前 checkpoint 推进的 release 目标
 
-- 让 canonical integration contract 从“运行时治理链路已统一”推进到“carrier 已完成对齐”，使 workflow / review / template / issue forms 不再各自维护第二套 integration 语义。
+- 让 GOV-0105 从“carrier 已对齐”推进到“repo 内 contract 主体与 repo 外 rollout evidence 已彻底分离”的最终治理终态。
 
 ## 当前事项在 sprint 中的角色 / 阻塞
 
-- 角色：替代链路的第三批 `PR-C Carrier Alignment`。
-- 阻塞：在 PR-C 合并前，workflow / review / template / issue forms 仍未完全对齐 canonical carrier；`Phase` 仍缺少明确的 integration metadata carve-out，PR-D 也还无法在稳定 carrier 基线之上完成最终 evidence 收口。
+- 角色：替代链路的第四批 `PR-D Evidence / Rollout` docs closeout round。
+- 阻塞：在 docs closeout 完成前，ADR / active `exec-plan` 仍带有批次性叙事；`#107` 也还不能按完整 replacement chain 关闭为 superseded。
 
 ## 已验证项
 
-- 已执行：`python3 -m unittest tests.governance.test_integration_carriers`
-- 已执行：`python3 scripts/workflow_guard.py --mode pre-commit`
-- 已执行：`python3 scripts/docs_guard.py --mode ci`
+- 待本轮 docs 变更完成后刷新。
 
 ## 未决风险
 
-- 若 PR-C 再继续夹带 evidence rollout 或运行时治理逻辑，scope 会再次膨胀，guardian finding 也会重新跨层连锁。
-- `main` 在替代链路推进期间继续前进；每一批 PR 在进入 guardian 和 merge 前都必须基于最新 `origin/main` 重跑本地门禁。
-- 由于当前 issue 已声明 canonical integration 字段，后续所有替代 PR 都必须完整对齐 contract，不允许退回 legacy 路径。
-- 当前 PR-C 仍在 carrier 收口阶段，因此 reviewer / guardian 应聚焦 carrier 是否与 canonical contract 一致，而不是重新解释运行时 integration 语义。
-- reviewer 阶段不能把外部 integration project 的 live-state 漂移升级为审查阻断；相关 live-state 只允许出现在运行时治理链路与 merge gate 入口。
+- 若 ADR / `exec-plan` 再次回写外部 GitHub rollout 事实，repo 内 contract 主体会重新失焦。
+- rollout evidence 文档若不在合并前刷新到最新 GitHub 状态，`#107` 的 replacement chain 与 `#105` 的外部 evidence 可能与 live state 漂移。
+- 当前分支使用自定义 GOV-0105 split worktree；在 PR-D 合并后必须按分支是否仍存在分别清理 worktree、state 与 branch。
 
 ## 回滚方式
 
-- 如需回滚，使用独立 revert PR 撤销 carrier alignment 与对应一致性测试，让 `#105` 回退到“运行时治理链路已统一，但 carrier 尚未完全对齐”的状态。
+- 如需回滚，使用独立 revert PR 撤销本批 docs-only closeout，让 ADR / `exec-plan` 与 rollout evidence 恢复到 PR-C 合并后的状态；该回滚不影响 runtime tooling 或 carrier 行为。
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 最近一次完成 PR-C carrier alignment 代码收口并同步验证证据的 checkpoint：`8debbd9fd776f94bf66d9aa431a85241172f7d72`
-- 当前 PR 审查态以 `#116` 的 latest head 为准；本轮最小验证集与 guardian 必须绑定同一 latest head，不得继续复用旧批次的验证摘要。
+- 当前 docs closeout round 的内容 checkpoint 将在本批文档收口与最小门禁验证完成后刷新到最新 head。
+- 本轮 guardian 与 merge gate 必须绑定当前 docs closeout PR 的 latest head，不得继续复用 `#116` 收口阶段的审查态摘要。

--- a/docs/governance-rollouts/GOV-0105-platform-evidence.md
+++ b/docs/governance-rollouts/GOV-0105-platform-evidence.md
@@ -20,6 +20,14 @@
 
 ## 当前核验记录
 
+- 采集时间：`2026-04-15T02:56:55Z`
+- 采集命令：
+  - `gh issue view 105 --repo MC-and-his-Agents/Syvert --json url,state,labels,projectItems,body`
+  - `gh issue view 107 --repo MC-and-his-Agents/Syvert --json url,state,title`
+  - `gh pr view 114 --repo MC-and-his-Agents/Syvert --json url,mergedAt,title`
+  - `gh pr view 115 --repo MC-and-his-Agents/Syvert --json url,mergedAt,title`
+  - `gh pr view 116 --repo MC-and-his-Agents/Syvert --json url,mergedAt,title`
+  - `gh pr view 117 --repo MC-and-his-Agents/Syvert --json url,state,isDraft,title`
 - `#105` 当前 labels：
   - `governance`
   - `integration:active`
@@ -27,13 +35,21 @@
   - `Syvert 主交付看板`：`Todo`
   - `Syvert × WebEnvoy Integration`：`Review`
 - `integration_ref` 当前指向 owner 级 project item，live state 已可由 merge gate / `governance_status` 读取。
+- `#107` 当前状态：`OPEN`；待 replacement chain 完整后关闭为 superseded。
+- `#114` / `#115` / `#116` 已分别在 `2026-04-14T10:04:20Z`、`2026-04-14T17:28:37Z`、`2026-04-15T02:19:22Z` 合并。
+- `#117` 为当前 `PR-D Evidence / Rollout` docs closeout PR，当前状态：`OPEN`、`Draft=true`。
+
+## Backfill
+
+- GOV-0105 在进入 PR-D 前已经具备 canonical integration metadata、`integration:active` label 与 owner 级 integration project item。
+- 本轮没有额外执行新的 labels / project / field backfill 变更；PR-D 只把这些既有外部事实的核验入口与快照集中保存在本 evidence 文档中。
 
 ## Replacement Chain
 
 - `PR-A Contract Kernel`：`#114`
 - `PR-B Consumer Wiring`：`#115`
 - `PR-C Carrier Alignment`：`#116`
-- `PR-D Evidence / Rollout`：本批 docs closeout round
+- `PR-D Evidence / Rollout`：`#117`
 
 ## 边界说明
 

--- a/docs/governance-rollouts/GOV-0105-platform-evidence.md
+++ b/docs/governance-rollouts/GOV-0105-platform-evidence.md
@@ -1,0 +1,41 @@
+# GOV-0105 Platform Evidence
+
+## 关联信息
+
+- Issue：`#105`
+- item_key：`GOV-0105-integration-governance-baseline`
+- release：`governance-baseline`
+- sprint：`integration-governance`
+
+## 目标
+
+- 为 GOV-0105 保留 repo 外 rollout facts 的独立证据入口。
+- 证明 external GitHub Project / labels / backfill 只作为 rollout evidence 存在，不再回写到 canonical integration contract 主体。
+
+## 外部 evidence 入口
+
+- integration project item：<https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_lADOECSWpc4BUdmRzgpwYyM>
+- canonical issue：<https://github.com/MC-and-his-Agents/Syvert/issues/105>
+- superseded PR candidate：<https://github.com/MC-and-his-Agents/Syvert/pull/107>
+
+## 当前核验记录
+
+- `#105` 当前 labels：
+  - `governance`
+  - `integration:active`
+- `#105` 当前 project items：
+  - `Syvert 主交付看板`：`Todo`
+  - `Syvert × WebEnvoy Integration`：`Review`
+- `integration_ref` 当前指向 owner 级 project item，live state 已可由 merge gate / `governance_status` 读取。
+
+## Replacement Chain
+
+- `PR-A Contract Kernel`：`#114`
+- `PR-B Consumer Wiring`：`#115`
+- `PR-C Carrier Alignment`：`#116`
+- `PR-D Evidence / Rollout`：本批 docs closeout round
+
+## 边界说明
+
+- 本文档只记录 repo 外 rollout evidence 与 superseded closeout 所需的核验入口。
+- canonical integration contract 的字段、枚举、merge gate 语义与 consumer 规则，以 `scripts/policy/integration_contract.json` 与 `scripts/integration_contract.py` 为准，不在此处重复。

--- a/docs/governance-rollouts/GOV-0105-platform-evidence.md
+++ b/docs/governance-rollouts/GOV-0105-platform-evidence.md
@@ -37,7 +37,7 @@
 - `integration_ref` 当前指向 owner 级 project item，live state 已可由 merge gate / `governance_status` 读取。
 - `#107` 当前状态：`OPEN`；待 replacement chain 完整后关闭为 superseded。
 - `#114` / `#115` / `#116` 已分别在 `2026-04-14T10:04:20Z`、`2026-04-14T17:28:37Z`、`2026-04-15T02:19:22Z` 合并。
-- `#117` 为当前 `PR-D Evidence / Rollout` docs closeout PR，当前状态：`OPEN`、`Draft=true`。
+- 在 `2026-04-15T02:56:55Z` 的采集快照中，`#117` 为当前 `PR-D Evidence / Rollout` docs closeout PR，状态为 `OPEN`、`Draft=true`。
 
 ## Backfill
 


### PR DESCRIPTION
## 摘要

- PR Class: `governance`
- 变更目的：把 GOV-0105 的 repo 内 canonical contract 主体与 repo 外 rollout evidence 彻底拆开
- 主要改动：ADR 只保留 single-source contract 决策、active exec-plan 只保留 docs closeout 停点，并新增独立 platform evidence 文档承接外部 GitHub rollout facts

## Issue 摘要

## Goal

补齐 `Syvert × WebEnvoy` 的跨仓治理联动插槽，让 Syvert 继续作为本地执行真相源，并在需要时能显式联动 WebEnvoy 与后续 integration project。

## 关联事项

- Issue: #105
- item_key: `GOV-0105-integration-governance-baseline`
- item_type: `GOV`
- release: `governance-baseline`
- sprint: `integration-governance`
- Closing: Refs #105

## 风险

- 风险级别：`medium`
- 审查关注：ADR / exec-plan 是否仍只保留 repo 内 contract 语义，外部 GitHub Project / labels / backfill 是否已完全收口到独立 evidence 文档

## 验证

- 已执行：`python3 scripts/workflow_guard.py --mode pre-commit`
- 已执行：`python3 scripts/docs_guard.py --mode ci`
- 已执行：`python3 scripts/open_pr.py --class governance --issue 105 --item-key GOV-0105-integration-governance-baseline --item-type GOV --release governance-baseline --sprint integration-governance --title "docs(governance): 收口 GOV-0105 rollout evidence" --base main --closing refs --draft --integration-touchpoint active --shared-contract-changed yes --integration-ref "https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_lADOECSWpc4BUdmRzgpwYyM" --external-dependency both --merge-gate integration_check_required --contract-surface runtime_modes --joint-acceptance-needed yes --integration-status-checked-before-pr yes --integration-status-checked-before-merge no --dry-run`
- 未执行：latest guardian（待当前 checks 全绿后重跑）

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: active
- shared_contract_changed: yes
- integration_ref: https://github.com/orgs/MC-and-his-Agents/projects/3?pane=issue&itemId=PVTI_lADOECSWpc4BUdmRzgpwYyM
- external_dependency: both
- merge_gate: integration_check_required
- contract_surface: runtime_modes
- joint_acceptance_needed: yes
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: no
补充说明：

- 本批只纳入 ADR、active `exec-plan` 与独立 platform evidence 文档，不回改 carrier 或 runtime tooling。
- `integration_check_required` 的 merge-time recheck 仍留给 guardian / `merge_pr`，不提前宣称已完成。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本批 docs-only closeout，让 GOV-0105 回退到 PR-C 合并后的仓内文档状态。
