### PR TITLE
docs(closeout): 收口 FR-0007 父事项

### DIFF
--- a/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
+++ b/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
@@ -117,6 +117,14 @@
 
 ## GitHub closeout 工件
 
+- `#121` 正文修正目标：
+  - 执行状态改为 `已完成（PR #125 已 MERGED）`
+  - 回填最终受审 head、docs checkpoint、metadata-only follow-up、merge commit 与最终验证记录
+  - 明确本事项只负责 docs / GitHub closeout 收口，不引入新 runtime 或 formal spec 语义
+- `#121` closeout 评论草案：
+  - `FR-0007` requirement container、active parent closeout exec-plan、release / sprint 索引已通过 PR `#125` 收口到主干
+  - `#67` 将按同一轮 closeout 更新正文并关闭
+  - `#63` 仅在 `#64/#65/#66/#67` 全部关闭且阶段正文完成对齐后才关闭
 - `#67` 正文修正目标：
   - 明确 formal spec 已由 PR `#84` 合入主干
   - 明确版本 gate 编排已由 `#118` / PR `#122` 落地
@@ -130,10 +138,17 @@
   - `#119` / PR `#124` 已完成双参考适配器真实回归执行器
   - `#120` / PR `#123` 已完成平台泄漏检查器，并独立区分 GitHub merge 真相与本地清理尾项
   - 当前父事项 closeout 已由 `#121` 承接，release / sprint / exec-plan / GitHub issue 真相已回链到同一条 `FR-0007` 证据链
+- `#63` 正文修正目标：
+  - 保持子 FR 为 `#64/#65/#66/#67`
+  - 当 `#67` 已关闭时，把阶段完成事实补齐为：`#64/#65/#66/#67` 均已 closed，且 `v0.2.0` release / sprint / formal spec / exec-plan 真相已一致
+  - 若 `#67` 仍未关闭，则不得把阶段写成已完成
 - `#63` 条件性关闭前提：
   - `#64/#65/#66/#67` 必须全部 `CLOSED`
   - `#63` 正文必须更新为与 `docs/releases/v0.2.0.md`、`docs/sprints/2026-S15.md` 一致的阶段完成事实
   - 若任一条件不满足，则不得关闭 `#63`
+- `#63` 条件性 closeout 评论草案：
+  - 若条件满足：`v0.2.0` 契约可验证 Core 阶段已完成，`#64/#65/#66/#67` 全部 closed，release / sprint / formal spec / exec-plan 真相已统一
+  - 若条件不满足：在 `#63` 留下 blocker 评论，明确尚未满足的 issue / project 条件，并保持 `#63` 为 `OPEN`
 
 ## 未决风险
 
@@ -151,5 +166,9 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `0603e3060f3518621afa4c0f0862e95b3d8e2380`
-- 说明：该 checkpoint 已新增 `FR-0007` requirement container、active parent closeout plan 与 release / sprint closeout 入口，并已绑定当前受审 PR `#125`；后续若只补 PR / issue 当前事实或验证记录，只能作为 metadata-only follow-up。
+- 实质 docs checkpoint：`0603e3060f3518621afa4c0f0862e95b3d8e2380`
+- 后续 metadata-only follow-up：
+  - `d5c01d6ad6780d9cf5bfce4d9fc43c60b3d2966c`：绑定当前受审 PR `#125` 与 docs 门禁记录
+  - `369758d383ff7dc2608d5f0b1d80216c3467ed64`：修正 `FR-0007` 历史子回合在 requirement container / release / sprint 中的状态口径
+  - `5992c5625b8c55ea7115dcb06579dc8515885a9f`：收紧 active parent closeout exec-plan 的剩余动作
+- 说明：`0603e306...` 只承载仓内 closeout 工件首次落盘的实质语义；其后的 PR 绑定、状态口径与 stop-point 更新均作为 metadata-only follow-up 追账，不伪装成新的实质 checkpoint。

--- a/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
+++ b/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
@@ -8,7 +8,7 @@
 - release：`v0.2.0`
 - sprint：`2026-S15`
 - 关联 spec：`docs/specs/FR-0007-release-gate-and-regression-checks/`
-- 关联 PR：`待创建`
+- 关联 PR：`#125`
 - 状态：`active`
 - active 收口事项：`CHORE-0121-fr-0007-parent-closeout`
 
@@ -42,6 +42,8 @@
 - 当前 `FR-0007` GitHub closeout 仍包含 Work Item `#121` 与父 FR `#67`；阶段 `#63` 仍为 `OPEN`，因为其子 FR `#67` 尚未关闭。
 - `#63` 的另外三个子 FR `#64/#65/#66` 已全部 `CLOSED`；`#67` 是当前阻止 `#63` closeout 的唯一直接前提。
 - 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-121-chore-fr-0007`。
+- 当前受审 PR：`#125`
+- 当前 docs checkpoint：`0603e3060f3518621afa4c0f0862e95b3d8e2380`
 
 ## 下一步动作
 
@@ -92,6 +94,16 @@
   - 结果：`state=MERGED`，`mergeCommit=830c1021febf4a4fa5be670dcdece009dc2352b5`
 - `gh pr view 123 --json state,mergedAt,mergeCommit`
   - 结果：`state=MERGED`，`mergeCommit=f9f2b564f17c3ef269eb25faecd12f1c0e18442b`
