### PR TITLE
fix(governance): 固化 guardian live head 与 checkpoint 边界

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -57,6 +57,7 @@ codex:
 - 长任务统一按 `kickoff -> checkpoint -> compact -> resume -> handoff -> merge-ready` 执行。
 - `核心事项` 强制存在 `exec-plan`，并记录事项上下文、停点、下一步、已验证项、未决风险、最近一次 checkpoint 对应的 head SHA。
 - `exec-plan` 中的 head SHA 用于恢复最近一次 checkpoint，不替代 guardian 对当前受审 head SHA 的绑定与 merge gate 校验。
+- 不得要求 active `exec-plan` 追写当前受审 head；当前 live review head 只以 PR `headRefOid` 与 guardian state / merge gate 结果为准。
 - 仅当执行回合显式推进新的 checkpoint 时，才刷新 `exec-plan` 中记录的 checkpoint head。
 - review 结论、GitHub checks、PR 关联、索引入口等审查态信息的更新，不自动构成新的 checkpoint。
 - checkpoint 与 resume 必须保持 `Issue`、`item_key`、`release`、`sprint` 一致；若事项上下文发生变化，必须先更新 active `exec-plan`，再继续执行。
@@ -103,6 +104,7 @@ codex:
 - 完成一组可验证改动后必须更新一次 checkpoint。
 - 变更停点、风险、验证结论或形成新的 checkpoint 时必须更新。
 - 若仅发生后续跟进 commit、但尚未形成新的 checkpoint，可保留最近一次 checkpoint head，并由 guardian state 绑定当前受审 head。
+- 若仅补 review / merge gate / closeout metadata，可记录 metadata-only follow-up 的追溯说明，但不得把版本化 `exec-plan` 的静态 SHA 定义为必须穷尽到当前 HEAD。
 - 若仅补充 review / merge gate 元数据，而未显式推进新的执行停点，不要求刷新 checkpoint head。
 - 变更 `item_key`、`item_type`、`release`、`sprint` 或事项在当前轮次中的定位时必须更新。
 - 进入 review、进入 merge gate 前必须更新到最新状态。

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -104,7 +104,7 @@ codex:
 - 完成一组可验证改动后必须更新一次 checkpoint。
 - 变更停点、风险、验证结论或形成新的 checkpoint 时必须更新。
 - 若仅发生后续跟进 commit、但尚未形成新的 checkpoint，可保留最近一次 checkpoint head，并由 guardian state 绑定当前受审 head。
-- 若仅补 review / merge gate / closeout metadata，可记录 metadata-only follow-up 的追溯说明，但不得把版本化 `exec-plan` 的静态 SHA 定义为必须穷尽到当前 HEAD。
+- 若当前回合被 active `exec-plan` 明确声明为 `metadata-only closeout follow-up`，且仅补 review / merge gate / closeout metadata，可记录该 follow-up 的追溯说明，但不得把版本化 `exec-plan` 的静态 SHA 定义为必须穷尽到当前 HEAD。
 - 若仅补充 review / merge gate 元数据，而未显式推进新的执行停点，不要求刷新 checkpoint head。
 - 变更 `item_key`、`item_type`、`release`、`sprint` 或事项在当前轮次中的定位时必须更新。
 - 进入 review、进入 merge gate 前必须更新到最新状态。

--- a/docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md
+++ b/docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md
@@ -1,0 +1,34 @@
+# ADR-GOV-0031 Guardian live review head stays outside versioned exec-plans
+
+## 关联信息
+
+- Issue：`#150`
+- item_key：`GOV-0031-guardian-live-head-binding`
+- item_type：`GOV`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+
+## 背景
+
+`#149` 的 parent closeout 审查暴露出一条治理层自引用循环：
+
+- active `exec-plan` 被要求静态记录“当前受审 head / 门禁绑定”
+- 但 closeout PR 自身又会继续修改这个版本化 `exec-plan`
+- 一旦为了追平最新 head 提交 metadata-only review sync，PR head 会再次变化
+- guardian 下一轮又会要求文档继续追写新的 head
+
+结果是 closeout 回合围绕“文档是否追平最新 SHA”无限追逐，而不是继续审查 checkpoint 语义、追溯关系与 merge gate 本身。
+
+## 决策
+
+- 当前 live review head 的唯一真相固定为 PR `headRefOid` 与 guardian state / merge gate 的当前绑定结果，不写回 versioned `exec-plan` 作为静态真相。
+- active `exec-plan` 只承载最近一次 checkpoint / resume truth；若需要描述后续 metadata-only review sync，只能作为追溯说明，而不是必须穷尽到当前 HEAD 的静态列表。
+- guardian prompt 必须显式提醒 reviewer：不要要求 active `exec-plan` 追写当前 live head；若当前 diff 仅补 review / merge gate / closeout metadata，也不要把 metadata-only head 视为新的 checkpoint。
+- metadata-only closeout follow-up 的审查重点固定为 checkpoint 语义、追溯关系、验证证据与门禁结果是否自洽，而不是文档中的静态 SHA 是否等于当前 HEAD。
+- 当前事项不放宽 reviewer rubric、guardian verdict schema、`safe_to_merge` 语义或 merge gate 条件；只修正 live head carrier 与 checkpoint carrier 的职责边界。
+
+## 影响
+
+- closeout PR 不再因为追写“当前受审 head”而触发自引用的 metadata-only SHA 追逐。
+- guardian 仍然绑定当前 PR live head，但这个绑定留在 PR 元数据与 guardian state，而不是留在会继续被 PR 自身改写的版本化文档里。
+- 后续若需要补充 closeout 追账，只能增加追溯说明或验证记录，不能再次把 `exec-plan` 退化成 live head 状态面。

