### PR TITLE
test(governance): 锁定 legacy review sync marker 兼容回归

### DIFF
--- a/docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md
+++ b/docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md
@@ -1,0 +1,26 @@
+# ADR-GOV-0032 Lock legacy metadata-only review sync marker compatibility
+
+## 关联信息
+
+- Issue：`#152`
+- item_key：`GOV-0032-legacy-metadata-only-review-sync-marker`
+- item_type：`GOV`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+
+## 背景
+
+`#150` 已把 guardian 对 metadata-only closeout follow-up 的例外边界收紧为显式 contract，并新增了正向 / 反向回归。但当前实现仍保留对 legacy marker `metadata-only review sync` 的兼容支持，以避免历史 closeout `exec-plan` 在未迁移前失去追溯语义。
+
+如果这条兼容路径只存在于实现代码，而没有独立回归，后续重构时可能在不影响新 marker 的情况下无意删除 legacy 支持，导致历史工件的 metadata-only closeout 判定回退。
+
+## 决策
+
+- 保留 `metadata-only review sync` 作为 legacy marker 的兼容触发词。
+- 为该 legacy marker 增加专门治理回归，独立证明它仍能触发 metadata-only closeout follow-up 判定。
+- 当前事项不改写 `#150` 已合入的 live head / checkpoint carrier contract，不放宽 merge gate，也不新增新的 marker。
+
+## 影响
+
+- legacy closeout `exec-plan` 在逐步迁移到新 marker 前，仍有明确测试保护。
+- 后续若要移除 `metadata-only review sync` 兼容，必须通过新的治理事项显式完成迁移和删除，而不是在重构中静默消失。

--- a/docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md
+++ b/docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md
@@ -27,13 +27,14 @@
 
 - `#150` 已合入主干，当前实现继续兼容 `metadata-only review sync` marker，但缺少独立回归。
 - 当前工作树已创建：`/Users/mc/code/worktrees/syvert/issue-152-gov-legacy-metadata-only-review-sync-marker`。
-- 下一步是在不改动实现逻辑的前提下补齐专门测试和 bootstrap 工件。
+- 当前补强已在 checkpoint `00aecaa5809db6004b16c7dbc01884b1e109a5e7` 落盘：legacy marker 专门回归、bootstrap decision / exec-plan 与 release / sprint 索引已同步补齐。
+- 当前停在推送分支与创建 PR 前；下一步进入受控 `open_pr`、guardian gate 与 merge gate 收口。
 
 ## 下一步动作
 
-- 补一条 legacy marker 正向回归。
-- 运行治理测试与 guard，确认只增加保护，不改变现有 contract。
-- 创建受控 PR，推进 guardian / merge gate / issue closeout。
+- 推送 `issue-152-gov-legacy-metadata-only-review-sync-marker` 分支。
+- 通过受控入口创建治理 PR，并把 `Issue` / `item_key` / `release` / `sprint` 与 canonical `integration_check` carrier 对齐。
+- 运行 guardian 审查与受控 merge，随后关闭 `#152` 并清理分支 / worktree。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -52,6 +53,15 @@
 - 已阅读：`docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
 - 已阅读：`docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
 - 已阅读：`tests/governance/test_pr_guardian.py`
+- 已完成最小改动文件：`tests/governance/test_pr_guardian.py`
+- 已完成最小改动文件：`docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
+- 已完成最小改动文件：`docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md`
+- 已完成最小改动文件：`docs/releases/v0.3.0.md`
+- 已完成最小改动文件：`docs/sprints/2026-S16.md`
+- `python3 -m unittest tests.governance.test_pr_guardian`
+- `python3 scripts/workflow_guard.py --mode ci`
+- `python3 scripts/docs_guard.py --mode ci`
+- `python3 scripts/open_pr.py --class governance --issue 152 --item-key GOV-0032-legacy-metadata-only-review-sync-marker --item-type GOV --release v0.3.0 --sprint 2026-S16 --title "test(governance): 锁定 legacy review sync marker 兼容回归" --dry-run`
 
 ## 未决风险
 
@@ -64,5 +74,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `c1ec5cf4f353568fa4c7e85b368d550678f4f744`
-- 说明：该 checkpoint 是 `#151` 合入后的主干基线；当前事项仅在其上补齐 legacy marker 兼容回归，不改写 guardian contract。
+- `00aecaa5809db6004b16c7dbc01884b1e109a5e7`
+- 说明：该 checkpoint 首次把 legacy `metadata-only review sync` marker 的专门回归、bootstrap decision / exec-plan 与 sprint / release 索引同步落盘；当前事项不改写 guardian contract，只补兼容保护。