+- `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
+  - 结果：在 docs checkpoint `0603e3060f3518621afa4c0f0862e95b3d8e2380` 上通过
+- `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
+  - 结果：在 docs checkpoint `0603e3060f3518621afa4c0f0862e95b3d8e2380` 上通过，`PR class=docs`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：在 docs checkpoint `0603e3060f3518621afa4c0f0862e95b3d8e2380` 上通过
+- `python3 scripts/spec_guard.py --all`
+  - 结果：在 docs checkpoint `0603e3060f3518621afa4c0f0862e95b3d8e2380` 上通过
+- `python3 scripts/open_pr.py --class docs --issue 121 --item-key CHORE-0121-fr-0007-parent-closeout --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'docs(closeout): 收口 FR-0007 父事项' --closing fixes`
+  - 结果：已创建当前受审 PR `#125`
 
 ## closeout 证据
 
@@ -139,5 +151,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `f9f2b564f17c3ef269eb25faecd12f1c0e18442b`
-- 说明：该 checkpoint 已包含 `FR-0007` formal spec、`#118/#119/#120` implementation 主干真相与 `#120` closeout 后的 GitHub 状态；本回合仅负责 parent closeout 元数据收口。
+- `0603e3060f3518621afa4c0f0862e95b3d8e2380`
+- 说明：该 checkpoint 已新增 `FR-0007` requirement container、active parent closeout plan 与 release / sprint closeout 入口，并已绑定当前受审 PR `#125`；后续若只补 PR / issue 当前事实或验证记录，只能作为 metadata-only follow-up。

--- a/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
+++ b/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
@@ -47,9 +47,9 @@
 
 ## 下一步动作
 
-- 新增 `FR-0007` requirement container，把 `#79/#118/#119/#120` 历史执行轮次与 `#121` closeout 入口收敛到同一条仓内证据链。
-- 同步 `docs/releases/v0.2.0.md` 与 `docs/sprints/2026-S15.md`，把 `FR-0007` 从 formal spec 入口推进到 implementation + parent closeout 完成的最终叙事。
-- 通过 docs PR 收口 `#121`，合并后修正 GitHub `#121` / `#67` 正文并关闭；若 `#63` 关闭条件届时全部满足，再关闭 `#63`。
+- 在当前受审 PR `#125` 上完成 guardian / merge gate。
+- 合并后修正 GitHub `#121` / `#67` 正文并关闭；若 `#63` 关闭条件届时全部满足，再关闭 `#63`。
+- 独立区分 GitHub merge 真相与本地 branch/worktree 清理真相，避免把收尾问题误判成 closeout 未完成。
 
 ## 当前 checkpoint 推进的 release 目标
 