--- a/docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md
+++ b/docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md
@@ -22,7 +22,7 @@
 ## 决策
 
 - 当前 live review head 的唯一真相固定为 PR `headRefOid` 与 guardian state / merge gate 的当前绑定结果，不写回 versioned `exec-plan` 作为静态真相。
-- active `exec-plan` 只承载最近一次 checkpoint / resume truth；若需要描述后续 metadata-only review sync，只能作为追溯说明，而不是必须穷尽到当前 HEAD 的静态列表。
+- active `exec-plan` 只承载最近一次 checkpoint / resume truth；只有当当前回合被该工件明确声明为 `metadata-only closeout follow-up` 且变更仅限 review / merge gate / closeout metadata 时，才允许把后续跟进写成追溯说明，而不是必须穷尽到当前 HEAD 的静态列表。
 - guardian prompt 必须显式提醒 reviewer：不要要求 active `exec-plan` 追写当前 live head；若当前 diff 仅补 review / merge gate / closeout metadata，也不要把 metadata-only head 视为新的 checkpoint。
 - metadata-only closeout follow-up 的审查重点固定为 checkpoint 语义、追溯关系、验证证据与门禁结果是否自洽，而不是文档中的静态 SHA 是否等于当前 HEAD。
 - 当前事项不放宽 reviewer rubric、guardian verdict schema、`safe_to_merge` 语义或 merge gate 条件；只修正 live head carrier 与 checkpoint carrier 的职责边界。

--- a/docs/exec-plans/GOV-0031-guardian-live-head-binding.md
+++ b/docs/exec-plans/GOV-0031-guardian-live-head-binding.md
@@ -1,0 +1,72 @@
+# GOV-0031 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0031-guardian-live-head-binding`
+- Issue：`#150`
+- item_type：`GOV`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+- 关联 spec：无（治理脚本事项）
+- 关联 decision：`docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
+- 关联 PR：
+- active 收口事项：`GOV-0031-guardian-live-head-binding`
+
+## 目标
+
+- 修复 guardian / closeout 流程在 metadata-only docs follow-up 下对“当前受审 head”进行自引用追逐的问题。
+- 把 live review head 与 checkpoint head 的 carrier 边界固定回 `PR metadata + guardian state` vs `versioned exec-plan`。
+- 为 guardian prompt 与治理测试补齐明确约束，避免后续 closeout 回合再次围绕静态 SHA 追逐。
+
+## 范围
+
+- 本次纳入：`scripts/pr_guardian.py`、`tests/governance/test_pr_guardian.py`、`WORKFLOW.md`、`docs/process/agent-loop.md`、`docs/exec-plans/README.md`、`docs/exec-plans/_template.md`、本事项 `decision` / `exec-plan`、必要的 release / sprint 索引
+- 本次不纳入：`merge_pr` 条件放宽、guardian verdict schema 调整、已有历史 closeout 工件的大规模迁移、`FR-0008` runtime / formal spec 语义改写
+
+## 当前停点
+
+- `#149` 合入后，`FR-0008` 已完成主干收口，但暴露出 guardian 对 metadata-only closeout head 的自引用追逐问题。
+- 当前已确认根因不在 runtime 或 closeout 语义，而在于 live review head 被错误地期待写回会继续被 PR 改动的 versioned `exec-plan`。
+- 当前工作树已创建：`/Users/mc/code/worktrees/syvert/issue-150-chore-guardian-metadata-only-closeout-head`；下一步在 guardian prompt、治理测试与执行文档中同步固化该边界。
+
+## 下一步动作
+
+- 修改 `scripts/pr_guardian.py`，显式把 live review head 绑定固定到 PR `headRefOid` 与 guardian state。
+- 为 metadata-only closeout follow-up 补齐 prompt 回归测试，防止 reviewer 再要求 exec-plan 追写当前 HEAD。
+- 运行治理测试与 guard，随后创建受控 PR，推进 guardian / merge gate / issue closeout。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.3.0` 的 closeout 治理链补齐稳定的 live head / checkpoint carrier 边界，避免 parent closeout PR 因 metadata-only sync 陷入自引用循环。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0008` closeout 后的治理修复项，负责把 guardian gate 对 live head 的消费边界恢复为单一 contract。
+- 阻塞：无外部实现阻塞；需要确保改动只修复 live head carrier，不误放宽 merge gate 或 reviewer rubric。
+
+## 已验证项
+
+- `gh issue view 150 --repo MC-and-his-Agents/Syvert`
+- `python3 scripts/create_worktree.py --issue 150 --class governance`
+- 已创建 worktree：`/Users/mc/code/worktrees/syvert/issue-150-chore-guardian-metadata-only-closeout-head`
+- 已阅读：`AGENTS.md`
+- 已阅读：`WORKFLOW.md`
+- 已阅读：`docs/process/agent-loop.md`
+- 已阅读：`docs/exec-plans/README.md`
+- 已阅读：`scripts/pr_guardian.py`
+- 已阅读：`tests/governance/test_pr_guardian.py`
+
+## 未决风险
+
+- 若只修改 prompt 文案而不补治理测试，后续重构仍可能让 guardian 再次回到“要求 exec-plan 追写 live head”的错误边界。
+- 若把 metadata-only closeout 例外扩大成任意 PR 的通用放宽，会削弱当前 merge gate 的 head 一致性要求。
+- 若 release / sprint / exec-plan 文档继续把 versioned `exec-plan` 当 live head 状态面，治理口径仍可能再次分裂。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销 `scripts/pr_guardian.py`、`tests/governance/test_pr_guardian.py`、本事项 decision / exec-plan 与相关治理文档的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `6e7e23d93459b92f9b7deeb54ad05da6a632b4e6`
+- 说明：该 checkpoint 是 `#149` 合入后的主干基线；当前事项在此基础上修复 guardian live head carrier，不改写 `FR-0008` 的 closeout 语义。

