### PR TITLE
feat(runtime): 落地 FR-0008 任务记录共享模型

### DIFF
--- a/docs/exec-plans/CHORE-0123-fr-0008-task-record-model.md
+++ b/docs/exec-plans/CHORE-0123-fr-0008-task-record-model.md
@@ -1,0 +1,80 @@
+# CHORE-0123 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0123-fr-0008-task-record-model`
+- Issue：`#138`
+- item_type：`CHORE`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+- 关联 spec：`docs/specs/FR-0008-task-record-persistence/`
+- 关联 PR：
+- active 收口事项：`CHORE-0123-fr-0008-task-record-model`
+
+## 目标
+
+- 在 `FR-0008` 范围内把任务状态、终态结果与执行日志的共享模型落地到 runtime 主路径。
+- 提供 JSON-safe 的任务记录序列化 / 回读能力，为 `#139` 的本地持久化管线提供稳定输入。
+- 保持现有 `execute_task()` success / failed envelope 行为不变，不提前引入本地存储或 CLI 查询 surface。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py`
+  - `syvert/task_record.py`
+  - `tests/runtime/test_task_record.py`
+  - 视需要最小调整 `tests/runtime/test_runtime.py` / `tests/runtime/test_executor.py`
+  - 当前 active `exec-plan`
+- 本次不纳入：
+  - 本地稳定存储写入 / 回读实现
+  - CLI 查询命令或输出格式改造
+  - `scripts/**` 治理工具链
+  - `#139` 的持久化收口
+
+## 当前停点
+
+- `FR-0008` formal spec 已由 PR `#145` 合入主干，当前实现入口切到真实 Work Item `#138`。
+- 当前 runtime 仍只返回 success / failed envelope，尚未在共享主路径中构建可回读的 `TaskRecord` 聚合。
+- 现有 pre-accepted 失败（invalid request / unsupported capability / unsupported target_type / unsupported collection_mode / registry failure 等）必须继续停留在 durable task history 边界之外。
+
+## 下一步动作
+
+- 落地 `TaskRecord` / `TaskRequestSnapshot` / `TaskTerminalResult` / `TaskLogEntry` 模型与 JSON-safe 序列化函数。
+- 在 runtime 中补出 accepted/running/terminal 三段共享生命周期，并保持 `execute_task()` 对外 envelope 不漂移。
+- 运行 runtime 测试、受控入口 dry-run、推送并创建 implementation PR。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.3.0` 提供可被持久化层直接消费的共享任务记录模型，使后续 `#139` 只需解决本地存储管线，而不再重新定义状态/结果/日志语义。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0008` 的模型层 implementation Work Item，负责把 formal spec 里的共享 task record contract 实际落到 runtime。
+- 阻塞：
+  - 必须守住 `FR-0008` 规定的 pre-`accepted` / post-`accepted` 边界，不把 admission/pre-execution 失败误写入 durable history。
+  - 不得让 runtime 依赖 `scripts/*` 或治理状态文件。
+
+## 已验证项
+
+- `gh issue view 138 --json number,title,body,state,projectItems,url`
+- `sed -n '1,260p' docs/specs/FR-0008-task-record-persistence/spec.md`
+- `sed -n '1,220p' docs/specs/FR-0008-task-record-persistence/data-model.md`
+- `sed -n '1,260p' syvert/runtime.py`
+- `sed -n '1,260p' tests/runtime/test_runtime.py`
+- `sed -n '1,220p' tests/runtime/test_models.py`
+- `sed -n '1,240p' tests/runtime/test_executor.py`
+- `python3 scripts/create_worktree.py --issue 138 --class implementation`
+  - 结果：已创建独立 worktree `/Users/mc/code/worktrees/syvert/issue-138-fr-0008`
+
+## 未决风险
+
+- 若 `TaskRecord` 模型与既有 envelope 语义漂移，`#139` 和 `FR-0009` 会被迫建立影子 schema。
+- 若 accepted 建档时点放得过早，会把上游 `FR-0004` / `FR-0005` 已冻结的 pre-execution 失败错误纳入 durable history。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销 `TaskRecord` 模型、runtime 生命周期接线与对应测试。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `093141b5dfbde9d5912963fe72497081334bc6bd`

--- a/syvert/cli.py
+++ b/syvert/cli.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Mapping, TextIO
 from syvert.runtime import (
     TaskInput,
     TaskRequest,
-    execute_task,
+    execute_task_with_record,
     failure_envelope,
     invalid_input_error,
     resolve_task_id,
@@ -86,11 +86,11 @@ def main(
         )
         err.write(json.dumps(envelope, ensure_ascii=False) + "\n")
         return 1
-    envelope = execute_task(
+    envelope = execute_task_with_record(
         request,
         adapters=resolved_adapters,
         task_id_factory=task_id_factory,
-    )
+    ).envelope
     stream = out if envelope["status"] == "success" else err
     try:
         payload = json.dumps(envelope, ensure_ascii=False)

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -7,6 +7,14 @@ from typing import Any, Callable, Mapping
 from uuid import uuid4
 
 from syvert.registry import AdapterRegistry, RegistryError
+from syvert.task_record import (
+    TaskRecord,
+    TaskRecordContractError,
+    build_task_request_snapshot,
+    create_task_record,
+    finish_task_record,
+    start_task_record,
+)
 
 CONTENT_DETAIL_BY_URL = "content_detail_by_url"
 CONTENT_DETAIL = "content_detail"
@@ -76,123 +84,190 @@ def default_task_id_factory() -> str:
     return f"task-{uuid4().hex}"
 
 
+@dataclass(frozen=True)
+class TaskExecutionResult:
+    envelope: dict[str, Any]
+    task_record: TaskRecord | None
+
+
 def execute_task(
     request: TaskRequest | CoreTaskRequest,
     *,
     adapters: Mapping[str, Any],
     task_id_factory: Callable[[], str] | None = None,
 ) -> dict[str, Any]:
+    return execute_task_with_record(
+        request,
+        adapters=adapters,
+        task_id_factory=task_id_factory,
+    ).envelope
+
+
+def execute_task_with_record(
+    request: TaskRequest | CoreTaskRequest,
+    *,
+    adapters: Mapping[str, Any],
+    task_id_factory: Callable[[], str] | None = None,
+) -> TaskExecutionResult:
     adapter_key, capability = extract_request_context(request)
     task_id, task_id_error = resolve_task_id(task_id_factory)
     if task_id_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, task_id_error)
+        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, task_id_error), None)
 
     normalized_request, contract_error = normalize_request(request)
     if contract_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, contract_error)
+        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, contract_error), None)
     if normalized_request is None:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            invalid_input_error("invalid_task_request", "task_request 顶层形状不合法"),
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                invalid_input_error("invalid_task_request", "task_request 顶层形状不合法"),
+            ),
+            None,
         )
 
     adapter_key = normalized_request.target.adapter_key
     capability = normalized_request.target.capability
     capability_family, capability_family_error = resolve_capability_family(capability)
     if capability_family_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, capability_family_error)
+        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, capability_family_error), None)
     if capability_family is None:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            invalid_input_error("invalid_capability", "capability 无法投影到 adapter-facing family"),
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                invalid_input_error("invalid_capability", "capability 无法投影到 adapter-facing family"),
+            ),
+            None,
         )
 
     projection_axis_error = validate_projection_axes_for_current_runtime(normalized_request)
     if projection_axis_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, projection_axis_error)
+        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, projection_axis_error), None)
 
     try:
         registry = AdapterRegistry.from_mapping(adapters)
     except RegistryError as error:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            runtime_contract_error(
-                error.code,
-                error.message,
-                details=error.details,
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                runtime_contract_error(
+                    error.code,
+                    error.message,
+                    details=error.details,
+                ),
             ),
+            None,
         )
 
     declaration = registry.lookup(adapter_key)
     if declaration is None:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            unsupported_error("adapter_not_found", f"adapter `{adapter_key}` 不存在"),
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                unsupported_error("adapter_not_found", f"adapter `{adapter_key}` 不存在"),
+            ),
+            None,
         )
 
     supported_capabilities = declaration.supported_capabilities
     if capability_family not in supported_capabilities:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            unsupported_error(
-                "capability_not_supported",
-                f"adapter `{adapter_key}` 不支持 `{capability_family}`",
-                details={
-                    "supported_capabilities": sorted(supported_capabilities),
-                    "capability_family": capability_family,
-                },
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                unsupported_error(
+                    "capability_not_supported",
+                    f"adapter `{adapter_key}` 不支持 `{capability_family}`",
+                    details={
+                        "supported_capabilities": sorted(supported_capabilities),
+                        "capability_family": capability_family,
+                    },
+                ),
             ),
+            None,
         )
 
     supported_targets = declaration.supported_targets
     if normalized_request.target.target_type not in supported_targets:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            invalid_input_error(
-                "target_type_not_supported",
-                f"adapter `{adapter_key}` 不支持 target_type `{normalized_request.target.target_type}`",
-                details={"supported_targets": sorted(supported_targets)},
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                invalid_input_error(
+                    "target_type_not_supported",
+                    f"adapter `{adapter_key}` 不支持 target_type `{normalized_request.target.target_type}`",
+                    details={"supported_targets": sorted(supported_targets)},
+                ),
             ),
+            None,
         )
 
     supported_collection_modes = declaration.supported_collection_modes
     if normalized_request.policy.collection_mode not in supported_collection_modes:
-        return failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            invalid_input_error(
-                "collection_mode_not_supported",
-                f"adapter `{adapter_key}` 不支持 collection_mode `{normalized_request.policy.collection_mode}`",
-                details={"supported_collection_modes": sorted(supported_collection_modes)},
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                invalid_input_error(
+                    "collection_mode_not_supported",
+                    f"adapter `{adapter_key}` 不支持 collection_mode `{normalized_request.policy.collection_mode}`",
+                    details={"supported_collection_modes": sorted(supported_collection_modes)},
+                ),
             ),
+            None,
         )
 
     adapter_request, projection_error = project_to_adapter_request(normalized_request, capability_family)
     if projection_error is not None:
-        return failure_envelope(task_id, adapter_key, capability, projection_error)
+        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, projection_error), None)
+
+    try:
+        record = start_task_record(create_task_record(task_id, build_task_request_snapshot(normalized_request)))
+    except TaskRecordContractError as error:
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                runtime_contract_error("invalid_task_record", str(error)),
+            ),
+            None,
+        )
 
     try:
         payload = declaration.adapter.execute(adapter_request)
         payload_error = validate_success_payload(payload)
         if payload_error is not None:
-            return failure_envelope(task_id, adapter_key, capability, payload_error)
+            envelope = failure_envelope(task_id, adapter_key, capability, payload_error)
+            return finalize_task_execution_result(
+                task_id,
+                adapter_key,
+                capability,
+                record,
+                envelope,
+            )
     except PlatformAdapterError as error:
-        return failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error))
+        envelope = failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error))
+        return finalize_task_execution_result(
+            task_id,
+            adapter_key,
+            capability,
+            record,
+            envelope,
+        )
     except Exception as error:
-        return failure_envelope(
+        envelope = failure_envelope(
             task_id,
             adapter_key,
             capability,
@@ -201,8 +276,15 @@ def execute_task(
                 str(error) or error.__class__.__name__,
             ),
         )
+        return finalize_task_execution_result(
+            task_id,
+            adapter_key,
+            capability,
+            record,
+            envelope,
+        )
 
-    return {
+    envelope = {
         "task_id": task_id,
         "adapter_key": adapter_key,
         "capability": capability,
@@ -210,6 +292,38 @@ def execute_task(
         "raw": payload["raw"],
         "normalized": payload["normalized"],
     }
+    return finalize_task_execution_result(
+        task_id,
+        adapter_key,
+        capability,
+        record,
+        envelope,
+    )
+
+
+def finalize_task_execution_result(
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    record: TaskRecord,
+    envelope: Mapping[str, Any],
+) -> TaskExecutionResult:
+    try:
+        return TaskExecutionResult(dict(envelope), finish_task_record(record, envelope))
+    except TaskRecordContractError as error:
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                runtime_contract_error(
+                    "envelope_not_json_serializable",
+                    "共享终态结果无法收口为 JSON-safe TaskRecord",
+                    details={"reason": str(error)},
+                ),
+            ),
+            None,
+        )
 
 
 def validate_request(request: Any) -> dict[str, Any] | None:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -96,10 +96,11 @@ def execute_task(
     adapters: Mapping[str, Any],
     task_id_factory: Callable[[], str] | None = None,
 ) -> dict[str, Any]:
-    return execute_task_with_record(
+    return execute_task_internal(
         request,
         adapters=adapters,
         task_id_factory=task_id_factory,
+        preserve_envelope_on_record_error=True,
     ).envelope
 
 
@@ -108,6 +109,21 @@ def execute_task_with_record(
     *,
     adapters: Mapping[str, Any],
     task_id_factory: Callable[[], str] | None = None,
+) -> TaskExecutionResult:
+    return execute_task_internal(
+        request,
+        adapters=adapters,
+        task_id_factory=task_id_factory,
+        preserve_envelope_on_record_error=False,
+    )
+
+
+def execute_task_internal(
+    request: TaskRequest | CoreTaskRequest,
+    *,
+    adapters: Mapping[str, Any],
+    task_id_factory: Callable[[], str] | None = None,
+    preserve_envelope_on_record_error: bool,
 ) -> TaskExecutionResult:
     adapter_key, capability = extract_request_context(request)
     task_id, task_id_error = resolve_task_id(task_id_factory)
@@ -256,6 +272,7 @@ def execute_task_with_record(
                 capability,
                 record,
                 envelope,
+                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
             )
     except PlatformAdapterError as error:
         envelope = failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error))
@@ -265,6 +282,7 @@ def execute_task_with_record(
             capability,
             record,
             envelope,
+            preserve_envelope_on_record_error=preserve_envelope_on_record_error,
         )
     except Exception as error:
         envelope = failure_envelope(
@@ -282,6 +300,7 @@ def execute_task_with_record(
             capability,
             record,
             envelope,
+            preserve_envelope_on_record_error=preserve_envelope_on_record_error,
         )
 
     envelope = {
@@ -298,6 +317,7 @@ def execute_task_with_record(
         capability,
         record,
         envelope,
+        preserve_envelope_on_record_error=preserve_envelope_on_record_error,
     )
 
 
@@ -307,10 +327,14 @@ def finalize_task_execution_result(
     capability: str,
     record: TaskRecord,
     envelope: Mapping[str, Any],
+    *,
+    preserve_envelope_on_record_error: bool,
 ) -> TaskExecutionResult:
     try:
         return TaskExecutionResult(dict(envelope), finish_task_record(record, envelope))
     except TaskRecordContractError as error:
+        if preserve_envelope_on_record_error:
+            return TaskExecutionResult(dict(envelope), None)
         return TaskExecutionResult(
             failure_envelope(
                 task_id,

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -17,7 +17,7 @@ SHARED_CAPABILITIES = frozenset({"content_detail_by_url"})
 SHARED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
 SHARED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
 ALLOWED_CONTENT_TYPES = frozenset({"video", "image_post", "mixed_media", "unknown"})
-RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 
 
 class TaskRecordContractError(ValueError):
@@ -410,11 +410,20 @@ def validate_request_snapshot(snapshot: TaskRequestSnapshot) -> None:
 def validate_timestamp(value: str, *, field: str) -> None:
     if not isinstance(value, str) or not RFC3339_UTC_RE.fullmatch(value):
         raise TaskRecordContractError(f"{field} 必须为 RFC3339 UTC 时间")
+    if parse_timestamp(value, field=field).utcoffset() != timezone.utc.utcoffset(None):
+        raise TaskRecordContractError(f"{field} 必须是 UTC 时间")
 
 
 def parse_timestamp(value: str, *, field: str) -> datetime:
-    validate_timestamp(value, field=field)
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if not isinstance(value, str) or not RFC3339_UTC_RE.fullmatch(value):
+        raise TaskRecordContractError(f"{field} 必须为 RFC3339 UTC 时间")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise TaskRecordContractError(f"{field} 必须为 RFC3339 UTC 时间") from error
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(None):
+        raise TaskRecordContractError(f"{field} 必须是 UTC 时间")
+    return parsed
 
 
 def terminal_record_status(envelope: Mapping[str, Any]) -> str:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -12,6 +12,11 @@ TASK_RECORD_SCHEMA_VERSION = "v0.3.0"
 TASK_RECORD_STATUSES = frozenset({"accepted", "running", "succeeded", "failed"})
 TASK_LOG_STAGES = frozenset({"admission", "execution", "completion"})
 TASK_LOG_LEVELS = frozenset({"info", "error"})
+TASK_LOG_STAGE_ORDER = {"admission": 0, "execution": 1, "completion": 2}
+SHARED_CAPABILITIES = frozenset({"content_detail_by_url"})
+SHARED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
+SHARED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
+ALLOWED_CONTENT_TYPES = frozenset({"video", "image_post", "mixed_media", "unknown"})
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
 
 
@@ -302,38 +307,70 @@ def validate_task_record(record: TaskRecord) -> None:
     validate_request_snapshot(record.request)
     if record.status not in TASK_RECORD_STATUSES:
         raise TaskRecordContractError("TaskRecord.status 不在允许值范围内")
-    validate_timestamp(record.created_at, field="created_at")
-    validate_timestamp(record.updated_at, field="updated_at")
+    created_at = parse_timestamp(record.created_at, field="created_at")
+    updated_at = parse_timestamp(record.updated_at, field="updated_at")
+    if updated_at < created_at:
+        raise TaskRecordContractError("TaskRecord.updated_at 不得早于 created_at")
+    terminal_at = None
     if record.terminal_at is not None:
-        validate_timestamp(record.terminal_at, field="terminal_at")
+        terminal_at = parse_timestamp(record.terminal_at, field="terminal_at")
+        if terminal_at < updated_at:
+            raise TaskRecordContractError("TaskRecord.terminal_at 不得早于 updated_at")
     if not record.logs:
         raise TaskRecordContractError("TaskRecord.logs 不得为空")
 
     last_sequence = 0
-    seen_stages: list[str] = []
+    stage_counts = {stage: 0 for stage in TASK_LOG_STAGES}
+    previous_occurred_at: datetime | None = None
+    previous_stage_order = -1
+    final_log_at: datetime | None = None
+    final_stage: str | None = None
     for entry in record.logs:
         if isinstance(entry.sequence, bool) or not isinstance(entry.sequence, int) or entry.sequence <= 0:
             raise TaskRecordContractError("TaskLogEntry.sequence 必须为正整数")
         if entry.sequence != last_sequence + 1:
             raise TaskRecordContractError("TaskRecord.logs.sequence 必须连续递增")
         last_sequence = entry.sequence
-        validate_timestamp(entry.occurred_at, field="logs.occurred_at")
+        occurred_at = parse_timestamp(entry.occurred_at, field="logs.occurred_at")
+        if previous_occurred_at is not None and occurred_at < previous_occurred_at:
+            raise TaskRecordContractError("TaskRecord.logs.occurred_at 必须随 sequence 单调推进")
+        previous_occurred_at = occurred_at
         if entry.stage not in TASK_LOG_STAGES:
             raise TaskRecordContractError("TaskLogEntry.stage 不在允许值范围内")
+        stage_order = TASK_LOG_STAGE_ORDER[entry.stage]
+        if stage_order < previous_stage_order:
+            raise TaskRecordContractError("TaskRecord.logs.stage 顺序不可信")
+        previous_stage_order = stage_order
         if entry.level not in TASK_LOG_LEVELS:
             raise TaskRecordContractError("TaskLogEntry.level 不在允许值范围内")
         if not isinstance(entry.message, str) or not entry.message:
             raise TaskRecordContractError("TaskLogEntry.message 必须为非空字符串")
         if entry.code is not None and (not isinstance(entry.code, str) or not entry.code):
             raise TaskRecordContractError("TaskLogEntry.code 必须为非空字符串或 null")
-        seen_stages.append(entry.stage)
+        stage_counts[entry.stage] += 1
+        final_log_at = occurred_at
+        final_stage = entry.stage
 
-    if "admission" not in seen_stages:
-        raise TaskRecordContractError("TaskRecord 缺少 accepted 生命周期事件")
-    if record.status in {"running", "succeeded", "failed"} and "execution" not in seen_stages:
-        raise TaskRecordContractError("TaskRecord 缺少 execution 生命周期事件")
-    if record.status in {"succeeded", "failed"} and "completion" not in seen_stages:
-        raise TaskRecordContractError("终态 TaskRecord 缺少 completion 生命周期事件")
+    if stage_counts["admission"] != 1:
+        raise TaskRecordContractError("TaskRecord 必须且只能包含一条 accepted 生命周期事件")
+    if record.logs[0].stage != "admission":
+        raise TaskRecordContractError("TaskRecord 第一条日志必须是 accepted 生命周期事件")
+    if final_log_at is None or final_stage is None:
+        raise TaskRecordContractError("TaskRecord.logs 不得为空")
+    if final_log_at != updated_at:
+        raise TaskRecordContractError("TaskRecord.updated_at 必须等于最后一条可信日志时间")
+    if parse_timestamp(record.logs[0].occurred_at, field="logs.occurred_at") != created_at:
+        raise TaskRecordContractError("TaskRecord.created_at 必须等于 accepted 生命周期事件时间")
+
+    if record.status == "accepted":
+        if stage_counts["execution"] != 0 or stage_counts["completion"] != 0 or final_stage != "admission":
+            raise TaskRecordContractError("accepted TaskRecord 不得包含 execution/completion 生命周期事件")
+    elif record.status == "running":
+        if stage_counts["execution"] != 1 or stage_counts["completion"] != 0 or final_stage != "execution":
+            raise TaskRecordContractError("running TaskRecord 必须只包含 accepted/execution 生命周期事件")
+    else:
+        if stage_counts["execution"] != 1 or stage_counts["completion"] != 1 or final_stage != "completion":
+            raise TaskRecordContractError("终态 TaskRecord 必须包含完整且可信的生命周期事件")
 
     if record.status in {"accepted", "running"}:
         if record.terminal_at is not None or record.result is not None:
@@ -341,26 +378,43 @@ def validate_task_record(record: TaskRecord) -> None:
     else:
         if record.terminal_at is None or record.result is None:
             raise TaskRecordContractError("终态 TaskRecord 必须包含终态结果")
+        if terminal_at != updated_at:
+            raise TaskRecordContractError("终态 TaskRecord.terminal_at 必须等于最后一次可信更新")
         normalized_envelope = normalize_json_value(record.result.envelope, field="result.envelope")
         if not isinstance(normalized_envelope, dict):
             raise TaskRecordContractError("TaskTerminalResult.envelope 必须是对象")
         if normalized_envelope != record.result.envelope:
             raise TaskRecordContractError("TaskTerminalResult.envelope 必须预先满足 JSON-safe 约束")
+        validate_terminal_envelope_contract(record, record.result.envelope)
         status = terminal_record_status(record.result.envelope)
         if status != record.status:
             raise TaskRecordContractError("TaskRecord.status 与终态 envelope.status 不一致")
 
 
 def validate_request_snapshot(snapshot: TaskRequestSnapshot) -> None:
-    for field_name in ("adapter_key", "capability", "target_type", "target_value", "collection_mode"):
-        value = getattr(snapshot, field_name)
-        if not isinstance(value, str) or not value:
-            raise TaskRecordContractError(f"TaskRequestSnapshot.{field_name} 必须为非空字符串")
+    adapter_key = require_string(snapshot.adapter_key, field="TaskRequestSnapshot.adapter_key")
+    capability = require_string(snapshot.capability, field="TaskRequestSnapshot.capability")
+    target_type = require_string(snapshot.target_type, field="TaskRequestSnapshot.target_type")
+    require_string(snapshot.target_value, field="TaskRequestSnapshot.target_value")
+    collection_mode = require_string(snapshot.collection_mode, field="TaskRequestSnapshot.collection_mode")
+    if capability not in SHARED_CAPABILITIES:
+        raise TaskRecordContractError("TaskRequestSnapshot.capability 不在共享请求模型允许值范围内")
+    if target_type not in SHARED_TARGET_TYPES:
+        raise TaskRecordContractError("TaskRequestSnapshot.target_type 不在共享请求模型允许值范围内")
+    if collection_mode not in SHARED_COLLECTION_MODES:
+        raise TaskRecordContractError("TaskRequestSnapshot.collection_mode 不在共享请求模型允许值范围内")
+    if not adapter_key:
+        raise TaskRecordContractError("TaskRequestSnapshot.adapter_key 必须为非空字符串")
 
 
 def validate_timestamp(value: str, *, field: str) -> None:
     if not isinstance(value, str) or not RFC3339_UTC_RE.fullmatch(value):
         raise TaskRecordContractError(f"{field} 必须为 RFC3339 UTC 时间")
+
+
+def parse_timestamp(value: str, *, field: str) -> datetime:
+    validate_timestamp(value, field=field)
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def terminal_record_status(envelope: Mapping[str, Any]) -> str:
@@ -390,6 +444,79 @@ def require_optional_string(value: Any, *, field: str) -> str | None:
     if not isinstance(value, str) or not value:
         raise TaskRecordContractError(f"{field} 必须为非空字符串或 null")
     return value
+
+
+def validate_terminal_envelope_contract(record: TaskRecord, envelope: Mapping[str, Any]) -> None:
+    task_id = require_string(envelope.get("task_id"), field="result.envelope.task_id")
+    adapter_key = require_string(envelope.get("adapter_key"), field="result.envelope.adapter_key")
+    capability = require_string(envelope.get("capability"), field="result.envelope.capability")
+    if task_id != record.task_id:
+        raise TaskRecordContractError("TaskTerminalResult.envelope.task_id 与 TaskRecord.task_id 不一致")
+    if adapter_key != record.request.adapter_key:
+        raise TaskRecordContractError("TaskTerminalResult.envelope.adapter_key 与请求快照不一致")
+    if capability != record.request.capability:
+        raise TaskRecordContractError("TaskTerminalResult.envelope.capability 与请求快照不一致")
+
+    status = terminal_record_status(envelope)
+    if status == "succeeded":
+        validate_success_terminal_envelope(envelope)
+        if "error" in envelope:
+            raise TaskRecordContractError("success TaskTerminalResult.envelope 不得包含 error")
+        return
+
+    validate_failed_terminal_envelope(envelope)
+    if "raw" in envelope or "normalized" in envelope:
+        raise TaskRecordContractError("failed TaskTerminalResult.envelope 不得包含 success payload 字段")
+
+
+def validate_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
+    if "raw" not in envelope:
+        raise TaskRecordContractError("success TaskTerminalResult.envelope 必须包含 raw")
+    normalized = envelope.get("normalized")
+    if not isinstance(normalized, Mapping):
+        raise TaskRecordContractError("success TaskTerminalResult.envelope.normalized 必须是对象")
+
+    required_non_empty = ("platform", "content_id", "content_type", "canonical_url")
+    for field in required_non_empty:
+        require_string(normalized.get(field), field=f"result.envelope.normalized.{field}")
+
+    if normalized["content_type"] not in ALLOWED_CONTENT_TYPES:
+        raise TaskRecordContractError("success TaskTerminalResult.envelope.normalized.content_type 不在允许值范围内")
+
+    for field in ("title", "body_text"):
+        value = normalized.get(field)
+        if not isinstance(value, str):
+            raise TaskRecordContractError(f"result.envelope.normalized.{field} 必须存在且为字符串")
+
+    published_at = normalized.get("published_at")
+    if published_at is not None:
+        validate_timestamp(published_at, field="result.envelope.normalized.published_at")
+
+    for field in ("author", "stats", "media"):
+        if not isinstance(normalized.get(field), Mapping):
+            raise TaskRecordContractError(f"result.envelope.normalized.{field} 必须存在且为对象")
+
+    author = normalized["author"]
+    stats = normalized["stats"]
+    media = normalized["media"]
+    for field in ("author_id", "display_name", "avatar_url"):
+        if field not in author:
+            raise TaskRecordContractError(f"result.envelope.normalized.author.{field} 不得缺失")
+    for field in ("like_count", "comment_count", "share_count", "collect_count"):
+        if field not in stats:
+            raise TaskRecordContractError(f"result.envelope.normalized.stats.{field} 不得缺失")
+    for field in ("cover_url", "video_url", "image_urls"):
+        if field not in media:
+            raise TaskRecordContractError(f"result.envelope.normalized.media.{field} 不得缺失")
+
+
+def validate_failed_terminal_envelope(envelope: Mapping[str, Any]) -> None:
+    error = envelope.get("error")
+    if not isinstance(error, Mapping):
+        raise TaskRecordContractError("failed TaskTerminalResult.envelope.error 必须是对象")
+    require_string(error.get("category"), field="result.envelope.error.category")
+    require_string(error.get("code"), field="result.envelope.error.code")
+    require_string(error.get("message"), field="result.envelope.error.message")
 
 
 def normalize_json_value(value: Any, *, field: str) -> Any:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -17,6 +17,7 @@ SHARED_CAPABILITIES = frozenset({"content_detail_by_url"})
 SHARED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
 SHARED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
 ALLOWED_CONTENT_TYPES = frozenset({"video", "image_post", "mixed_media", "unknown"})
+ALLOWED_ERROR_CATEGORIES = frozenset({"invalid_input", "unsupported", "runtime_contract", "platform"})
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 
 
@@ -547,9 +548,14 @@ def validate_failed_terminal_envelope(envelope: Mapping[str, Any]) -> None:
     error = envelope.get("error")
     if not isinstance(error, Mapping):
         raise TaskRecordContractError("failed TaskTerminalResult.envelope.error 必须是对象")
-    require_string(error.get("category"), field="result.envelope.error.category")
+    category = require_string(error.get("category"), field="result.envelope.error.category")
     require_string(error.get("code"), field="result.envelope.error.code")
     require_string(error.get("message"), field="result.envelope.error.message")
+    details = error.get("details")
+    if not isinstance(details, Mapping):
+        raise TaskRecordContractError("result.envelope.error.details 必须存在且为对象")
+    if category not in ALLOWED_ERROR_CATEGORIES:
+        raise TaskRecordContractError("result.envelope.error.category 不在允许值范围内")
 
 
 def normalize_json_value(value: Any, *, field: str) -> Any:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -509,6 +509,30 @@ def validate_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
         if field not in media:
             raise TaskRecordContractError(f"result.envelope.normalized.media.{field} 不得缺失")
 
+    author_id = author.get("author_id")
+    display_name = author.get("display_name")
+    avatar_url = author.get("avatar_url")
+    if author_id is not None and (not isinstance(author_id, str) or not author_id):
+        raise TaskRecordContractError("result.envelope.normalized.author.author_id 必须为非空字符串或 null")
+    if display_name is not None and (not isinstance(display_name, str) or not display_name):
+        raise TaskRecordContractError("result.envelope.normalized.author.display_name 必须为非空字符串或 null")
+    if avatar_url is not None and not isinstance(avatar_url, str):
+        raise TaskRecordContractError("result.envelope.normalized.author.avatar_url 必须为字符串或 null")
+
+    for field in ("like_count", "comment_count", "share_count", "collect_count"):
+        value = stats.get(field)
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            raise TaskRecordContractError(f"result.envelope.normalized.stats.{field} 必须为整数或 null")
+
+    for field in ("cover_url", "video_url"):
+        value = media.get(field)
+        if value is not None and not isinstance(value, str):
+            raise TaskRecordContractError(f"result.envelope.normalized.media.{field} 必须为字符串或 null")
+
+    image_urls = media.get("image_urls")
+    if not isinstance(image_urls, list) or not all(isinstance(item, str) for item in image_urls):
+        raise TaskRecordContractError("result.envelope.normalized.media.image_urls 必须是字符串数组")
+
 
 def validate_failed_terminal_envelope(envelope: Mapping[str, Any]) -> None:
     error = envelope.get("error")

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import math
+import re
+from typing import Any
+
+
+TASK_RECORD_SCHEMA_VERSION = "v0.3.0"
+TASK_RECORD_STATUSES = frozenset({"accepted", "running", "succeeded", "failed"})
+TASK_LOG_STAGES = frozenset({"admission", "execution", "completion"})
+TASK_LOG_LEVELS = frozenset({"info", "error"})
+RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+
+
+class TaskRecordContractError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class TaskRequestSnapshot:
+    adapter_key: str
+    capability: str
+    target_type: str
+    target_value: str
+    collection_mode: str
+
+
+@dataclass(frozen=True)
+class TaskLogEntry:
+    sequence: int
+    occurred_at: str
+    stage: str
+    level: str
+    message: str
+    code: str | None = None
+
+
+@dataclass(frozen=True)
+class TaskTerminalResult:
+    envelope: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TaskRecord:
+    schema_version: str
+    task_id: str
+    request: TaskRequestSnapshot
+    status: str
+    created_at: str
+    updated_at: str
+    terminal_at: str | None
+    result: TaskTerminalResult | None
+    logs: tuple[TaskLogEntry, ...]
+
+
+def now_rfc3339_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def build_task_request_snapshot(request: Any) -> TaskRequestSnapshot:
+    try:
+        target = request.target
+        policy = request.policy
+        snapshot = TaskRequestSnapshot(
+            adapter_key=target.adapter_key,
+            capability=target.capability,
+            target_type=target.target_type,
+            target_value=target.target_value,
+            collection_mode=policy.collection_mode,
+        )
+    except AttributeError as error:
+        raise TaskRecordContractError("TaskRequestSnapshot 缺少共享请求字段") from error
+    validate_request_snapshot(snapshot)
+    return snapshot
+
+
+def create_task_record(
+    task_id: str,
+    request: TaskRequestSnapshot,
+    *,
+    occurred_at: str | None = None,
+    existing: TaskRecord | None = None,
+) -> TaskRecord:
+    timestamp = occurred_at or now_rfc3339_utc()
+    validate_request_snapshot(request)
+    validate_timestamp(timestamp, field="occurred_at")
+    if existing is not None:
+        validate_task_record(existing)
+        if existing.task_id != task_id:
+            raise TaskRecordContractError("重复建档必须绑定同一 task_id")
+        if existing.request != request:
+            raise TaskRecordContractError("重复建档时请求快照不一致")
+        if existing.status != "accepted":
+            raise TaskRecordContractError("重复建档只能对既有 accepted 记录执行幂等 no-op")
+        return existing
+
+    record = TaskRecord(
+        schema_version=TASK_RECORD_SCHEMA_VERSION,
+        task_id=task_id,
+        request=request,
+        status="accepted",
+        created_at=timestamp,
+        updated_at=timestamp,
+        terminal_at=None,
+        result=None,
+        logs=(
+            TaskLogEntry(
+                sequence=1,
+                occurred_at=timestamp,
+                stage="admission",
+                level="info",
+                message="task accepted",
+            ),
+        ),
+    )
+    validate_task_record(record)
+    return record
+
+
+def start_task_record(record: TaskRecord, *, occurred_at: str | None = None) -> TaskRecord:
+    validate_task_record(record)
+    if record.status == "running":
+        return record
+    if record.status != "accepted":
+        raise TaskRecordContractError("只有 accepted 记录可以进入 running")
+    timestamp = occurred_at or now_rfc3339_utc()
+    validate_timestamp(timestamp, field="occurred_at")
+    updated = TaskRecord(
+        schema_version=record.schema_version,
+        task_id=record.task_id,
+        request=record.request,
+        status="running",
+        created_at=record.created_at,
+        updated_at=timestamp,
+        terminal_at=None,
+        result=None,
+        logs=record.logs
+        + (
+            TaskLogEntry(
+                sequence=len(record.logs) + 1,
+                occurred_at=timestamp,
+                stage="execution",
+                level="info",
+                message="task execution started",
+            ),
+        ),
+    )
+    validate_task_record(updated)
+    return updated
+
+
+def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occurred_at: str | None = None) -> TaskRecord:
+    validate_task_record(record)
+    terminal_status = terminal_record_status(envelope)
+    normalized_envelope = normalize_json_value(envelope, field="result.envelope")
+    if not isinstance(normalized_envelope, dict):
+        raise TaskRecordContractError("TaskTerminalResult.envelope 必须是对象")
+    if record.status in {"succeeded", "failed"}:
+        if record.result is None:
+            raise TaskRecordContractError("终态记录缺少终态结果")
+        if terminal_status != record.status:
+            raise TaskRecordContractError("重复终态写入试图改写既有终态状态")
+        if record.result.envelope != normalized_envelope:
+            raise TaskRecordContractError("重复终态写入试图改写既有终态 envelope")
+        return record
+    if record.status != "running":
+        raise TaskRecordContractError("只有 running 记录可以进入终态")
+
+    timestamp = occurred_at or now_rfc3339_utc()
+    validate_timestamp(timestamp, field="occurred_at")
+    log_level = "error" if terminal_status == "failed" else "info"
+    log_message = "task failed" if terminal_status == "failed" else "task succeeded"
+    log_code = None
+    error = envelope.get("error")
+    if isinstance(error, Mapping):
+        code = error.get("code")
+        if isinstance(code, str) and code:
+            log_code = code
+
+    updated = TaskRecord(
+        schema_version=record.schema_version,
+        task_id=record.task_id,
+        request=record.request,
+        status=terminal_status,
+        created_at=record.created_at,
+        updated_at=timestamp,
+        terminal_at=timestamp,
+        result=TaskTerminalResult(envelope=normalized_envelope),
+        logs=record.logs
+        + (
+            TaskLogEntry(
+                sequence=len(record.logs) + 1,
+                occurred_at=timestamp,
+                stage="completion",
+                level=log_level,
+                message=log_message,
+                code=log_code,
+            ),
+        ),
+    )
+    validate_task_record(updated)
+    return updated
+
+
+def task_record_to_dict(record: TaskRecord) -> dict[str, Any]:
+    validate_task_record(record)
+    payload: dict[str, Any] = {
+        "schema_version": record.schema_version,
+        "task_id": record.task_id,
+        "request": {
+            "adapter_key": record.request.adapter_key,
+            "capability": record.request.capability,
+            "target_type": record.request.target_type,
+            "target_value": record.request.target_value,
+            "collection_mode": record.request.collection_mode,
+        },
+        "status": record.status,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "terminal_at": record.terminal_at,
+        "result": None,
+        "logs": [
+            {
+                "sequence": entry.sequence,
+                "occurred_at": entry.occurred_at,
+                "stage": entry.stage,
+                "level": entry.level,
+                "message": entry.message,
+                "code": entry.code,
+            }
+            for entry in record.logs
+        ],
+    }
+    if record.result is not None:
+        payload["result"] = {
+            "envelope": normalize_json_value(record.result.envelope, field="result.envelope"),
+        }
+    return payload
+
+
+def task_record_from_dict(payload: Mapping[str, Any]) -> TaskRecord:
+    if not isinstance(payload, Mapping):
+        raise TaskRecordContractError("TaskRecord 载荷必须是对象")
+    request_payload = payload.get("request")
+    if not isinstance(request_payload, Mapping):
+        raise TaskRecordContractError("TaskRecord.request 必须是对象")
+    logs_payload = payload.get("logs")
+    if not isinstance(logs_payload, list):
+        raise TaskRecordContractError("TaskRecord.logs 必须是数组")
+    result_payload = payload.get("result")
+    result: TaskTerminalResult | None = None
+    if result_payload is not None:
+        if not isinstance(result_payload, Mapping):
+            raise TaskRecordContractError("TaskRecord.result 必须是对象或 null")
+        envelope = result_payload.get("envelope")
+        if not isinstance(envelope, Mapping):
+            raise TaskRecordContractError("TaskTerminalResult.envelope 必须是对象")
+        result = TaskTerminalResult(envelope=dict(normalize_json_value(envelope, field="result.envelope")))
+
+    record = TaskRecord(
+        schema_version=require_string(payload.get("schema_version"), field="schema_version"),
+        task_id=require_string(payload.get("task_id"), field="task_id"),
+        request=TaskRequestSnapshot(
+            adapter_key=require_string(request_payload.get("adapter_key"), field="request.adapter_key"),
+            capability=require_string(request_payload.get("capability"), field="request.capability"),
+            target_type=require_string(request_payload.get("target_type"), field="request.target_type"),
+            target_value=require_string(request_payload.get("target_value"), field="request.target_value"),
+            collection_mode=require_string(request_payload.get("collection_mode"), field="request.collection_mode"),
+        ),
+        status=require_string(payload.get("status"), field="status"),
+        created_at=require_string(payload.get("created_at"), field="created_at"),
+        updated_at=require_string(payload.get("updated_at"), field="updated_at"),
+        terminal_at=require_optional_string(payload.get("terminal_at"), field="terminal_at"),
+        result=result,
+        logs=tuple(
+            TaskLogEntry(
+                sequence=coerce_int(entry.get("sequence"), field="logs.sequence"),
+                occurred_at=require_string(entry.get("occurred_at"), field="logs.occurred_at"),
+                stage=require_string(entry.get("stage"), field="logs.stage"),
+                level=require_string(entry.get("level"), field="logs.level"),
+                message=require_string(entry.get("message"), field="logs.message"),
+                code=require_optional_string(entry.get("code"), field="logs.code"),
+            )
+            for entry in logs_payload
+            if isinstance(entry, Mapping)
+        ),
+    )
+    if len(record.logs) != len(logs_payload):
+        raise TaskRecordContractError("TaskRecord.logs 项必须全部为对象")
+    validate_task_record(record)
+    return record
+
+
+def validate_task_record(record: TaskRecord) -> None:
+    if record.schema_version != TASK_RECORD_SCHEMA_VERSION:
+        raise TaskRecordContractError("TaskRecord.schema_version 不合法")
+    if not isinstance(record.task_id, str) or not record.task_id:
+        raise TaskRecordContractError("TaskRecord.task_id 必须为非空字符串")
+    validate_request_snapshot(record.request)
+    if record.status not in TASK_RECORD_STATUSES:
+        raise TaskRecordContractError("TaskRecord.status 不在允许值范围内")
+    validate_timestamp(record.created_at, field="created_at")
+    validate_timestamp(record.updated_at, field="updated_at")
+    if record.terminal_at is not None:
+        validate_timestamp(record.terminal_at, field="terminal_at")
+    if not record.logs:
+        raise TaskRecordContractError("TaskRecord.logs 不得为空")
+
+    last_sequence = 0
+    seen_stages: list[str] = []
+    for entry in record.logs:
+        if isinstance(entry.sequence, bool) or not isinstance(entry.sequence, int) or entry.sequence <= 0:
+            raise TaskRecordContractError("TaskLogEntry.sequence 必须为正整数")
+        if entry.sequence != last_sequence + 1:
+            raise TaskRecordContractError("TaskRecord.logs.sequence 必须连续递增")
+        last_sequence = entry.sequence
+        validate_timestamp(entry.occurred_at, field="logs.occurred_at")
+        if entry.stage not in TASK_LOG_STAGES:
+            raise TaskRecordContractError("TaskLogEntry.stage 不在允许值范围内")
+        if entry.level not in TASK_LOG_LEVELS:
+            raise TaskRecordContractError("TaskLogEntry.level 不在允许值范围内")
+        if not isinstance(entry.message, str) or not entry.message:
+            raise TaskRecordContractError("TaskLogEntry.message 必须为非空字符串")
+        if entry.code is not None and (not isinstance(entry.code, str) or not entry.code):
+            raise TaskRecordContractError("TaskLogEntry.code 必须为非空字符串或 null")
+        seen_stages.append(entry.stage)
+
+    if "admission" not in seen_stages:
+        raise TaskRecordContractError("TaskRecord 缺少 accepted 生命周期事件")
+    if record.status in {"running", "succeeded", "failed"} and "execution" not in seen_stages:
+        raise TaskRecordContractError("TaskRecord 缺少 execution 生命周期事件")
+    if record.status in {"succeeded", "failed"} and "completion" not in seen_stages:
+        raise TaskRecordContractError("终态 TaskRecord 缺少 completion 生命周期事件")
+
+    if record.status in {"accepted", "running"}:
+        if record.terminal_at is not None or record.result is not None:
+            raise TaskRecordContractError("非终态 TaskRecord 不得包含终态结果")
+    else:
+        if record.terminal_at is None or record.result is None:
+            raise TaskRecordContractError("终态 TaskRecord 必须包含终态结果")
+        normalized_envelope = normalize_json_value(record.result.envelope, field="result.envelope")
+        if not isinstance(normalized_envelope, dict):
+            raise TaskRecordContractError("TaskTerminalResult.envelope 必须是对象")
+        if normalized_envelope != record.result.envelope:
+            raise TaskRecordContractError("TaskTerminalResult.envelope 必须预先满足 JSON-safe 约束")
+        status = terminal_record_status(record.result.envelope)
+        if status != record.status:
+            raise TaskRecordContractError("TaskRecord.status 与终态 envelope.status 不一致")
+
+
+def validate_request_snapshot(snapshot: TaskRequestSnapshot) -> None:
+    for field_name in ("adapter_key", "capability", "target_type", "target_value", "collection_mode"):
+        value = getattr(snapshot, field_name)
+        if not isinstance(value, str) or not value:
+            raise TaskRecordContractError(f"TaskRequestSnapshot.{field_name} 必须为非空字符串")
+
+
+def validate_timestamp(value: str, *, field: str) -> None:
+    if not isinstance(value, str) or not RFC3339_UTC_RE.fullmatch(value):
+        raise TaskRecordContractError(f"{field} 必须为 RFC3339 UTC 时间")
+
+
+def terminal_record_status(envelope: Mapping[str, Any]) -> str:
+    raw_status = envelope.get("status")
+    if raw_status == "success":
+        return "succeeded"
+    if raw_status == "failed":
+        return "failed"
+    raise TaskRecordContractError("终态 envelope.status 必须为 success 或 failed")
+
+
+def coerce_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TaskRecordContractError(f"{field} 必须为整数")
+    return value
+
+
+def require_string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise TaskRecordContractError(f"{field} 必须为非空字符串")
+    return value
+
+
+def require_optional_string(value: Any, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise TaskRecordContractError(f"{field} 必须为非空字符串或 null")
+    return value
+
+
+def normalize_json_value(value: Any, *, field: str) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise TaskRecordContractError(f"{field} 包含非有限浮点数")
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key:
+                raise TaskRecordContractError(f"{field} 仅允许非空字符串键")
+            normalized[key] = normalize_json_value(item, field=f"{field}.{key}")
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [normalize_json_value(item, field=f"{field}[]") for item in value]
+    raise TaskRecordContractError(f"{field} 包含不可序列化值 `{type(value).__name__}`")

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -114,6 +114,43 @@ class UnserializableSuccessAdapter:
         }
 
 
+class OffsetTimestampSuccessAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request):
+        return {
+            "raw": {"id": "raw-offset-1"},
+            "normalized": {
+                "platform": "stub",
+                "content_id": "content-offset-1",
+                "content_type": "unknown",
+                "canonical_url": request.input.url,
+                "title": "",
+                "body_text": "",
+                "published_at": "2026-04-17T10:30:00+00:00",
+                "author": {
+                    "author_id": None,
+                    "display_name": None,
+                    "avatar_url": None,
+                },
+                "stats": {
+                    "like_count": None,
+                    "comment_count": None,
+                    "share_count": None,
+                    "collect_count": None,
+                },
+                "media": {
+                    "cover_url": None,
+                    "video_url": None,
+                    "image_urls": [],
+                },
+            },
+        }
+
+
 class TaskRecordCodecTests(unittest.TestCase):
     def test_round_trips_success_record(self) -> None:
         outcome = execute_task_with_record(
@@ -341,6 +378,24 @@ class RuntimeTaskRecordTests(unittest.TestCase):
         self.assertEqual(envelope["task_id"], "task-record-8")
         self.assertIn("raw", envelope)
         self.assertEqual(type(envelope["raw"]["bad"]).__name__, "object")
+
+    def test_execute_task_with_record_accepts_offset_utc_timestamp_in_success_payload(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/9"),
+            ),
+            adapters={"stub": OffsetTimestampSuccessAdapter()},
+            task_id_factory=lambda: "task-record-9",
+        )
+
+        self.assertEqual(outcome.envelope["status"], "success")
+        self.assertIsNotNone(outcome.task_record)
+        self.assertEqual(
+            outcome.task_record.result.envelope["normalized"]["published_at"],
+            "2026-04-17T10:30:00+00:00",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -270,6 +270,38 @@ class TaskRecordCodecTests(unittest.TestCase):
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(payload)
 
+    def test_rejects_failed_envelope_without_details_during_round_trip_load(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/3cf"),
+            ),
+            adapters={"stub": PlatformFailureAdapter()},
+            task_id_factory=lambda: "task-record-3cf",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        del payload["result"]["envelope"]["error"]["details"]
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_failed_envelope_with_invalid_category_during_round_trip_load(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/3cg"),
+            ),
+            adapters={"stub": PlatformFailureAdapter()},
+            task_id_factory=lambda: "task-record-3cg",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        payload["result"]["envelope"]["error"]["category"] = "broken"
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
     def test_rejects_untrusted_timeline_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -215,6 +215,24 @@ class TaskRecordCodecTests(unittest.TestCase):
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(payload)
 
+    def test_rejects_success_envelope_nested_type_drift_during_round_trip_load(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/3cc"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-3cc",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        payload["result"]["envelope"]["normalized"]["author"]["author_id"] = 123
+        payload["result"]["envelope"]["normalized"]["stats"]["like_count"] = "1"
+        payload["result"]["envelope"]["normalized"]["media"]["image_urls"] = [1]
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
     def test_rejects_untrusted_timeline_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -199,6 +199,51 @@ class TaskRecordCodecTests(unittest.TestCase):
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(payload)
 
+    def test_rejects_terminal_envelope_mismatch_during_round_trip_load(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/3c"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-3c",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        payload["result"]["envelope"]["task_id"] = "task-record-other"
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_untrusted_timeline_during_round_trip_load(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/3d"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-3d",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        payload["logs"][1]["occurred_at"] = "2026-04-17T10:29:59Z"
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_snapshot_values_outside_shared_request_model(self) -> None:
+        with self.assertRaises(TaskRecordContractError):
+            create_task_record(
+                "task-record-3e",
+                TaskRequestSnapshot(
+                    adapter_key="stub",
+                    capability="content_detail_by_url",
+                    target_type="unsupported",
+                    target_value="https://example.com/post/3e",
+                    collection_mode="hybrid",
+                ),
+            )
+
 
 class RuntimeTaskRecordTests(unittest.TestCase):
     def test_execute_task_with_record_keeps_preaccepted_failure_outside_durable_history(self) -> None:
@@ -262,6 +307,22 @@ class RuntimeTaskRecordTests(unittest.TestCase):
         self.assertEqual(outcome.envelope["status"], "failed")
         self.assertEqual(outcome.envelope["error"]["code"], "envelope_not_json_serializable")
         self.assertIsNone(outcome.task_record)
+
+    def test_execute_task_preserves_public_envelope_when_task_record_fails_to_close(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/8"),
+            ),
+            adapters={"stub": UnserializableSuccessAdapter()},
+            task_id_factory=lambda: "task-record-8",
+        )
+
+        self.assertEqual(envelope["status"], "success")
+        self.assertEqual(envelope["task_id"], "task-record-8")
+        self.assertIn("raw", envelope)
+        self.assertEqual(type(envelope["raw"]["bad"]).__name__, "object")
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import unittest
+
+from syvert.runtime import TaskInput, TaskRequest, execute_task, execute_task_with_record
+from syvert.task_record import (
+    TaskRecordContractError,
+    TaskRequestSnapshot,
+    create_task_record,
+    finish_task_record,
+    start_task_record,
+    task_record_from_dict,
+    task_record_to_dict,
+)
+
+
+class SuccessfulAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request):
+        return {
+            "raw": {"id": "raw-1"},
+            "normalized": {
+                "platform": "stub",
+                "content_id": "content-1",
+                "content_type": "unknown",
+                "canonical_url": request.input.url,
+                "title": "",
+                "body_text": "",
+                "published_at": None,
+                "author": {
+                    "author_id": None,
+                    "display_name": None,
+                    "avatar_url": None,
+                },
+                "stats": {
+                    "like_count": None,
+                    "comment_count": None,
+                    "share_count": None,
+                    "collect_count": None,
+                },
+                "media": {
+                    "cover_url": None,
+                    "video_url": None,
+                    "image_urls": [],
+                },
+            },
+        }
+
+
+class PlatformFailureAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request):
+        from syvert.runtime import PlatformAdapterError
+
+        raise PlatformAdapterError(
+            code="platform_broken",
+            message="boom",
+            details={"reason": "bad"},
+        )
+
+
+class UnsupportedCapabilityAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"creator_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request):
+        raise AssertionError("execute should not be called")
+
+
+class UnserializableSuccessAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request):
+        return {
+            "raw": {"id": "raw-bad", "bad": object()},
+            "normalized": {
+                "platform": "stub",
+                "content_id": "content-bad",
+                "content_type": "unknown",
+                "canonical_url": request.input.url,
+                "title": "",
+                "body_text": "",
+                "published_at": None,
+                "author": {
+                    "author_id": None,
+                    "display_name": None,
+                    "avatar_url": None,
+                },
+                "stats": {
+                    "like_count": None,
+                    "comment_count": None,
+                    "share_count": None,
+                    "collect_count": None,
+                },
+                "media": {
+                    "cover_url": None,
+                    "video_url": None,
+                    "image_urls": [],
+                },
+            },
+        }
+
+
+class TaskRecordCodecTests(unittest.TestCase):
+    def test_round_trips_success_record(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/1"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-1",
+        )
+
+        self.assertEqual(outcome.envelope["status"], "success")
+        self.assertIsNotNone(outcome.task_record)
+
+        payload = task_record_to_dict(outcome.task_record)
+        restored = task_record_from_dict(payload)
+
+        self.assertEqual(restored, outcome.task_record)
+        self.assertEqual(restored.status, "succeeded")
+
+    def test_rejects_missing_required_lifecycle_event(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/2"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-2",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        payload["logs"] = payload["logs"][:-1]
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_accepts_idempotent_terminal_rewrite_and_rejects_conflicting_terminal(self) -> None:
+        snapshot = TaskRequestSnapshot(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            target_type="url",
+            target_value="https://example.com/post/3",
+            collection_mode="hybrid",
+        )
+        accepted = create_task_record("task-record-3", snapshot, occurred_at="2026-04-17T10:30:00Z")
+        running = start_task_record(accepted, occurred_at="2026-04-17T10:30:01Z")
+        envelope = {
+            "task_id": "task-record-3",
+            "adapter_key": "stub",
+            "capability": "content_detail_by_url",
+            "status": "failed",
+            "error": {
+                "category": "platform",
+                "code": "platform_broken",
+                "message": "boom",
+                "details": {"reason": "bad"},
+            },
+        }
+        failed = finish_task_record(running, envelope, occurred_at="2026-04-17T10:30:02Z")
+
+        self.assertEqual(finish_task_record(failed, envelope), failed)
+
+        conflicting = dict(envelope)
+        conflicting["error"] = dict(envelope["error"])
+        conflicting["error"]["code"] = "changed"
+        with self.assertRaises(TaskRecordContractError):
+            finish_task_record(failed, conflicting)
+
+    def test_rejects_invalid_scalar_types_during_round_trip_load(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/3b"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-3b",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        payload["task_id"] = 123
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+
+class RuntimeTaskRecordTests(unittest.TestCase):
+    def test_execute_task_with_record_keeps_preaccepted_failure_outside_durable_history(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/4"),
+            ),
+            adapters={"stub": UnsupportedCapabilityAdapter()},
+            task_id_factory=lambda: "task-record-4",
+        )
+
+        self.assertEqual(outcome.envelope["status"], "failed")
+        self.assertEqual(outcome.envelope["error"]["code"], "capability_not_supported")
+        self.assertIsNone(outcome.task_record)
+
+    def test_execute_task_with_record_builds_failed_record_for_business_failure(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/5"),
+            ),
+            adapters={"stub": PlatformFailureAdapter()},
+            task_id_factory=lambda: "task-record-5",
+        )
+
+        self.assertEqual(outcome.envelope["status"], "failed")
+        self.assertIsNotNone(outcome.task_record)
+        self.assertEqual(outcome.task_record.status, "failed")
+        self.assertEqual(outcome.task_record.result.envelope["error"]["code"], "platform_broken")
+
+    def test_execute_task_envelope_contract_stays_unchanged(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/6"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-6",
+        )
+
+        self.assertEqual(envelope["status"], "success")
+        self.assertEqual(envelope["task_id"], "task-record-6")
+        self.assertIn("raw", envelope)
+        self.assertIn("normalized", envelope)
+
+    def test_execute_task_with_record_fails_closed_when_terminal_envelope_is_not_json_serializable(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/7"),
+            ),
+            adapters={"stub": UnserializableSuccessAdapter()},
+            task_id_factory=lambda: "task-record-7",
+        )
+
+        self.assertEqual(outcome.envelope["status"], "failed")
+        self.assertEqual(outcome.envelope["error"]["code"], "envelope_not_json_serializable")
+        self.assertIsNone(outcome.task_record)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：把 `FR-0008` 冻结的任务状态、终态结果与执行日志共享模型落到 runtime 主路径，为 `#139` 的本地持久化管线提供稳定输入。
- 主要改动：
  - 新增 `syvert/task_record.py`，落地 `TaskRecord` / `TaskRequestSnapshot` / `TaskTerminalResult` / `TaskLogEntry` 及 JSON-safe 序列化、反序列化与 fail-closed 校验。
  - 在 `syvert/runtime.py` 新增 `execute_task_with_record()`，把 `accepted -> running -> succeeded|failed` 生命周期接到共享执行主路径，并保留 `execute_task()` 现有 envelope surface。
  - 新增 `tests/runtime/test_task_record.py`，覆盖 pre-accepted failure 不入 durable history、业务失败 durable failed、非法反序列化拒绝、非 JSON-safe 终态 fail-closed。

## Issue 摘要

`#138` 要求在不提前引入本地持久化或 CLI 查询 surface 的前提下，先把 `FR-0008` 的共享 task record contract 真正落到 runtime，确保 `#139` 不再重定义状态/结果/日志语义。

## 关联事项

- Issue: #138
- item_key: `CHORE-0123-fr-0008-task-record-model`
- item_type: `CHORE`
- release: `v0.3.0`
- sprint: `2026-S16`
- Closing: Fixes #138

## 风险

- 风险级别：`normal`
- 审查关注：
  - pre-`accepted` failure 是否仍然停留在 durable history 之外
  - 终态 envelope 与 `TaskRecord.status` / JSON-safe 约束是否保持 fail-closed
  - 本 PR 是否严格停留在共享模型层，没有越界进入 `#139` 的本地存储实现

## 验证

- 已执行：
  - `python3 -m py_compile syvert/runtime.py syvert/task_record.py tests/runtime/test_task_record.py`
  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_models tests.runtime.test_cli`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/commit_check.py --mode pr --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/governance_gate.py --mode ci --base-sha $(git merge-base origin/main HEAD) --head-sha $(git rev-parse HEAD) --head-ref issue-138-fr-0008`
- 未执行：
  - `pr_guardian.py` / merge gate（待 PR 审查阶段执行）

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