--- a/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
+++ b/docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md
@@ -1,0 +1,143 @@
+# CHORE-0121-fr-0007-parent-closeout 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0121-fr-0007-parent-closeout`
+- Issue：`#121`
+- item_type：`CHORE`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0007-release-gate-and-regression-checks/`
+- 关联 PR：`待创建`
+- 状态：`active`
+- active 收口事项：`CHORE-0121-fr-0007-parent-closeout`
+
+## 目标
+
+- 在不引入新运行时代码或新 formal spec 语义的前提下，通过合法 Work Item `#121` 完成父 FR `#67` 的最终 closeout。
+- 把 `FR-0007` 的 formal spec、`#118/#119/#120` 实现、release / sprint 索引与 GitHub issue 真相映射回同一条父事项证据链。
+- 在满足条件时关闭 `#121`、关闭 `#67`，并独立核对 `#63` 是否满足阶段关闭前提。
+
+## 范围
+
+- 本次纳入：
+  - `docs/exec-plans/FR-0007-release-gate-and-regression-checks.md`
+  - `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md`
+  - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`
+  - `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`
+  - `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`
+  - `docs/releases/v0.2.0.md`
+  - `docs/sprints/2026-S15.md`
+  - GitHub `#121` / `#67` / `#63` issue 正文与 closeout 评论
+- 本次不纳入：
+  - 任何新的 runtime / adapter / test 实现
+  - `FR-0007` formal spec 语义改写
+  - `FR-0004`、`FR-0005`、`FR-0006` 的事项状态调整
+
+## 当前停点
+
+- `origin/main@f9f2b564f17c3ef269eb25faecd12f1c0e18442b` 已包含 `FR-0007` closeout 所需的关键前提：PR `#84`、`#122`、`#124`、`#123`。
+- `#79` 已由 PR `#84` 合入并关闭；`#118` 已由 PR `#122` 合入并关闭；`#119` 已由 PR `#124` 合入并关闭；`#120` 已由 PR `#123` 合入并关闭。
+- 当前 `FR-0007` GitHub closeout 仍包含 Work Item `#121` 与父 FR `#67`；阶段 `#63` 仍为 `OPEN`，因为其子 FR `#67` 尚未关闭。
+- `#63` 的另外三个子 FR `#64/#65/#66` 已全部 `CLOSED`；`#67` 是当前阻止 `#63` closeout 的唯一直接前提。
+- 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-121-chore-fr-0007`。
+
+## 下一步动作
+
+- 新增 `FR-0007` requirement container，把 `#79/#118/#119/#120` 历史执行轮次与 `#121` closeout 入口收敛到同一条仓内证据链。
+- 同步 `docs/releases/v0.2.0.md` 与 `docs/sprints/2026-S15.md`，把 `FR-0007` 从 formal spec 入口推进到 implementation + parent closeout 完成的最终叙事。
+- 通过 docs PR 收口 `#121`，合并后修正 GitHub `#121` / `#67` 正文并关闭；若 `#63` 关闭条件届时全部满足，再关闭 `#63`。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.2.0` 完成 `FR-0007` 父事项收口，使版本 gate、双参考适配器真实回归与平台泄漏检查 requirement 已被 formal spec、主干实现、验证证据与 GitHub 关闭语义完整消费。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0007` 父事项 closeout Work Item。
+- 阻塞：
+  - 必须先保证 `#79/#118/#119/#120` 全部关闭，且 release / sprint / exec-plan 不再把 `FR-0007` 误表述为只有 formal spec 入口。
+  - 必须在关闭前修正 GitHub `#67` 正文，使其反映 formal spec、版本 gate、双参考适配器真实回归、平台泄漏检查与 parent closeout 的主干真相。
+  - `#63` 只有在 `#67` 关闭后才可能满足阶段关闭前提；不得从 `#64/#65/#66` 已关闭自动推断。
+
+## 已验证项
+
+- 已阅读：`docs/specs/FR-0007-release-gate-and-regression-checks/`
+- 已阅读：`docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
+- 已阅读：`docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`
+- 已阅读：`docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`
+- 已阅读：`docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`
+- `gh issue view 67 --json state,title,url,body`
+  - 结果：`#67` 当前为 `OPEN`，且正文仍只覆盖 formal spec 与子 Work Item 列表，尚未写入 implementation 与 parent closeout 完成事实。
+- `gh issue view 121 --json state,title,url,body`
+  - 结果：`#121` 当前为 `OPEN`，且执行状态仍为 `待开始`。
+- `gh issue view 63 --json state,title,url,body`
+  - 结果：`#63` 当前为 `OPEN`，且关闭条件要求所有子 FR 完成并关闭。
+- `gh issue view 64 --json state,url`
+  - 结果：`#64` 为 `CLOSED`。
+- `gh issue view 65 --json state,url`
+  - 结果：`#65` 为 `CLOSED`。
+- `gh issue view 66 --json state,url`
+  - 结果：`#66` 为 `CLOSED`。
+- `gh issue view 118 --json state,title,url,body`
+  - 结果：`#118` 为 `CLOSED`，对应 PR `#122` / merge commit `eb5bbc3d0bf0dc5b91fe64a8a63aa24c34ba8479`。
+- `gh issue view 119 --json state,title,url,body`
+  - 结果：`#119` 为 `CLOSED`，对应 PR `#124` / merge commit `830c1021febf4a4fa5be670dcdece009dc2352b5`。
+- `gh issue view 120 --json state,title,url,body`
+  - 结果：`#120` 为 `CLOSED`，对应 PR `#123` / merge commit `f9f2b564f17c3ef269eb25faecd12f1c0e18442b`；GitHub merge 真相、issue 关闭真相与 remote branch 删除真相已独立成立。
+- `gh pr view 122 --json state,mergedAt,mergeCommit`
+  - 结果：`state=MERGED`，`mergeCommit=eb5bbc3d0bf0dc5b91fe64a8a63aa24c34ba8479`
+- `gh pr view 124 --json state,mergedAt,mergeCommit`
+  - 结果：`state=MERGED`，`mergeCommit=830c1021febf4a4fa5be670dcdece009dc2352b5`
+- `gh pr view 123 --json state,mergedAt,mergeCommit`
+  - 结果：`state=MERGED`，`mergeCommit=f9f2b564f17c3ef269eb25faecd12f1c0e18442b`
+
+## closeout 证据
+
+- formal spec 证据：PR `#84` 已把 `FR-0007` formal spec 合入主干，对应 `docs/specs/FR-0007-release-gate-and-regression-checks/`
+- implementation 证据：
+  - PR `#122` / `#118`：落地版本 gate 编排与统一结果模型，冻结 harness / real-regression / platform-leakage 三类 source report 的公共消费面
+  - PR `#124` / `#119`：落地双参考适配器真实回归执行器，固定 `xhs` / `douyin` 最小回归矩阵并生成版本 gate 可直接消费的 source report
+  - PR `#123` / `#120`：落地平台泄漏检查器，固定共享边界扫描面、fail-closed evidence trace 与 `shared_input_model` / `shared_error_model` / `shared_result_contract` 分类
+- 主干证据：`origin/main@f9f2b564f17c3ef269eb25faecd12f1c0e18442b` 已包含 `FR-0007` 当前全部 formal spec + implementation 前提
+- GitHub closeout 证据：当前剩余 GitHub closeout issue 为 active Work Item `#121` 与父 FR `#67`；`#63` 需等 `#67` 关闭后再独立核对阶段关闭条件
+
+## GitHub closeout 工件
+
+- `#67` 正文修正目标：
+  - 明确 formal spec 已由 PR `#84` 合入主干
+  - 明确版本 gate 编排已由 `#118` / PR `#122` 落地
+  - 明确双参考适配器真实回归执行器已由 `#119` / PR `#124` 落地
+  - 明确平台泄漏检查器已由 `#120` / PR `#123` 落地
+  - 将父事项 closeout 入口补为 `#121`
+  - 子 Work Item 保持：`#118`、`#119`、`#120`、`#121`
+- `#67` closeout 评论草案：
+  - `FR-0007` formal spec 已由 PR `#84` 合入主干，spec 真相位于 `docs/specs/FR-0007-release-gate-and-regression-checks/`
+  - `#118` / PR `#122` 已完成版本 gate 编排与统一结果模型
+  - `#119` / PR `#124` 已完成双参考适配器真实回归执行器
+  - `#120` / PR `#123` 已完成平台泄漏检查器，并独立区分 GitHub merge 真相与本地清理尾项
+  - 当前父事项 closeout 已由 `#121` 承接，release / sprint / exec-plan / GitHub issue 真相已回链到同一条 `FR-0007` 证据链
+- `#63` 条件性关闭前提：
+  - `#64/#65/#66/#67` 必须全部 `CLOSED`
+  - `#63` 正文必须更新为与 `docs/releases/v0.2.0.md`、`docs/sprints/2026-S15.md` 一致的阶段完成事实
+  - 若任一条件不满足，则不得关闭 `#63`
+
+## 未决风险
+
+- 若 `#67` 关闭前 release / sprint 仍只把 `FR-0007` 视为 formal spec 入口，会留下 requirement / implementation / closeout 语义断裂。
+- 若把 `#120` 这轮的本地 branch/worktree 保留误判成 GitHub merge 未完成，会错误阻塞 `#121` 与 `#67` closeout。
+- 若在 `#67` 关闭前不独立核对 `#63` 的子 FR 状态与阶段正文，会把阶段 closeout 建立在推断而非证据上。
+
+## 回滚方式
+
+- 仓内回滚：如需回滚，使用独立 revert PR 撤销本事项对 `docs/exec-plans/FR-0007-release-gate-and-regression-checks.md`、`docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md`、`docs/releases/v0.2.0.md` 与 `docs/sprints/2026-S15.md` 的增量修改。
+- GitHub 侧回滚：
+  - 若已编辑 `#67` / `#63` 正文但 PR 未合入，恢复其 closeout 前正文，并保留 `#121/#67/#63` 的 open/closed 真相不变
+  - 若已发布 closeout 评论但发现仓内工件仍不一致，在对应 issue 追加纠正评论并停止关闭动作
+  - 若 `#67` 或 `#63` 已关闭后发现 closeout 事实错误，先重新打开对应 issue，再通过独立 revert PR 与新的 closeout 回合修复仓内 / GitHub 状态
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `f9f2b564f17c3ef269eb25faecd12f1c0e18442b`
+- 说明：该 checkpoint 已包含 `FR-0007` formal spec、`#118/#119/#120` implementation 主干真相与 `#120` closeout 后的 GitHub 状态；本回合仅负责 parent closeout 元数据收口。