--- a/docs/exec-plans/GOV-0031-guardian-live-head-binding.md
+++ b/docs/exec-plans/GOV-0031-guardian-live-head-binding.md
@@ -27,13 +27,14 @@
 
 - `#149` 合入后，`FR-0008` 已完成主干收口，但暴露出 guardian 对 metadata-only closeout head 的自引用追逐问题。
 - 当前已确认根因不在 runtime 或 closeout 语义，而在于 live review head 被错误地期待写回会继续被 PR 改动的 versioned `exec-plan`。
-- 当前工作树已创建：`/Users/mc/code/worktrees/syvert/issue-150-chore-guardian-metadata-only-closeout-head`；下一步在 guardian prompt、治理测试与执行文档中同步固化该边界。
+- 当前治理修复已在 checkpoint `a1f1cba463e7036e0fe7155d8b1b99789f84b03e` 落盘：guardian prompt、回归测试、bootstrap decision、active `exec-plan` 与 release / sprint 索引已同步对齐。
+- 当前停在推送分支与创建 PR 前；下一步进入受控 `open_pr`、guardian gate 与 merge gate 收口。
 
 ## 下一步动作
 
-- 修改 `scripts/pr_guardian.py`，显式把 live review head 绑定固定到 PR `headRefOid` 与 guardian state。
-- 为 metadata-only closeout follow-up 补齐 prompt 回归测试，防止 reviewer 再要求 exec-plan 追写当前 HEAD。
-- 运行治理测试与 guard，随后创建受控 PR，推进 guardian / merge gate / issue closeout。
+- 推送 `issue-150-chore-guardian-metadata-only-closeout-head` 分支。
+- 通过受控入口创建治理 PR，并把 `Issue` / `item_key` / `release` / `sprint` 与 canonical `integration_check` carrier 对齐。
+- 运行 guardian 审查与受控 merge，随后同步关闭 `#150` 并更新 Project 状态。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -47,6 +48,7 @@
 ## 已验证项
 
 - `gh issue view 150 --repo MC-and-his-Agents/Syvert`
+- `gh issue edit 150 --title "[GOV] 修复 guardian 对 metadata-only closeout head 的自引用追逐"`
 - `python3 scripts/create_worktree.py --issue 150 --class governance`
 - 已创建 worktree：`/Users/mc/code/worktrees/syvert/issue-150-chore-guardian-metadata-only-closeout-head`
 - 已阅读：`AGENTS.md`
@@ -55,6 +57,20 @@
 - 已阅读：`docs/exec-plans/README.md`
 - 已阅读：`scripts/pr_guardian.py`
 - 已阅读：`tests/governance/test_pr_guardian.py`
+- 已完成最小改动文件：`scripts/pr_guardian.py`
+- 已完成最小改动文件：`tests/governance/test_pr_guardian.py`
+- 已完成最小改动文件：`WORKFLOW.md`
+- 已完成最小改动文件：`docs/process/agent-loop.md`
+- 已完成最小改动文件：`docs/exec-plans/README.md`
+- 已完成最小改动文件：`docs/exec-plans/_template.md`
+- 已完成最小改动文件：`docs/releases/v0.3.0.md`
+- 已完成最小改动文件：`docs/sprints/2026-S16.md`
+- 已完成最小改动文件：`docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
+- 已完成最小改动文件：`docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
+- `python3 -m unittest tests.governance.test_pr_guardian`
+- `python3 scripts/workflow_guard.py --mode ci`
+- `python3 scripts/docs_guard.py --mode ci`
+- `python3 scripts/open_pr.py --class governance --issue 150 --item-key GOV-0031-guardian-live-head-binding --item-type GOV --release v0.3.0 --sprint 2026-S16 --title "fix(governance): 固化 guardian live head 与 checkpoint 边界" --dry-run`
 
 ## 未决风险
 