--- a/docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md
+++ b/docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md
@@ -1,0 +1,68 @@
+# GOV-0032 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0032-legacy-metadata-only-review-sync-marker`
+- Issue：`#152`
+- item_type：`GOV`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+- 关联 spec：无（治理脚本事项）
+- 关联 decision：`docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
+- 关联 PR：
+- active 收口事项：`GOV-0032-legacy-metadata-only-review-sync-marker`
+
+## 目标
+
+- 为 guardian 的 legacy `metadata-only review sync` marker 兼容路径补一条专门回归。
+- 锁定历史 closeout `exec-plan` 在未迁移到新 marker 前仍能被正确识别。
+- 不改写 `#150` 已合入的 contract 边界，也不新增新的 metadata 例外。
+
+## 范围
+
+- 本次纳入：`tests/governance/test_pr_guardian.py`、本事项 `decision` / `exec-plan`、必要的 release / sprint 索引
+- 本次不纳入：`scripts/pr_guardian.py` 逻辑改写、merge gate 调整、`#150` contract 改动、历史 `exec-plan` 的批量迁移
+
+## 当前停点
+
+- `#150` 已合入主干，当前实现继续兼容 `metadata-only review sync` marker，但缺少独立回归。
+- 当前工作树已创建：`/Users/mc/code/worktrees/syvert/issue-152-gov-legacy-metadata-only-review-sync-marker`。
+- 下一步是在不改动实现逻辑的前提下补齐专门测试和 bootstrap 工件。
+
+## 下一步动作
+
+- 补一条 legacy marker 正向回归。
+- 运行治理测试与 guard，确认只增加保护，不改变现有 contract。
+- 创建受控 PR，推进 guardian / merge gate / issue closeout。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.3.0` 的 guardian 治理链补齐 legacy marker 兼容回归，避免历史 closeout marker 在后续重构中静默失效。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`#150` 合入后的治理补强项，负责锁死 legacy marker 兼容路径。
+- 阻塞：无；只需确保改动停留在测试与治理工件层。
+
+## 已验证项
+
+- `gh issue create --title "[GOV] 锁定 legacy metadata-only review sync marker 兼容回归" ...`
+- `python3 scripts/create_worktree.py --issue 152 --class governance`
+- 已创建 worktree：`/Users/mc/code/worktrees/syvert/issue-152-gov-legacy-metadata-only-review-sync-marker`
+- 已阅读：`docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
+- 已阅读：`docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
+- 已阅读：`tests/governance/test_pr_guardian.py`
+
+## 未决风险
+
+- 若只保留新 marker 的测试而不锁住 legacy marker，后续重构可能在无意中删除兼容支持。
+- 若本事项误扩展到实现逻辑，会把一个纯测试锁定项演化成新的治理语义变更。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对测试、decision、exec-plan 与 release / sprint 索引的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `c1ec5cf4f353568fa4c7e85b368d550678f4f744`
+- 说明：该 checkpoint 是 `#151` 合入后的主干基线；当前事项仅在其上补齐 legacy marker 兼容回归，不改写 guardian contract。

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -31,6 +31,7 @@
 - `CHORE-0128-fr-0009-cli-core-path-persistence-closeout`：`FR-0009` 持久化任务的 CLI/Core 同路径闭环，对应 Issue `#143`
 - `CHORE-0129-fr-0009-parent-closeout`：`FR-0009` 父事项 closeout Work Item，对应 Issue `#144`
 - `GOV-0031-guardian-live-head-binding`：修复 guardian 对 metadata-only closeout head 的自引用追逐，对应 Issue `#150`
+- `GOV-0032-legacy-metadata-only-review-sync-marker`：锁定 legacy metadata-only review sync marker 兼容回归，对应 Issue `#152`
 
 ## 相关前提
 
@@ -51,8 +52,10 @@
   - `docs/exec-plans/CHORE-0124-fr-0008-local-persistence-and-serialization.md`
   - `docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md`
   - `docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
+  - `docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md`
 - decision：
   - `docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
+  - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
 
 ## 当前 closeout 真相
 

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -22,6 +22,7 @@
 - `CHORE-0128-fr-0009-cli-core-path-persistence-closeout`：`FR-0009` 持久化任务的 CLI/Core 同路径闭环，对应 Issue `#143`
 - `CHORE-0129-fr-0009-parent-closeout`：`FR-0009` 父事项 closeout Work Item，对应 Issue `#144`
 - `GOV-0031-guardian-live-head-binding`：修复 guardian 对 metadata-only closeout head 的自引用追逐，对应 Issue `#150`
+- `GOV-0032-legacy-metadata-only-review-sync-marker`：锁定 legacy metadata-only review sync marker 兼容回归，对应 Issue `#152`
 
 ## 进入前依赖
 