--- a/docs/exec-plans/FR-0007-release-gate-and-regression-checks.md
+++ b/docs/exec-plans/FR-0007-release-gate-and-regression-checks.md
@@ -1,0 +1,24 @@
+# FR-0007 执行计划（requirement container）
+
+## 关联信息
+
+- item_key：`FR-0007-release-gate-and-regression-checks`
+- Issue：`#67`
+- item_type：`FR`
+- release：`v0.2.0`
+- sprint：`2026-S15`
+- 关联 spec：`docs/specs/FR-0007-release-gate-and-regression-checks/`
+- 状态：`inactive requirement container`
+
+## 说明
+
+- `FR-0007` 作为 canonical requirement 容器，不直接承载 worktree、PR 或 active 执行回合。
+- `FR-0007` formal spec 已由 PR `#84` 合入主干；对应 `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md` 仅保留为历史 formal spec 收口记录。
+- `FR-0007` 的版本 gate 编排与统一结果模型已由 PR `#122` 完成并关闭 `#118`；对应 `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md` 仅保留为历史实现记录。
+- `FR-0007` 的双参考适配器真实回归执行器已由 PR `#124` 完成并关闭 `#119`；对应 `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md` 仅保留为历史实现记录。
+- `FR-0007` 的平台泄漏检查器已由 PR `#123` 完成并关闭 `#120`；对应 `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md` 仅保留为历史实现记录。
+- `FR-0007` 的父事项 closeout 由 `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md` 记录 `#121` 执行回合，并负责把 `#67` 与 `#63` 的关闭语义、release / sprint 索引和 GitHub 真相收口到同一条证据链。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `f9f2b564f17c3ef269eb25faecd12f1c0e18442b`