@@ -68,5 +84,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `6e7e23d93459b92f9b7deeb54ad05da6a632b4e6`
-- 说明：该 checkpoint 是 `#149` 合入后的主干基线；当前事项在此基础上修复 guardian live head carrier，不改写 `FR-0008` 的 closeout 语义。
+- `a1f1cba463e7036e0fe7155d8b1b99789f84b03e`
+- 说明：该 checkpoint 首次把 guardian live head / checkpoint carrier 边界、回归测试、bootstrap decision 与 sprint / release 索引同步落盘；后续若只补 PR / guardian / merge gate 追账，则作为 metadata-only follow-up 记录，不把版本化 `exec-plan` 退化为 live head 状态面。

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -19,7 +19,7 @@
 - `exec-plan` 中的 head SHA 用于恢复最近一次 checkpoint，不替代 guardian 对当前受审 head SHA 的绑定与 merge gate 校验。
 - 不得要求 active `exec-plan` 追写当前受审 head；当前 live review head 只由 PR `headRefOid` 与 guardian state / merge gate 绑定。
 - 若当前 PR 在最近一次 checkpoint 之后仍有跟进 commit，但尚未形成新的 checkpoint，可保留最近一次 checkpoint head，并由 guardian state 绑定当前受审 head。
-- 若仅补 review / merge gate / closeout metadata，可记录 metadata-only follow-up 的追溯说明，但不得把版本化 `exec-plan` 的静态 SHA 定义为必须穷尽到当前 HEAD。
+- 若当前回合被 active `exec-plan` 明确声明为 `metadata-only closeout follow-up`，且仅补 review / merge gate / closeout metadata，可记录该 follow-up 的追溯说明，但不得把版本化 `exec-plan` 的静态 SHA 定义为必须穷尽到当前 HEAD。
 - review 结论、GitHub checks、PR 关联与索引入口的更新，只要未显式推进新的执行停点，就属于审查态元数据补充，不要求单独刷新 checkpoint head。
 
 ## 职责边界

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -17,7 +17,9 @@
   - 最近一次 checkpoint 对应的 head SHA
 - `存量事项` 在进入新的执行回合前补齐上述字段。
 - `exec-plan` 中的 head SHA 用于恢复最近一次 checkpoint，不替代 guardian 对当前受审 head SHA 的绑定与 merge gate 校验。
+- 不得要求 active `exec-plan` 追写当前受审 head；当前 live review head 只由 PR `headRefOid` 与 guardian state / merge gate 绑定。
 - 若当前 PR 在最近一次 checkpoint 之后仍有跟进 commit，但尚未形成新的 checkpoint，可保留最近一次 checkpoint head，并由 guardian state 绑定当前受审 head。
+- 若仅补 review / merge gate / closeout metadata，可记录 metadata-only follow-up 的追溯说明，但不得把版本化 `exec-plan` 的静态 SHA 定义为必须穷尽到当前 HEAD。
 - review 结论、GitHub checks、PR 关联与索引入口的更新，只要未显式推进新的执行停点，就属于审查态元数据补充，不要求单独刷新 checkpoint head。
 
 ## 职责边界

--- a/docs/exec-plans/_template.md
+++ b/docs/exec-plans/_template.md
@@ -52,4 +52,4 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - `<checkpoint_commit_sha>`
-- 如需描述 metadata-only review sync，只记录追溯说明，不把当前受审 head 写成必须与最新 HEAD 完全一致的静态字段。
+- 如当前回合被明确声明为 `metadata-only closeout follow-up`，只记录该 follow-up 的追溯说明，不把当前受审 head 写成必须与最新 HEAD 完全一致的静态字段。

--- a/docs/exec-plans/_template.md
+++ b/docs/exec-plans/_template.md
@@ -52,3 +52,4 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - `<checkpoint_commit_sha>`
+- 如需描述 metadata-only review sync，只记录追溯说明，不把当前受审 head 写成必须与最新 HEAD 完全一致的静态字段。

--- a/docs/process/agent-loop.md
+++ b/docs/process/agent-loop.md
@@ -25,6 +25,8 @@
   - 最近一次 checkpoint 对应的 head SHA
 - 只有当执行回合显式形成新的 checkpoint 时，才推进该 head SHA。
 - review 结论、GitHub checks、PR 关联等审查态信息的补充，不单独构成新的 checkpoint。
+- 当前 live review head 只由 PR `headRefOid` 与 guardian state / merge gate 绑定，不要求 active `exec-plan` 追写该值。
+- 若仅补 review / merge gate / closeout metadata，可附带 metadata-only follow-up 追溯说明，但不得把其写成必须穷尽当前 HEAD 的静态清单。
 
 ## compact
 

--- a/docs/process/agent-loop.md
+++ b/docs/process/agent-loop.md
@@ -26,7 +26,7 @@
 - 只有当执行回合显式形成新的 checkpoint 时，才推进该 head SHA。
 - review 结论、GitHub checks、PR 关联等审查态信息的补充，不单独构成新的 checkpoint。
 - 当前 live review head 只由 PR `headRefOid` 与 guardian state / merge gate 绑定，不要求 active `exec-plan` 追写该值。