@@ -38,7 +39,7 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#126`、`#127`、`#128`、`#137`、`#138`、`#139`、`#140`、`#141`、`#142`、`#143`、`#144`、`#150`
+- 相关 Issue / PR：`#126`、`#127`、`#128`、`#137`、`#138`、`#139`、`#140`、`#141`、`#142`、`#143`、`#144`、`#150`、`#152`
 
 ## 关联工件
 
@@ -52,8 +53,10 @@
   - `docs/exec-plans/CHORE-0124-fr-0008-local-persistence-and-serialization.md`
   - `docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md`
   - `docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
+  - `docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md`
 - decision：
   - `docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
+  - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
 
 ## 当前 closeout 真相
 

--- a/tests/governance/test_pr_guardian.py
+++ b/tests/governance/test_pr_guardian.py
@@ -1553,6 +1553,30 @@ class CodexReviewExecutionTests(unittest.TestCase):
 
         self.assertTrue(result)
 
+    def test_metadata_only_closeout_follow_up_accepts_legacy_review_sync_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            exec_plan_path = repo_root / "docs" / "exec-plans" / "CHORE-0125-fr-0008-parent-closeout.md"
+            exec_plan_path.parent.mkdir(parents=True, exist_ok=True)
+            exec_plan_path.write_text(
+                "当前回合仍保留 legacy metadata-only review sync 追溯说明，仅补 review / merge gate / closeout metadata。\n",
+                encoding="utf-8",
+            )
+
+            result = is_metadata_only_closeout_follow_up(
+                repo_root,
+                {
+                    "item_key": "CHORE-0125-fr-0008-parent-closeout",
+                    "exec_plan": "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                },
+                [
+                    "docs/exec-plans/CHORE-0125-fr-0008-parent-closeout.md",
+                    "docs/releases/v0.3.0.md",
+                ],
+            )
+
+        self.assertTrue(result)
+
     def test_metadata_only_closeout_follow_up_rejects_docs_only_closeout_without_marker(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)


### PR DESCRIPTION
test(governance): 锁定 legacy review sync marker 兼容回归
## 摘要

- PR Class: `governance`
- 变更目的：为 legacy `metadata-only review sync` marker 的兼容路径补一条专门回归，防止后续重构时静默丢失历史 closeout marker 支持。
- 主要改动：
  - 在 `tests/governance/test_pr_guardian.py` 新增 legacy marker 正向回归，独立证明旧 marker 仍可触发 metadata-only closeout follow-up 判定。
  - 新增 `ADR-GOV-0032` 与 `GOV-0032` active exec-plan，明确这是 `#150` 合入后的兼容补强项，而不是新的 contract 变更。
  - 更新 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 索引，纳入本事项仓内语义入口。

## Issue 摘要

- Goal: 为 guardian 的 legacy `metadata-only review sync` marker 兼容路径补一条专门回归。
- Scope: 只补治理回归、bootstrap decision / exec-plan 与 release / sprint 索引；不改写 `#150` contract。
- Required Outcomes: legacy marker 继续被测试锁定；后续重构不能在只保留新 marker 的情况下静默删除兼容支持。
- Acceptance: `tests.governance.test_pr_guardian`、`ADR-GOV-0032`、`GOV-0032` exec-plan 与 release / sprint 索引一致收口。

## Scope

- 补一条治理回归，证明 legacy marker 仍可触发 metadata-only closeout follow-up 判定
- 不改写 `#150` 已合入的 contract 边界
- 不放宽 merge gate 或新增新的 metadata 例外

## 关联事项

- Issue: #152
- item_key: `GOV-0032-legacy-metadata-only-review-sync-marker`
- item_type: `GOV`
- release: `v0.3.0`
- sprint: `2026-S16`
- Closing: Fixes #152

## 风险

- 风险级别：`high`
- 审查关注：
  - 只能补 legacy marker 的兼容测试，不能顺手放宽 metadata-only closeout 判定逻辑。
  - 不能把这条兼容路径升级成新的常驻 contract 入口或新增额外 marker。
  - 不能改动 `#150` 已冻结的 live head / checkpoint carrier 边界。

## 验证

- 已执行：
  - `python3 -m unittest tests.governance.test_pr_guardian`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/open_pr.py --class governance --issue 152 --item-key GOV-0032-legacy-metadata-only-review-sync-marker --item-type GOV --release v0.3.0 --sprint 2026-S16 --title "test(governance): 锁定 legacy review sync marker 兼容回归" --dry-run`
- 未执行：
  - guardian 审查
  - 受控 merge 后的 GitHub closeout 同步

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次对治理测试、decision / exec-plan 与 release / sprint 索引的增量修改。