--- a/docs/exec-plans/FR-0007-release-gate-and-regression-checks.md
+++ b/docs/exec-plans/FR-0007-release-gate-and-regression-checks.md
@@ -13,10 +13,11 @@
 ## 说明
 
 - `FR-0007` 作为 canonical requirement 容器，不直接承载 worktree、PR 或 active 执行回合。
-- `FR-0007` formal spec 已由 PR `#84` 合入主干；对应 `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md` 仅保留为历史 formal spec 收口记录。
-- `FR-0007` 的版本 gate 编排与统一结果模型已由 PR `#122` 完成并关闭 `#118`；对应 `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md` 仅保留为历史实现记录。
-- `FR-0007` 的双参考适配器真实回归执行器已由 PR `#124` 完成并关闭 `#119`；对应 `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md` 仅保留为历史实现记录。
-- `FR-0007` 的平台泄漏检查器已由 PR `#123` 完成并关闭 `#120`；对应 `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md` 仅保留为历史实现记录。
+- `FR-0007` formal spec 已由 PR `#84` 合入主干；对应 `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md` 保留 formal spec 收口轮次的原始执行记录。
+- `FR-0007` 的版本 gate 编排与统一结果模型已由 PR `#122` 完成并关闭 `#118`；对应 `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md` 保留该实现轮次的原始执行记录。
+- `FR-0007` 的双参考适配器真实回归执行器已由 PR `#124` 完成并关闭 `#119`；对应 `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md` 保留该实现轮次的原始执行记录。
+- `FR-0007` 的平台泄漏检查器已由 PR `#123` 完成并关闭 `#120`；对应 `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md` 保留该实现轮次的原始执行记录。
+- 上述子事项 exec-plan 中残留的 active / current 表述仅绑定各自已结束的历史执行轮次，不构成当前 `FR-0007` 的 active 入口，也不重新打开这些 Work Item。
 - `FR-0007` 的父事项 closeout 由 `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md` 记录 `#121` 执行回合，并负责把 `#67` 与 `#63` 的关闭语义、release / sprint 索引和 GitHub 真相收口到同一条证据链。
 
 ## 最近一次 checkpoint 对应的 head SHA

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -96,9 +96,9 @@
   - `docs/exec-plans/CHORE-0100-fr-0006-parent-closeout.md`（current active；绑定 Issue `#110`）
   - `docs/exec-plans/FR-0007-release-gate-and-regression-checks.md`（inactive requirement container；绑定 FR `#67`）
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
-  - `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`（historical / inactive；实现已由 PR `#122` 收口）
-  - `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`（historical / inactive；实现已由 PR `#124` 收口）
-  - `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`（historical / inactive；实现已由 PR `#123` 收口）
+  - `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`（历史实现轮次记录；实现已由 PR `#122` 收口）
+  - `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`（历史实现轮次记录；实现已由 PR `#124` 收口）
+  - `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`（历史实现轮次记录；实现已由 PR `#123` 收口）
   - `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md`（绑定 Issue `#121`）
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`
   - `docs/exec-plans/GOV-0028-harness-compat-migration.md`

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -25,6 +25,10 @@
 - `FR-0003-github-delivery-structure-and-repo-semantic-split`：`v0.2.0` governance requirement 主线，对应 Issue `#55`
 - `FR-0007-release-gate-and-regression-checks`：版本 gate 与回归检查 requirement，对应 Issue `#67`
 - `CHORE-0079-fr-0007-formal-spec-closeout`：`FR-0007` formal spec 收口 Work Item，对应 Issue `#79`
+- `CHORE-0118-fr-0007-version-gate-orchestrator`：`FR-0007` 版本 gate 编排与统一结果模型，对应 Issue `#118`，已由 PR `#122` 合入主干
+- `CHORE-0119-fr-0007-dual-reference-adapter-regression`：`FR-0007` 双参考适配器真实回归执行器，对应 Issue `#119`，已由 PR `#124` 合入主干
+- `CHORE-0120-fr-0007-platform-leakage-check`：`FR-0007` 平台泄漏检查器，对应 Issue `#120`，已由 PR `#123` 合入主干
+- `CHORE-0121-fr-0007-parent-closeout`：`FR-0007` 父事项 closeout Work Item，对应 Issue `#121`
 - `FR-0004-input-target-and-collection-policy`：`v0.2.0` 共享输入模型与采集策略模型；父事项 closeout 当前由 Work Item `#95` 承接
 - `CHORE-0068-fr-0004-implementation-closeout`：`FR-0004` implementation 聚合 closeout，对应 Issue `#68`，已由 PR `#93` 收口
 - `CHORE-0087-fr-0004-core-input-admission`：`FR-0004` Core 输入受理与共享模型接入，对应 Issue `#87`
@@ -58,6 +62,7 @@
 - 当前仅剩父 FR `#64` closeout，由 Work Item `#95` / PR `#96` 把以上主干事实与 GitHub 关闭语义完成最终对齐
 - `FR-0005` 的 formal spec 已由 PR `#78` 合入主干；`#69` 已由 PR `#97` 收口标准化错误模型实现；`#70` 已由 PR `#98` 收口 adapter registry 实现；当前仅剩父 FR `#65` closeout，由 Work Item `#99` 承接
 - `FR-0006` 的 fake adapter / harness host 已由 `#102` / PR `#104` 合入主干；验证工具已由 `#101` / PR `#108` 合入主干；contract samples 与最小 automation 已由 `#103` / PR `#109` 合入主干；当前仅剩父 FR `#66` closeout，由 Work Item `#110` 承接