-- 若仅补 review / merge gate / closeout metadata，可附带 metadata-only follow-up 追溯说明，但不得把其写成必须穷尽当前 HEAD 的静态清单。
+- 若当前回合被 active `exec-plan` 明确声明为 `metadata-only closeout follow-up`，且仅补 review / merge gate / closeout metadata，可附带该 follow-up 的追溯说明，但不得把其写成必须穷尽当前 HEAD 的静态清单。
 
 ## compact
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -30,6 +30,7 @@
 - `CHORE-0127-fr-0009-cli-task-query`：`FR-0009` CLI 任务状态与结果查询，对应 Issue `#142`
 - `CHORE-0128-fr-0009-cli-core-path-persistence-closeout`：`FR-0009` 持久化任务的 CLI/Core 同路径闭环，对应 Issue `#143`
 - `CHORE-0129-fr-0009-parent-closeout`：`FR-0009` 父事项 closeout Work Item，对应 Issue `#144`
+- `GOV-0031-guardian-live-head-binding`：修复 guardian 对 metadata-only closeout head 的自引用追逐，对应 Issue `#150`
 
 ## 相关前提
 
@@ -49,6 +50,9 @@
   - `docs/exec-plans/CHORE-0123-fr-0008-task-record-model.md`
   - `docs/exec-plans/CHORE-0124-fr-0008-local-persistence-and-serialization.md`
   - `docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md`
+  - `docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
+- decision：
+  - `docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
 
 ## 当前 closeout 真相
 

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -21,6 +21,7 @@
 - `CHORE-0127-fr-0009-cli-task-query`：`FR-0009` CLI 任务状态与结果查询，对应 Issue `#142`
 - `CHORE-0128-fr-0009-cli-core-path-persistence-closeout`：`FR-0009` 持久化任务的 CLI/Core 同路径闭环，对应 Issue `#143`
 - `CHORE-0129-fr-0009-parent-closeout`：`FR-0009` 父事项 closeout Work Item，对应 Issue `#144`
+- `GOV-0031-guardian-live-head-binding`：修复 guardian 对 metadata-only closeout head 的自引用追逐，对应 Issue `#150`
 
 ## 进入前依赖
 
@@ -37,7 +38,7 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#126`、`#127`、`#128`、`#137`、`#138`、`#139`、`#140`、`#141`、`#142`、`#143`、`#144`
+- 相关 Issue / PR：`#126`、`#127`、`#128`、`#137`、`#138`、`#139`、`#140`、`#141`、`#142`、`#143`、`#144`、`#150`
 
 ## 关联工件
 
@@ -50,6 +51,9 @@
   - `docs/exec-plans/CHORE-0123-fr-0008-task-record-model.md`
   - `docs/exec-plans/CHORE-0124-fr-0008-local-persistence-and-serialization.md`
   - `docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md`
+  - `docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
+- decision：
+  - `docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
 
 ## 当前 closeout 真相
 

--- a/scripts/pr_guardian.py
+++ b/scripts/pr_guardian.py
@@ -66,6 +66,10 @@ METADATA_ONLY_CLOSEOUT_DOC_PREFIXES = (
     "docs/releases/",
     "docs/sprints/",
 )