+- `FR-0007` 的 formal spec 已由 PR `#84` 合入主干；`#118` 已由 PR `#122` 收口版本 gate 编排与统一结果模型；`#119` 已由 PR `#124` 收口双参考适配器真实回归执行器；`#120` 已由 PR `#123` 收口平台泄漏检查器；父事项 closeout 由 Work Item `#121` 负责把上述主干事实与 GitHub 关闭语义完成最终对齐
 
 ## 关联工件
 
@@ -89,7 +94,12 @@
   - `docs/exec-plans/CHORE-0101-fr-0006-validation-tooling.md`
   - `docs/exec-plans/CHORE-0103-fr-0006-contract-samples-minimal-automation.md`
   - `docs/exec-plans/CHORE-0100-fr-0006-parent-closeout.md`（current active；绑定 Issue `#110`）
+  - `docs/exec-plans/FR-0007-release-gate-and-regression-checks.md`（inactive requirement container；绑定 FR `#67`）
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`（historical / inactive；实现已由 PR `#122` 收口）
+  - `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`（historical / inactive；实现已由 PR `#124` 收口）
+  - `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`（historical / inactive；实现已由 PR `#123` 收口）
+  - `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md`（绑定 Issue `#121`）
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`
   - `docs/exec-plans/GOV-0028-harness-compat-migration.md`
   - `docs/exec-plans/GOV-0029-remove-legacy-todo-md.md`

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -151,9 +151,9 @@
   - `docs/exec-plans/CHORE-0100-fr-0006-parent-closeout.md`（current active；绑定 Issue `#110`）
   - `docs/exec-plans/FR-0007-release-gate-and-regression-checks.md`（inactive requirement container；绑定 FR `#67`）
   - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
-  - `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`（historical / inactive；实现已由 PR `#122` 收口）
-  - `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`（historical / inactive；实现已由 PR `#124` 收口）
-  - `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`（historical / inactive；实现已由 PR `#123` 收口）
+  - `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`（历史实现轮次记录；实现已由 PR `#122` 收口）
+  - `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`（历史实现轮次记录；实现已由 PR `#124` 收口）
+  - `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`（历史实现轮次记录；实现已由 PR `#123` 收口）
   - `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md`（绑定 Issue `#121`）
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`
   - `docs/exec-plans/GOV-0028-harness-compat-migration.md`

--- a/docs/sprints/2026-S15.md
+++ b/docs/sprints/2026-S15.md
@@ -36,6 +36,10 @@
 - `FR-0003-github-delivery-structure-and-repo-semantic-split`：`v0.2.0` governance requirement 主线，对应 Phase `#54` 下的 FR `#55`
 - `FR-0007-release-gate-and-regression-checks`：`v0.2.0` 版本 gate 与回归检查 requirement，对应 Phase `#63` 下的 FR `#67`
 - `CHORE-0079-fr-0007-formal-spec-closeout`：`FR-0007` formal spec 收口 Work Item，对应 Issue `#79`
+- `CHORE-0118-fr-0007-version-gate-orchestrator`：`FR-0007` 版本 gate 编排与统一结果模型，对应 Issue `#118`，已由 PR `#122` 合入主干
+- `CHORE-0119-fr-0007-dual-reference-adapter-regression`：`FR-0007` 双参考适配器真实回归执行器，对应 Issue `#119`，已由 PR `#124` 合入主干
+- `CHORE-0120-fr-0007-platform-leakage-check`：`FR-0007` 平台泄漏检查器，对应 Issue `#120`，已由 PR `#123` 合入主干
+- `CHORE-0121-fr-0007-parent-closeout`：`FR-0007` 父事项 closeout Work Item，对应 Issue `#121`
 - `GOV-0027-governance-contract-rewrite`：`FR-0003` 首个治理 Work Item，对应 Issue `#56`
 - `GOV-0028-harness-compat-migration`：后续 harness 兼容迁移 Work Item，对应 Issue `#57`
 - `GOV-0029-remove-legacy-todo-md`：移除 legacy `TODO.md` 的正式治理流入口，对应 Issue `#58`
@@ -60,6 +64,7 @@
 - `CHORE-0042` 已把双参考适配器共享 Core 路径验证收口到可追溯工件链：`CHORE-0047`、`CHORE-0050`、共享 registry 验证与当前 closeout exec-plan
 - `FR-0003` formal spec 已入库，并明确 GitHub 单一调度层与仓内单一语义层边界
 - `FR-0007` formal spec 已入库，并明确版本 gate、双参考适配器回归与平台泄漏检查的 requirement 边界
+- `FR-0007` 的实现子事项 `#118/#119/#120` 已全部合入主干，并把版本 gate、双参考适配器真实回归与平台泄漏检查收口为同一条版本级验证主线；当前由 `#121` 承接父事项 closeout。
 - `FR-0004` formal spec 已入库，并冻结 `InputTarget` 与 `CollectionPolicy` 的共享模型边界
 - `GOV-0027` 已让当前 sprint 可直接索引 `v0.2.0` 的治理工件入口，而不引入第二套状态真相源
 - `GOV-0029` 已把 legacy `TODO.md` 从 formal spec live 最小套件、模板与治理主链路中移除
@@ -71,12 +76,14 @@
 - `CHORE-0047` 与 `CHORE-0050` 已把小红书、抖音两个真实参考适配器合入主干，并保留可追溯的手动验收记录。
 - `CHORE-0042` 已把双参考适配器共享 Core 路径验证收口到 release / sprint / exec-plan 工件链，为 `#38` 与 `v0.1.0` 的正式完成判定提供直接输入。
 - `FR-0004` 的 implementation 子事项 `#87/#89/#88` 已全部合入主干，对应 PR `#90/#91/#92`；`#68` 聚合 closeout 已由 PR `#93` 收口，当前仅剩 `#64` 父 FR closeout，由 Work Item `#95` / PR `#96` 承接。
+- `FR-0007` 已从 formal spec 入口推进到 implementation 主线：PR `#122/#124/#123` 已分别收口版本 gate、双参考适配器真实回归与平台泄漏检查；当前 `#121` 负责把 `#67` 与 release / sprint / exec-plan / GitHub issue 真相完成最终 closeout。
 - `GOV-0029` 已清理 template / FR 套件中的 legacy `TODO.md` 实体，并让 guard、policy、`open_pr` 与治理测试对该删除语义保持一致。
 
 ## 本轮新增入口
 
 - `FR-0003` / `GOV-0027` 已在当前 sprint 建立治理入口；相关 formal spec、exec-plan、decision 与 release/sprint 索引工件见下方“关联工件”。
 - `FR-0007` 已在当前 sprint 建立版本 gate formal spec 入口，为后续 contract harness / 回归检查实现回合提供 requirement 基线。
+- `FR-0007` 已在当前 sprint 建立 requirement container 与 parent closeout 入口，用于把 `#79/#118/#119/#120/#121` 的 formal spec、实现与 closeout 证据收成一致。
 - `FR-0004` 已在当前 sprint 建立共享输入模型与采集策略的 formal spec 入口；对应 requirement 继续由 FR `#64` 承载。
 - `CHORE-0068-fr-0004-formal-spec-closeout` 已完成 formal spec 历史收口；当前仅保留归档索引。
 - `CHORE-0087` 已在当前 sprint 建立 `FR-0004` 的首个 implementation 入口，负责把共享输入模型接入 Core 输入受理层。
@@ -99,9 +106,9 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`、`#87`、`#88`、`#89`、`#90`、`#91`、`#92`、`#93`、`#95`、`#96`、`#97`、`#98`、`#99`、`#101`、`#102`、`#103`、`#104`、`#108`、`#109`、`#110`、`#111`
+- 相关 Issue / PR：`#38`、`#39`、`#40`、`#41`、`#42`、`#44`、`#47`、`#48`、`#50`、`#51`、`#52`、`#64`、`#65`、`#66`、`#67`、`#69`、`#70`、`#74`、`#77`、`#79`、`#84`、`#87`、`#88`、`#89`、`#90`、`#91`、`#92`、`#93`、`#95`、`#96`、`#97`、`#98`、`#99`、`#101`、`#102`、`#103`、`#104`、`#108`、`#109`、`#110`、`#111`、`#118`、`#119`、`#120`、`#121`、`#122`、`#123`、`#124`
 - `pre-v0.2.0` governance 事项树：`#54`、`#55`、`#56`、`#57`、`#58`
-- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`、`#87`、`#88`、`#89`、`#95`、`#99`、`#101`、`#102`、`#103`、`#110`
+- `v0.2.0` 契约可验证 Core 事项树：`#63`、`#64`、`#65`、`#66`、`#67`、`#68`、`#69`、`#70`、`#74`、`#77`、`#79`、`#87`、`#88`、`#89`、`#95`、`#99`、`#101`、`#102`、`#103`、`#110`、`#118`、`#119`、`#120`、`#121`
 
 ## 关联工件
 
@@ -142,10 +149,15 @@
   - `docs/exec-plans/CHORE-0101-fr-0006-validation-tooling.md`
   - `docs/exec-plans/CHORE-0103-fr-0006-contract-samples-minimal-automation.md`
   - `docs/exec-plans/CHORE-0100-fr-0006-parent-closeout.md`（current active；绑定 Issue `#110`）
+  - `docs/exec-plans/FR-0007-release-gate-and-regression-checks.md`（inactive requirement container；绑定 FR `#67`）
+  - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0118-fr-0007-version-gate-orchestrator.md`（historical / inactive；实现已由 PR `#122` 收口）
+  - `docs/exec-plans/CHORE-0119-fr-0007-dual-reference-adapter-regression.md`（historical / inactive；实现已由 PR `#124` 收口）
+  - `docs/exec-plans/CHORE-0120-fr-0007-platform-leakage-check.md`（historical / inactive；实现已由 PR `#123` 收口）
+  - `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md`（绑定 Issue `#121`）
   - `docs/exec-plans/GOV-0027-governance-contract-rewrite.md`
   - `docs/exec-plans/GOV-0028-harness-compat-migration.md`
   - `docs/exec-plans/GOV-0029-remove-legacy-todo-md.md`