+METADATA_ONLY_CLOSEOUT_MARKERS = (
+    "metadata-only closeout follow-up",
+    "metadata-only review sync",
+)
 REVIEW_SECTION_ALIASES = {
     "摘要": "summary",
     "Issue 摘要": "issue_summary",
@@ -763,24 +767,48 @@ def append_optional_section(lines: list[str], title: str, content: str) -> None:
     lines.extend(["", title, content])
 
 
-def is_metadata_only_closeout_follow_up(item_context: dict[str, str], changed_files: list[str]) -> bool:
+def resolve_exec_plan_path(repo_root: Path, item_context: dict[str, str]) -> Path | None:
+    path_text = str(item_context.get("exec_plan", "")).strip()
+    if not path_text:
+        return None
+    exec_plan_path = Path(path_text)
+    if not exec_plan_path.is_absolute():
+        exec_plan_path = repo_root / exec_plan_path
+    return exec_plan_path
+
+
+def exec_plan_declares_metadata_only_closeout_follow_up(repo_root: Path, item_context: dict[str, str]) -> bool:
+    exec_plan_path = resolve_exec_plan_path(repo_root, item_context)
+    if exec_plan_path is None or not exec_plan_path.exists():
+        return False
+    normalized = exec_plan_path.read_text(encoding="utf-8").lower()
+    return any(marker in normalized for marker in METADATA_ONLY_CLOSEOUT_MARKERS)
+
+
+def is_metadata_only_closeout_follow_up(repo_root: Path, item_context: dict[str, str], changed_files: list[str]) -> bool:
     item_key = str(item_context.get("item_key", "")).strip().lower()
     if "closeout" not in item_key or not changed_files:
         return False
     categories = {item.category for item in classify_paths(changed_files)}
     if categories != {"docs"}:
         return False
-    return all(path.startswith(METADATA_ONLY_CLOSEOUT_DOC_PREFIXES) for path in changed_files)
+    if not all(path.startswith(METADATA_ONLY_CLOSEOUT_DOC_PREFIXES) for path in changed_files):
+        return False
+    return exec_plan_declares_metadata_only_closeout_follow_up(repo_root, item_context)
 
 
-def head_checkpoint_contract_rules(context: dict[str, object]) -> list[str]:
+def head_checkpoint_contract_rules(repo_root: Path, context: dict[str, object]) -> list[str]:
     rules = [
         "当前 live review head 以 PR 基本信息中的 `头部提交` 为准，并由 guardian state / merge gate 绑定；不要要求 active exec-plan 追写该值。",
         "active exec-plan 只承载最近一次 checkpoint / resume truth；若当前 diff 仅补 review / merge gate / closeout metadata，不要把 metadata-only head 视为新的 checkpoint。",
     ]
     item_context = context.get("item_context")
     changed_files = context.get("changed_files")
-    if isinstance(item_context, dict) and isinstance(changed_files, list) and is_metadata_only_closeout_follow_up(item_context, changed_files):
+    if (
+        isinstance(item_context, dict)
+        and isinstance(changed_files, list)
+        and is_metadata_only_closeout_follow_up(repo_root, item_context, changed_files)
+    ):
         rules.append(
             "当前 diff 命中 metadata-only closeout follow-up：请核对 checkpoint 语义、追溯关系与门禁证据是否自洽；不要因 exec-plan 未把静态 SHA 追到当前 HEAD 而单独给出阻断。"
         )
@@ -834,7 +862,7 @@ def build_prompt(meta: dict, worktree_dir: Path) -> str:
         *[f"- {rule}" for rule in REVIEW_EXECUTION_RULES],
         "",
         "Head / Checkpoint Contract：",
-        *[f"- {rule}" for rule in head_checkpoint_contract_rules(context)],
+        *[f"- {rule}" for rule in head_checkpoint_contract_rules(worktree_dir, context)],
         "",
         "Reviewer Rubric 节选（来自 `code_review.md`）：",
         rubric_excerpt,

--- a/scripts/pr_guardian.py
+++ b/scripts/pr_guardian.py
@@ -47,6 +47,7 @@ from scripts.integration_contract import (
 )
 from scripts.item_context import active_exec_plans_for_issue, load_item_context_from_exec_plan, parse_item_context_from_body
 from scripts.open_pr import extract_issue_summary_sections
+from scripts.policy.policy import classify_paths
 from scripts.state_paths import guardian_legacy_state_path, guardian_state_path
 
 
@@ -59,6 +60,11 @@ REVIEW_REQUIRED_BODY_FIELDS = ("issue", "item_key", "item_type", "release", "spr
 REVIEW_EXECUTION_RULES = (
     "工件完整性只用于确认输入是否足够，不要把 checks、Draft 状态或 merge 动作当成 reviewer 结论来源。",
     "若缺少必要工件或验证证据，应明确指出阻断项；merge gate、head 绑定与 squash merge 安全性由 guardian gate 入口单独消费。",
+)
+METADATA_ONLY_CLOSEOUT_DOC_PREFIXES = (
+    "docs/exec-plans/",
+    "docs/releases/",
+    "docs/sprints/",
 )
 REVIEW_SECTION_ALIASES = {
     "摘要": "summary",
@@ -757,6 +763,30 @@ def append_optional_section(lines: list[str], title: str, content: str) -> None:
     lines.extend(["", title, content])
 
 
+def is_metadata_only_closeout_follow_up(item_context: dict[str, str], changed_files: list[str]) -> bool:
+    item_key = str(item_context.get("item_key", "")).strip().lower()
+    if "closeout" not in item_key or not changed_files:
+        return False
+    categories = {item.category for item in classify_paths(changed_files)}
+    if categories != {"docs"}:
+        return False
+    return all(path.startswith(METADATA_ONLY_CLOSEOUT_DOC_PREFIXES) for path in changed_files)
+
+
+def head_checkpoint_contract_rules(context: dict[str, object]) -> list[str]:
+    rules = [
+        "当前 live review head 以 PR 基本信息中的 `头部提交` 为准，并由 guardian state / merge gate 绑定；不要要求 active exec-plan 追写该值。",
+        "active exec-plan 只承载最近一次 checkpoint / resume truth；若当前 diff 仅补 review / merge gate / closeout metadata，不要把 metadata-only head 视为新的 checkpoint。",
+    ]
+    item_context = context.get("item_context")
+    changed_files = context.get("changed_files")
+    if isinstance(item_context, dict) and isinstance(changed_files, list) and is_metadata_only_closeout_follow_up(item_context, changed_files):
+        rules.append(
+            "当前 diff 命中 metadata-only closeout follow-up：请核对 checkpoint 语义、追溯关系与门禁证据是否自洽；不要因 exec-plan 未把静态 SHA 追到当前 HEAD 而单独给出阻断。"
+        )
+    return rules
+
+
 def render_raw_body_fallback(raw_body: str, raw_sections: dict[str, str]) -> str:
     if not raw_body:
         return ""
@@ -802,6 +832,9 @@ def build_prompt(meta: dict, worktree_dir: Path) -> str:
         "",
         "执行约束：",
         *[f"- {rule}" for rule in REVIEW_EXECUTION_RULES],
+        "",
+        "Head / Checkpoint Contract：",
+        *[f"- {rule}" for rule in head_checkpoint_contract_rules(context)],
         "",
         "Reviewer Rubric 节选（来自 `code_review.md`）：",
         rubric_excerpt,

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -1469,6 +1469,44 @@ class CodexReviewExecutionTests(unittest.TestCase):
         self.assertIn("风险摘要：", prompt)
         self.assertIn("审查关注：guardian 入口不要回退到模板噪音", prompt)
 
+    def test_build_prompt_marks_metadata_only_closeout_follow_up_as_live_head_contract(self) -> None:
+        meta = {
+            "number": 149,
+            "title": "文档: 收口 FR-0008 父事项",
+            "url": "https://example.test/pr/149",
+            "baseRefName": "main",
+            "headRefOid": "sha-149",
+            "headRefName": "issue-140-closeout-branch",
+            "body": "## 摘要\n\n- 变更目的：收口 closeout metadata\n",
+        }
+
+        with patch(
+            "scripts.pr_guardian.build_review_context",
+            return_value={
+                "pr_identity": ["- PR: #149", "- 头部提交: sha-149"],
+                "issue_context": {"identity": [], "summary": ""},
+                "item_context": {"issue": "140", "item_key": "CHORE-0125-fr-0008-parent-closeout"},
+                "raw_sections": {"摘要": "- 变更目的：收口 closeout metadata"},
+                "pr_sections": {"summary": "- 变更目的：收口 closeout metadata"},
+                "changed_files": [
+                    "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                    "docs/exec-plans/FR-0008-task-record-persistence.md",
+                    "docs/releases/v0.3.0.md",
+                    "docs/sprints/2026-S16.md",
+                ],
+                "diff_stat": "4 files changed",
+                "related_paths": ["docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md"],
+                "context_notes": [],
+            },
+        ):
+            with patch("scripts.pr_guardian.load_reviewer_rubric_excerpt", return_value="## Review Rubric\n- contract 一致性"):
+                prompt = build_prompt(meta, Path("/tmp/worktree"))
+
+        self.assertIn("Head / Checkpoint Contract：", prompt)
+        self.assertIn("不要要求 active exec-plan 追写该值", prompt)
+        self.assertIn("当前 diff 命中 metadata-only closeout follow-up", prompt)
+        self.assertIn("不要因 exec-plan 未把静态 SHA 追到当前 HEAD 而单独给出阻断", prompt)
+
     def test_build_item_context_summary_returns_exec_plan_and_related_paths(self) -> None:
         meta = {
             "body": "\n".join(

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -18,6 +18,7 @@ from scripts.pr_guardian import (
     integration_merge_gate_errors,
     load_guardian_state,
     load_reviewer_rubric_excerpt,
+    is_metadata_only_closeout_follow_up,
     merge_if_safe,
     parse_bullet_kv_section,
     parse_integration_check_payload,
@@ -1480,32 +1481,101 @@ class CodexReviewExecutionTests(unittest.TestCase):
             "body": "## 摘要\n\n- 变更目的：收口 closeout metadata\n",
         }
 
-        with patch(
-            "scripts.pr_guardian.build_review_context",
-            return_value={
-                "pr_identity": ["- PR: #149", "- 头部提交: sha-149"],
-                "issue_context": {"identity": [], "summary": ""},
-                "item_context": {"issue": "140", "item_key": "CHORE-0125-fr-0008-parent-closeout"},
-                "raw_sections": {"摘要": "- 变更目的：收口 closeout metadata"},
-                "pr_sections": {"summary": "- 变更目的：收口 closeout metadata"},
-                "changed_files": [
-                    "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
-                    "docs/exec-plans/FR-0008-task-record-persistence.md",
-                    "docs/releases/v0.3.0.md",
-                    "docs/sprints/2026-S16.md",
-                ],
-                "diff_stat": "4 files changed",
-                "related_paths": ["docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md"],
-                "context_notes": [],
-            },
-        ):
-            with patch("scripts.pr_guardian.load_reviewer_rubric_excerpt", return_value="## Review Rubric\n- contract 一致性"):
-                prompt = build_prompt(meta, Path("/tmp/worktree"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            worktree_dir = Path(temp_dir)
+            exec_plan_path = worktree_dir / "docs" / "exec-plans" / "CHORE-0125-fr-0008-parent-closeout.md"
+            exec_plan_path.parent.mkdir(parents=True, exist_ok=True)
+            exec_plan_path.write_text(
+                "\n".join(
+                    [
+                        "# closeout",
+                        "",
+                        "## 当前停点",
+                        "",
+                        "- 当前回合已进入 metadata-only closeout follow-up，只补 review / merge gate / closeout metadata。",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "scripts.pr_guardian.build_review_context",
+                return_value={
+                    "pr_identity": ["- PR: #149", "- 头部提交: sha-149"],
+                    "issue_context": {"identity": [], "summary": ""},
+                    "item_context": {
+                        "issue": "140",
+                        "item_key": "CHORE-0125-fr-0008-parent-closeout",
+                        "exec_plan": "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                    },
+                    "raw_sections": {"摘要": "- 变更目的：收口 closeout metadata"},
+                    "pr_sections": {"summary": "- 变更目的：收口 closeout metadata"},
+                    "changed_files": [
+                        "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                        "docs/exec-plans/FR-0008-task-record-persistence.md",
+                        "docs/releases/v0.3.0.md",
+                        "docs/sprints/2026-S16.md",
+                    ],
+                    "diff_stat": "4 files changed",
+                    "related_paths": ["docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md"],
+                    "context_notes": [],
+                },
+            ):
+                with patch("scripts.pr_guardian.load_reviewer_rubric_excerpt", return_value="## Review Rubric\n- contract 一致性"):
+                    prompt = build_prompt(meta, worktree_dir)
 
         self.assertIn("Head / Checkpoint Contract：", prompt)
         self.assertIn("不要要求 active exec-plan 追写该值", prompt)
         self.assertIn("当前 diff 命中 metadata-only closeout follow-up", prompt)
         self.assertIn("不要因 exec-plan 未把静态 SHA 追到当前 HEAD 而单独给出阻断", prompt)
+
+    def test_metadata_only_closeout_follow_up_requires_explicit_exec_plan_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            exec_plan_path = repo_root / "docs" / "exec-plans" / "CHORE-0125-fr-0008-parent-closeout.md"
+            exec_plan_path.parent.mkdir(parents=True, exist_ok=True)
+            exec_plan_path.write_text(
+                "当前回合是 metadata-only closeout follow-up，仅补 review / merge gate / closeout metadata。\n",
+                encoding="utf-8",
+            )
+
+            result = is_metadata_only_closeout_follow_up(
+                repo_root,
+                {
+                    "item_key": "CHORE-0125-fr-0008-parent-closeout",
+                    "exec_plan": "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                },
+                [
+                    "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                    "docs/releases/v0.3.0.md",
+                ],
+            )
+
+        self.assertTrue(result)
+
+    def test_metadata_only_closeout_follow_up_rejects_docs_only_closeout_without_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            exec_plan_path = repo_root / "docs" / "exec-plans" / "CHORE-0125-fr-0008-parent-closeout.md"
+            exec_plan_path.parent.mkdir(parents=True, exist_ok=True)
+            exec_plan_path.write_text(
+                "当前回合继续补齐 closeout 证据与索引，不声明 metadata-only follow-up。\n",
+                encoding="utf-8",
+            )
+
+            result = is_metadata_only_closeout_follow_up(
+                repo_root,
+                {
+                    "item_key": "CHORE-0125-fr-0008-parent-closeout",
+                    "exec_plan": "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                },
+                [
+                    "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                    "docs/releases/v0.3.0.md",
+                ],
+            )
+
+        self.assertFalse(result)
 
     def test_build_item_context_summary_returns_exec_plan_and_related_paths(self) -> None:
         meta = {


### PR DESCRIPTION
fix(governance): 固化 guardian live head 与 checkpoint 边界
## 摘要

- PR Class: `governance`
- 变更目的：把 guardian 对当前 live review head 的绑定固定回 `PR headRefOid + guardian state`，停止要求 versioned `exec-plan` 追写当前受审 head。
- 主要改动：
  - 在 `scripts/pr_guardian.py` 的 prompt contract 中显式区分 live review head 与 checkpoint head 的 carrier，并为 metadata-only closeout follow-up 增加定向审查指引。
  - 补齐 `tests/governance/test_pr_guardian.py` 回归，锁定“metadata-only closeout 不得因 exec-plan 未追平当前 HEAD 而单独阻断”。
  - 把同一条治理边界写回 `WORKFLOW.md`、`docs/process/agent-loop.md`、`docs/exec-plans/README.md` 与 `docs/exec-plans/_template.md`，并新增 `ADR-GOV-0031` 与 active `exec-plan`。

## Issue 摘要

- Goal: 修复 guardian / closeout 流程在 metadata-only docs follow-up 下对“当前受审 head”进行自引用追逐的问题。
- Scope: 固化 live review head 与 checkpoint head 的 carrier 边界，补齐 prompt、测试与治理文档。
- Required Outcomes: guardian 不再要求 versioned `exec-plan` 静态追写当前 live head；metadata-only closeout follow-up 只按 checkpoint 语义、追溯关系与门禁证据审查。
- Acceptance: `pr_guardian` prompt、治理测试、bootstrap decision、active exec-plan 与 release/sprint 索引在同一条 contract 上收口。

## Out of Scope

- 不改写 `FR-0008` formal spec、runtime 或 closeout 语义
- 不为任意 implementation PR 放宽实质验证要求
- 不修改 guardian verdict schema、`safe_to_merge` 语义或 `merge_pr` 条件

## 关联事项

- Issue: #150
- item_key: `GOV-0031-guardian-live-head-binding`
- item_type: `GOV`
- release: `v0.3.0`
- sprint: `2026-S16`
- Closing: Fixes #150

## 风险

- 风险级别：`high`
- 审查关注：
  - 不能把 metadata-only closeout 的定向指引扩大成任意 PR 的 merge gate 放宽。
  - 不能让 versioned `exec-plan` 再次退化成 live head 状态面。
  - 不能改变现有 guardian verdict / checks / head 一致性的 merge gate 语义。

## 验证

- 已执行：
  - `python3 -m unittest tests.governance.test_pr_guardian`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/open_pr.py --class governance --issue 150 --item-key GOV-0031-guardian-live-head-binding --item-type GOV --release v0.3.0 --sprint 2026-S16 --title "fix(governance): 固化 guardian live head 与 checkpoint 边界" --dry-run`
- 未执行：
  - guardian 审查
  - GitHub checks 全绿后的受控 merge

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次对 guardian prompt、治理测试、decision / exec-plan 与相关治理文档的增量修改。