-  - `docs/exec-plans/CHORE-0079-fr-0007-formal-spec-closeout.md`
 - decision：`docs/decisions/ADR-0001-governance-bootstrap-contract.md`
 - decision：`docs/decisions/ADR-0003-github-delivery-structure-and-repo-semantic-split.md`（上位 shared decision；`docs/decisions/ADR-GOV-0029-remove-legacy-todo-md.md` 定义了 `TODO.md` 退出 formal governance flow 的目标态与过渡规则）
 - decision：`docs/decisions/ADR-GOV-0029-remove-legacy-todo-md.md`（当前 active decision）


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：通过 `#121` 完成 `FR-0007` 父事项 closeout，把 formal spec、`#118/#119/#120` 实现、release / sprint 索引与 GitHub issue 真相收成一致。
- 主要改动：
  - 新增 `docs/exec-plans/FR-0007-release-gate-and-regression-checks.md`，把 `FR-0007` 固定为 inactive requirement container，不再让 FR 直接承载执行回合。
  - 新增 `docs/exec-plans/CHORE-0121-fr-0007-parent-closeout.md`，把 `#121` 绑定为唯一合法 parent closeout 入口，并记录 `#121/#67/#63` 的关闭前提、正文目标与 closeout 评论工件。
  - 更新 `docs/releases/v0.2.0.md` 与 `docs/sprints/2026-S15.md`，把 `FR-0007` 从 formal spec 入口推进到 implementation + parent closeout 叙事。
  - 当前 docs checkpoint `0603e3060f3518621afa4c0f0862e95b3d8e2380` 完成 closeout 工件落盘；当前 PR head `b9fc548d2cedfa2ee0c0e7a2e378c6d1ae6a72a0` 是 metadata-only follow-up，只用于把 active exec-plan、PR / issue 当前事实与验证记录绑定到同一个 docs checkpoint，并持续收紧历史轮次口径、剩余动作与 GitHub closeout 工件说明。

## Issue 摘要

- `#121` 是 `FR-0007` 的 docs closeout Work Item，目标是在不引入新运行时代码或新 formal spec 语义的前提下关闭父 FR `#67`，并在条件满足时关闭阶段 `#63`。
- 本 PR 不新增 runtime / adapter / test 实现，也不调整 `FR-0004/0005/0006` 的事项状态。

## Scope

- 新增 `FR-0007` requirement container
- 新增 `#121` active parent closeout exec-plan
- 同步 release / sprint 索引到 `FR-0007` implementation + closeout 真相
- 为合并后的 `#121/#67/#63` GitHub closeout 准备一致的正文与评论事实

## 关联事项

- Issue: #121
- item_key: `CHORE-0121-fr-0007-parent-closeout`
- item_type: `CHORE`
- release: `v0.2.0`
- sprint: `2026-S15`
- Closing: Fixes #121

## 风险

- 风险级别：`lightweight`
- 审查关注：
  - `FR-0007` requirement container 是否保持“FR 只承载 requirement，不直接承载执行回合”的治理约束。
  - release / sprint 是否只做 FR-0007 增量收口，而没有误改 `FR-0004/0005/0006` 叙事。
  - `#79/#118/#119/#120` 的历史 exec-plan 口径是否与底层 metadata 真相一致，没有误写成 inactive。
  - active parent closeout exec-plan 是否只保留真正剩余的 closeout 步骤，并补齐了 `#121/#63` 的 GitHub closeout 工件。

## 验证

- 当前受审 head：`b9fc548d2cedfa2ee0c0e7a2e378c6d1ae6a72a0`
- 当前 docs checkpoint：`0603e3060f3518621afa4c0f0862e95b3d8e2380`
- 已执行：
  - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/spec_guard.py --all`
  - `python3 scripts/open_pr.py --class docs --issue 121 --item-key CHORE-0121-fr-0007-parent-closeout --item-type CHORE --release v0.2.0 --sprint 2026-S15 --title 'docs(closeout): 收口 FR-0007 父事项' --closing fixes`
- 结果：
  - `commit_check`、`pr_scope_guard`、`docs_guard`、`spec_guard` 已在当前受审 head `b9fc548d2cedfa2ee0c0e7a2e378c6d1ae6a72a0` 上通过。
  - docs checkpoint `0603e3060f3518621afa4c0f0862e95b3d8e2380` 已完成 `FR-0007` requirement container、active parent closeout exec-plan 与 release / sprint closeout 入口落盘。
  - metadata follow-up `b9fc548d2cedfa2ee0c0e7a2e378c6d1ae6a72a0` 已补齐 `#121/#63` closeout 工件说明，并把 checkpoint 注记改写成“实质 checkpoint + metadata-only follow-up”两层叙事。
  - 受控 `open_pr` 入口已成功创建当前 PR `#125`。
- 未执行：guardian / merge gate / 合并后的 `#67/#63` GitHub closeout 动作。

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 本 PR 只收口 docs / GitHub closeout 语义，不引入新的共享契约实现。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
