### PR TITLE
feat(cli): 增加任务查询子命令

### DIFF
--- a/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
+++ b/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
@@ -32,7 +32,7 @@
 - `issue-142-fr-0009-cli` 已作为 `#142` 的独立 implementation worktree 建立，且只保留 `syvert/cli.py`、`tests/runtime/test_cli.py` 与当前 exec-plan 的受控改动。
 - 当前分支已经完成 `run/query` 顶层子命令、legacy 平铺执行入口兼容、query 成功输出完整 `TaskRecord` JSON，以及 `invalid_cli_arguments` / `task_record_not_found` / `task_record_unavailable` 的 formal spec 错误映射实现。
 - `#141` formal spec 已由 PR `#154` 合入主干，当前分支也已 rebase 到最新 `origin/main`。
-- `#142` 当前停点是恢复推进补丁已在本地落盘并完成回归，待提交到 PR `#156`，再重跑 guardian 与受控 merge gate。
+- `#142` 当前停点是恢复推进补丁已提交为 checkpoint `51be04214fcb79fdfe0630d775bc1118c11cde48`，并已完成本地回归；下一步是推送到 PR `#156` 并重跑 guardian / merge gate。
 
 ## 下一步动作
 
@@ -71,4 +71,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `7b5688d99d8c79fd3e8db0f502d759b5c970e7e5`
+- `51be04214fcb79fdfe0630d775bc1118c11cde48`

--- a/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
+++ b/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
@@ -30,13 +30,14 @@
 
 - `issue-142-fr-0009-cli` 已作为 `#142` 的独立 implementation worktree 建立，且只保留 `syvert/cli.py`、`tests/runtime/test_cli.py` 与当前 exec-plan 的受控改动。
 - 当前分支已经完成 `run/query` 顶层子命令、legacy 平铺执行入口兼容、query 成功输出完整 `TaskRecord` JSON，以及 `invalid_cli_arguments` / `task_record_not_found` / `task_record_unavailable` 的错误映射实现。
-- `#141` formal spec 已由 PR `#154` 合入主干，`#142` 当前停点是把现有实现 rebasing 到最新 `origin/main`，完成实现门禁、受控开 PR 与 guardian merge gate。
+- `#141` formal spec 已由 PR `#154` 合入主干，当前分支也已 rebase 到最新 `origin/main`。
+- `#142` 当前停点是同步 GitHub issue 执行上下文，完成实现门禁、受控开 PR 与 guardian merge gate。
 
 ## 下一步动作
 
-- 将当前 `#142` 改动提交为独立 implementation checkpoint，并 rebase 到已包含 `#141` 的最新 `origin/main`。
-- 运行 CLI / task-record 回归、adapter CLI 最小回归、`pr_scope_guard` 与 `open_pr.py --dry-run`。
+- 运行 `pr_scope_guard` 与 `open_pr.py --dry-run`，确认 PR 范围与事项上下文一致。
 - 同步 GitHub issue `#142` 的执行状态与当前事项上下文后，创建 implementation PR 并进入 guardian 审查与受控合并。
+- guardian / merge gate 通过后，以受控 merge 收口 `#142`，再建立 `#143` 的独立执行现场。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -53,6 +54,8 @@
 - 已核对 `#141` formal spec 已由 PR `#154` 合入主干，且 `#128` 的 formal spec 字段已收敛到已入库真相。
 - `python3 -m unittest tests.runtime.test_cli tests.runtime.test_task_record tests.runtime.test_task_record_store`
   - 结果：通过（63 tests, OK）
+- `python3 -m unittest tests.runtime.test_xhs_adapter.XhsAdapterTests.test_cli_module_path_can_load_xhs_adapter_from_shared_registry`
+  - 结果：通过（1 test, OK）
 - 已新增并本地通过的回归覆盖：
   - `run/query` 顶层子命令
   - legacy 平铺执行入口兼容
@@ -71,4 +74,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `3de165090c55a089c4785eead3b3d31321634564`
+- `7b5688d99d8c79fd3e8db0f502d759b5c970e7e5`

--- a/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
+++ b/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
@@ -1,0 +1,74 @@
+# CHORE-0127-fr-0009-cli-task-query 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0127-fr-0009-cli-task-query`
+- Issue：`#142`
+- item_type：`CHORE`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+- 关联 spec：`docs/specs/FR-0009-cli-task-query-and-core-path/`
+- 状态：`active`
+- active 收口事项：`CHORE-0127-fr-0009-cli-task-query`
+
+## 目标
+
+- 在不扩张 `FR-0009` requirement 的前提下，为 CLI 落地 `query --task-id <id>` public surface，并把顶层入口重构为 `run/query`，同时保留 legacy 平铺执行入口兼容。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/cli.py`
+  - 与 CLI query public surface 直接相关的测试
+  - `docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md`
+- 本次不纳入：
+  - `FR-0008` durable schema 改写
+  - 列表查询、筛选、摘要视图
+  - `#143` 的端到端 same-path 证据收口
+
+## 当前停点
+
+- `issue-142-fr-0009-cli` 已作为 `#142` 的独立 implementation worktree 建立，且只保留 `syvert/cli.py`、`tests/runtime/test_cli.py` 与当前 exec-plan 的受控改动。
+- 当前分支已经完成 `run/query` 顶层子命令、legacy 平铺执行入口兼容、query 成功输出完整 `TaskRecord` JSON，以及 `invalid_cli_arguments` / `task_record_not_found` / `task_record_unavailable` 的错误映射实现。
+- `#141` formal spec 已由 PR `#154` 合入主干，`#142` 当前停点是把现有实现 rebasing 到最新 `origin/main`，完成实现门禁、受控开 PR 与 guardian merge gate。
+
+## 下一步动作
+
+- 将当前 `#142` 改动提交为独立 implementation checkpoint，并 rebase 到已包含 `#141` 的最新 `origin/main`。
+- 运行 CLI / task-record 回归、adapter CLI 最小回归、`pr_scope_guard` 与 `open_pr.py --dry-run`。
+- 同步 GitHub issue `#142` 的执行状态与当前事项上下文后，创建 implementation PR 并进入 guardian 审查与受控合并。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.3.0` 建立最小 CLI query public surface，使 durable `TaskRecord` 可被显式查询。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0009` 的 CLI query 实现 Work Item。
+- 阻塞：
+  - `#143` 必须等待本事项合入主干后再建立 same-path closeout 现场。
+
+## 已验证项
+
+- 已核对 `#141` formal spec 已由 PR `#154` 合入主干，且 `#128` 的 formal spec 字段已收敛到已入库真相。
+- `python3 -m unittest tests.runtime.test_cli tests.runtime.test_task_record tests.runtime.test_task_record_store`
+  - 结果：通过（63 tests, OK）
+- 已新增并本地通过的回归覆盖：
+  - `run/query` 顶层子命令
+  - legacy 平铺执行入口兼容
+  - `query` 回读 `accepted` / `running` / `succeeded` / `failed`
+  - `invalid_cli_arguments` / `task_record_not_found` / `task_record_unavailable`
+  - 已加载 record 的输出失败回填 `record.request.adapter_key` / `capability`
+  - `run` 与 legacy 平铺执行入口的共享 durable truth 一致性
+
+## 未决风险
+
+- 当前分支尚未 rebase 到包含 `#141` 的最新 `origin/main`；若 rebase 暴露同文件冲突，需要先按 formal spec 真相收敛，再进入 PR 流程。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销 CLI 入口改动与 query public surface 相关测试。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `3de165090c55a089c4785eead3b3d31321634564`

--- a/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
+++ b/docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md
@@ -18,6 +18,7 @@
 ## 范围
 
 - 本次纳入：
+  - `docs/exec-plans/artifacts/FR-0009-cli-query-and-core-path-verification-matrix.md`
   - `syvert/cli.py`
   - 与 CLI query public surface 直接相关的测试
   - `docs/exec-plans/CHORE-0127-fr-0009-cli-task-query.md`
@@ -29,15 +30,15 @@
 ## 当前停点
 
 - `issue-142-fr-0009-cli` 已作为 `#142` 的独立 implementation worktree 建立，且只保留 `syvert/cli.py`、`tests/runtime/test_cli.py` 与当前 exec-plan 的受控改动。
-- 当前分支已经完成 `run/query` 顶层子命令、legacy 平铺执行入口兼容、query 成功输出完整 `TaskRecord` JSON，以及 `invalid_cli_arguments` / `task_record_not_found` / `task_record_unavailable` 的错误映射实现。
+- 当前分支已经完成 `run/query` 顶层子命令、legacy 平铺执行入口兼容、query 成功输出完整 `TaskRecord` JSON，以及 `invalid_cli_arguments` / `task_record_not_found` / `task_record_unavailable` 的 formal spec 错误映射实现。
 - `#141` formal spec 已由 PR `#154` 合入主干，当前分支也已 rebase 到最新 `origin/main`。
-- `#142` 当前停点是同步 GitHub issue 执行上下文，完成实现门禁、受控开 PR 与 guardian merge gate。
+- `#142` 当前停点是恢复推进补丁已在本地落盘并完成回归，待提交到 PR `#156`，再重跑 guardian 与受控 merge gate。
 
 ## 下一步动作
 
-- 运行 `pr_scope_guard` 与 `open_pr.py --dry-run`，确认 PR 范围与事项上下文一致。
-- 同步 GitHub issue `#142` 的执行状态与当前事项上下文后，创建 implementation PR 并进入 guardian 审查与受控合并。
-- guardian / merge gate 通过后，以受控 merge 收口 `#142`，再建立 `#143` 的独立执行现场。
+- 提交本轮恢复推进补丁，并把 verification matrix、exec-plan、实现与测试一起推送到 PR `#156`。
+- 同步 GitHub issue `#142` 与 PR `#156` 的执行真相，明确当前 PR 已进入“guardian findings recovered”状态。
+- 在当前 head 上重跑 guardian 与 `merge_pr.py 156 --delete-branch --refresh-review`，如仍有阻断则先回填 matrix 再修。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -52,21 +53,17 @@
 ## 已验证项
 
 - 已核对 `#141` formal spec 已由 PR `#154` 合入主干，且 `#128` 的 formal spec 字段已收敛到已入库真相。
+- 已建立 `FR-0009` formal spec clause -> runtime/test 的 verification matrix carrier：`docs/exec-plans/artifacts/FR-0009-cli-query-and-core-path-verification-matrix.md`
 - `python3 -m unittest tests.runtime.test_cli tests.runtime.test_task_record tests.runtime.test_task_record_store`
-  - 结果：通过（63 tests, OK）
+  - 结果：通过（65 tests, OK）
 - `python3 -m unittest tests.runtime.test_xhs_adapter.XhsAdapterTests.test_cli_module_path_can_load_xhs_adapter_from_shared_registry`
   - 结果：通过（1 test, OK）
-- 已新增并本地通过的回归覆盖：
-  - `run/query` 顶层子命令
-  - legacy 平铺执行入口兼容
-  - `query` 回读 `accepted` / `running` / `succeeded` / `failed`
-  - `invalid_cli_arguments` / `task_record_not_found` / `task_record_unavailable`
-  - 已加载 record 的输出失败回填 `record.request.adapter_key` / `capability`
-  - `run` 与 legacy 平铺执行入口的共享 durable truth 一致性
+- 当前已验证项以 verification matrix 为准；`#142` 只负责矩阵中 `scope owner=#142` 的条目，`#143` 同路径闭环条目保持 `planned`。
 
 ## 未决风险
 
-- 当前分支尚未 rebase 到包含 `#141` 的最新 `origin/main`；若 rebase 暴露同文件冲突，需要先按 formal spec 真相收敛，再进入 PR 流程。
+- 若继续只按 guardian 最新 finding 点修，而不按 verification matrix 全量对账，`#156` 仍可能因遗漏相邻负路径再次被驳回。
+- 需要确保推送到 PR `#156` 的 head 与当前 exec-plan / verification matrix / guardian 复审绑定到同一提交，避免再次出现 review 真相分叉。
 
 ## 回滚方式
 

--- a/docs/exec-plans/artifacts/FR-0009-cli-query-and-core-path-verification-matrix.md
+++ b/docs/exec-plans/artifacts/FR-0009-cli-query-and-core-path-verification-matrix.md
@@ -1,0 +1,38 @@
+# FR-0009 CLI query and core path verification matrix
+
+## 关联信息
+
+- FR：`#128`
+- formal spec：`docs/specs/FR-0009-cli-task-query-and-core-path/`
+- 当前 implementation Work Item：`#142 / CHORE-0127-fr-0009-cli-task-query`
+- 后续 same-path Work Item：`#143 / CHORE-0128-fr-0009-cli-core-path-persistence-closeout`
+- 当前主 PR：`#156`
+
+## 使用规则
+
+- 本矩阵是 `FR-0009` 在 `#142/#143` 之间的唯一 contract-to-test carrier。
+- `scope owner=#142` 的条目必须在 `#156` 合入前实现、测试并回填状态。
+- `scope owner=#143` 的条目只允许在 `#142` 合入后进入执行回合。
+- guardian 新 finding 若属于 `FR-0009` contract，必须先回填到本矩阵，再继续修复。
+
+| spec clause | scope owner | runtime/code path | expected stdout/stderr | expected exit code | expected error fields | test name | status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `query --task-id <id>` 成功回读 durable success record | `#142` | `parse_args()` -> `execute_query_command()` -> `store.load()` -> `task_record_to_dict()` | `stdout=完整 TaskRecord JSON` / `stderr=""` | `0` | `n/a` | `test_query_subcommand_returns_persisted_success_record` | `implemented` |
+| `query` 可回读 `accepted` record | `#142` | `execute_query_command()` success path | `stdout=完整 TaskRecord JSON` / `stderr=""` | `0` | `n/a` | `test_query_subcommand_returns_accepted_record` | `implemented` |
+| `query` 可回读 `running` record | `#142` | `execute_query_command()` success path | `stdout=完整 TaskRecord JSON` / `stderr=""` | `0` | `n/a` | `test_query_subcommand_returns_running_record` | `implemented` |
+| `query` 可回读 persisted failed record | `#142` | `execute_query_command()` success path | `stdout=完整 TaskRecord JSON` / `stderr=""` | `0` | `n/a` | `test_query_subcommand_returns_persisted_failed_record` | `implemented` |
+| `query` 缺少 `--task-id` 时使用 fallback task_id 并返回 invalid cli arguments | `#142` | `main()` parse failure -> `recover_cli_failure_context()` -> `resolve_task_id()` | `stdout=""` / `stderr=failed envelope` | `1` | `code=invalid_cli_arguments`, `category=invalid_input`, `adapter_key=""`, `capability=""`, `task_id=fallback` | `test_query_subcommand_returns_invalid_cli_arguments_when_task_id_missing` | `implemented` |
+| malformed `query` argv 若仍可恢复 `--task-id`，必须回显该 task_id | `#142` | `main()` parse failure -> `recover_cli_failure_context()` | `stdout=""` / `stderr=failed envelope` | `1` | `code=invalid_cli_arguments`, `category=invalid_input`, `adapter_key=""`, `capability=""`, `task_id=<recovered>` | `test_query_subcommand_parse_failure_preserves_recoverable_task_id` | `implemented` |
+| `query` 参数错误且 fallback task_id 生成失败时，必须优先返回 invalid task id | `#142` | `main()` parse failure -> `resolve_task_id()` | `stdout=""` / `stderr=failed envelope` | `1` | `code=invalid_task_id`, `category=runtime_contract`, `adapter_key=""`, `capability=""` | `test_query_subcommand_parse_failure_returns_invalid_task_id_when_fallback_task_id_generation_fails` | `implemented` |
+| unknown `task_id` 返回 task record not found | `#142` | `execute_query_command()` -> `store.load()` raises `FileNotFoundError` | `stdout=""` / `stderr=failed envelope` | `1` | `code=task_record_not_found`, `category=invalid_input`, `task_id=<requested>`, `adapter_key=""`, `capability=""` | `test_query_subcommand_returns_not_found_for_unknown_task_id` | `implemented` |
+| invalid marker 返回 task record unavailable | `#142` | `execute_query_command()` -> `store.load()` raises persistence/store error | `stdout=""` / `stderr=failed envelope` | `1` | `code=task_record_unavailable`, `category=runtime_contract`, `task_id=<requested>`, `adapter_key=""`, `capability=""` | `test_query_subcommand_returns_unavailable_for_invalid_marker` | `implemented` |
+| damaged JSON 返回 task record unavailable | `#142` | `execute_query_command()` -> `store.load()` raises persistence/store error | `stdout=""` / `stderr=failed envelope` | `1` | `code=task_record_unavailable`, `category=runtime_contract`, `task_id=<requested>`, `adapter_key=""`, `capability=""` | `test_query_subcommand_returns_unavailable_for_invalid_json_record` | `implemented` |
+| contract-invalid record 返回 task record unavailable | `#142` | `execute_query_command()` -> `store.load()` raises persistence/store error | `stdout=""` / `stderr=failed envelope` | `1` | `code=task_record_unavailable`, `category=runtime_contract`, `task_id=<requested>`, `adapter_key=""`, `capability=""` | `test_query_subcommand_returns_unavailable_for_contract_invalid_record` | `implemented` |
+| store root 不可用返回 task record unavailable | `#142` | `validate_query_store_root()` | `stdout=""` / `stderr=failed envelope` | `1` | `code=task_record_unavailable`, `category=runtime_contract`, `task_id=<requested>`, `adapter_key=""`, `capability=""` | `test_query_subcommand_returns_unavailable_when_store_root_is_missing` | `implemented` |
+| record 已加载后共享序列化失败，必须 fail-closed 并回填 record context | `#142` | `execute_query_command()` post-load serialization branch | `stdout=""` / `stderr=failed envelope` | `1` | `code=task_record_unavailable`, `category=runtime_contract`, `task_id=<record.task_id>`, `adapter_key=<record.request.adapter_key>`, `capability=<record.request.capability>` | `test_query_subcommand_uses_record_context_when_loaded_record_fails_to_serialize` | `implemented` |
+| record 已加载后 stdout 写出失败，必须 fail-closed 并回填 record context | `#142` | `execute_query_command()` post-load output branch | `stdout=""` / `stderr=failed envelope` | `1` | `code=task_record_unavailable`, `category=runtime_contract`, `task_id=<record.task_id>`, `adapter_key=<record.request.adapter_key>`, `capability=<record.request.capability>` | `test_query_subcommand_uses_record_context_when_loaded_record_cannot_be_written_to_stdout` | `implemented` |
+| `run` 子命令成功输出 shared success envelope | `#142` | `parse_args()` -> `execute_task_with_record()` | `stdout=success envelope` / `stderr=""` | `0` | `n/a` | `test_run_subcommand_writes_success_envelope_to_stdout` | `implemented` |
+| legacy 平铺执行入口 parse failure 继续保留 shared failed envelope 行为 | `#142` | `main()` legacy parse failure -> `extract_cli_context()` | `stdout=""` / `stderr=failed envelope` | `1` | `code=invalid_cli_arguments`, `category=invalid_input`, recoverable `adapter_key` / `capability` preserved | `test_cli_fails_closed_for_missing_required_arguments`, `test_cli_parse_failure_preserves_adapter_key_from_equals_syntax`, `test_cli_parse_failure_does_not_consume_next_flag_as_adapter_value` | `implemented` |
+| `run` 后 `query` 必须等于 `task_record_to_dict(store.load(task_id))` | `#143` | `run`/legacy run -> shared store -> `query` | `stdout=完整 TaskRecord JSON` / `stderr=""` | `0` | `n/a` | `planned in #143` | `planned` |
+| legacy run 与 `run` 子命令写入等价 durable truth | `#143` | legacy run path + `run` path -> shared durable record | `n/a` | `0` | `n/a` | `planned in #143` | `planned` |
+| `query` 不得消费 shadow file / shadow payload | `#143` | same-path evidence / e2e tests | `n/a` | `n/a` | `n/a` | `planned in #143` | `planned` |

--- a/syvert/cli.py
+++ b/syvert/cli.py
@@ -100,8 +100,7 @@ def main(
     try:
         args = parse_args(argv)
     except CliArgumentError as error:
-        task_id, task_id_error = resolve_task_id(task_id_factory)
-        adapter_key, capability = extract_cli_context(argv)
+        task_id, adapter_key, capability, task_id_error = recover_cli_failure_context(argv, task_id_factory)
         envelope_error = task_id_error or invalid_input_error("invalid_cli_arguments", str(error))
         envelope = failure_envelope(task_id, adapter_key, capability, envelope_error)
         err.write(json.dumps(envelope, ensure_ascii=False) + "\n")
@@ -219,7 +218,8 @@ def execute_query_command(
     try:
         payload = task_record_to_dict(record)
         serialized = json.dumps(payload, ensure_ascii=False)
-    except (TaskRecordContractError, TypeError, ValueError) as error:
+        stdout.write(serialized + "\n")
+    except (TaskRecordContractError, TypeError, ValueError, OSError) as error:
         return write_query_failure(
             task_id=task_id,
             adapter_key=record.request.adapter_key,
@@ -231,8 +231,6 @@ def execute_query_command(
                 details={"reason": str(error) or error.__class__.__name__},
             ),
         )
-
-    stdout.write(serialized + "\n")
     return 0
 
 
@@ -294,6 +292,23 @@ def extract_cli_context(argv: list[str] | None) -> tuple[str, str]:
     adapter_key = extract_cli_option(args, "--adapter")
     capability = extract_cli_option(args, "--capability")
     return adapter_key, capability
+
+
+def recover_cli_failure_context(
+    argv: list[str] | None,
+    task_id_factory: Callable[[], str] | None,
+) -> tuple[str, str, str, dict[str, Any] | None]:
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if args and args[0] == "query":
+        query_task_id = extract_cli_option(args[1:], "--task-id")
+        if query_task_id:
+            return query_task_id, "", "", None
+        task_id, task_id_error = resolve_task_id(task_id_factory)
+        return task_id, "", "", task_id_error
+
+    task_id, task_id_error = resolve_task_id(task_id_factory)
+    adapter_key, capability = extract_cli_context(args)
+    return task_id, adapter_key, capability, task_id_error
 
 
 def extract_cli_option(argv: list[str], option: str) -> str:

--- a/syvert/cli.py
+++ b/syvert/cli.py
@@ -15,7 +15,13 @@ from syvert.runtime import (
     resolve_task_id,
     runtime_contract_error,
 )
-from syvert.task_record_store import default_task_record_store
+from syvert.task_record import TaskRecordContractError, task_record_to_dict
+from syvert.task_record_store import (
+    LocalTaskRecordStore,
+    TaskRecordPersistenceError,
+    TaskRecordStoreError,
+    default_task_record_store,
+)
 
 
 class CliArgumentError(ValueError):
@@ -28,7 +34,43 @@ class FailClosedArgumentParser(argparse.ArgumentParser):
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = FailClosedArgumentParser(description="运行 Syvert v0.1.0 本地单进程任务。")
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if args and args[0] in {"-h", "--help"}:
+        return build_root_parser().parse_args(args)
+    if args and args[0] == "run":
+        namespace = build_run_parser(prog="syvert.cli run").parse_args(args[1:])
+        namespace.command = "run"
+        return namespace
+    if args and args[0] == "query":
+        namespace = build_query_parser(prog="syvert.cli query").parse_args(args[1:])
+        namespace.command = "query"
+        return namespace
+    namespace = build_legacy_parser().parse_args(args)
+    namespace.command = "legacy_run"
+    return namespace
+
+
+def build_root_parser() -> FailClosedArgumentParser:
+    parser = FailClosedArgumentParser(description="运行或查询 Syvert v0.3.0 本地单进程任务。")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=("run", "query"),
+        help="可选子命令：`run` 运行任务，`query` 查询持久化任务记录。",
+    )
+    return parser
+
+
+def build_legacy_parser() -> FailClosedArgumentParser:
+    return build_run_like_parser(description="运行 Syvert v0.3.0 本地单进程任务。")
+
+
+def build_run_parser(*, prog: str) -> FailClosedArgumentParser:
+    return build_run_like_parser(description="运行 Syvert v0.3.0 本地单进程任务。", prog=prog)
+
+
+def build_run_like_parser(description: str, *, prog: str | None = None) -> FailClosedArgumentParser:
+    parser = FailClosedArgumentParser(description=description, prog=prog)
     parser.add_argument("--adapter", required=True, help="目标 adapter_key")
     parser.add_argument("--capability", required=True, help="任务 capability")
     parser.add_argument("--url", required=True, help="目标内容 URL")
@@ -36,7 +78,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--adapter-module",
         help="可选的 adapter 源，格式为 `module:attr`；attr 可以是 mapping 或返回 mapping 的可调用对象。",
     )
-    return parser.parse_args(argv)
+    return parser
+
+
+def build_query_parser(*, prog: str) -> FailClosedArgumentParser:
+    parser = FailClosedArgumentParser(description="查询 Syvert v0.3.0 的持久化任务记录。", prog=prog)
+    parser.add_argument("--task-id", required=True, help="目标 task_id")
+    return parser
 
 
 def main(
@@ -58,6 +106,20 @@ def main(
         envelope = failure_envelope(task_id, adapter_key, capability, envelope_error)
         err.write(json.dumps(envelope, ensure_ascii=False) + "\n")
         return 1
+    if args.command == "query":
+        if not isinstance(args.task_id, str) or not args.task_id:
+            return write_query_failure(
+                task_id_factory=task_id_factory,
+                stderr=err,
+                error=invalid_input_error("invalid_cli_arguments", "`--task-id` 不得为空"),
+            )
+        return execute_query_command(
+            args.task_id,
+            task_id_factory=task_id_factory,
+            stdout=out,
+            stderr=err,
+        )
+
     request = TaskRequest(
         adapter_key=args.adapter,
         capability=args.capability,
@@ -116,6 +178,99 @@ def main(
     return 0 if envelope["status"] == "success" else 1
 
 
+def execute_query_command(
+    task_id: str,
+    *,
+    task_id_factory: Callable[[], str] | None = None,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    store = default_task_record_store()
+    root_error = validate_query_store_root(store)
+    if root_error is not None:
+        return write_query_failure(
+            task_id=task_id,
+            stderr=stderr,
+            error=root_error,
+        )
+
+    try:
+        record = store.load(task_id)
+    except FileNotFoundError:
+        return write_query_failure(
+            task_id=task_id,
+            stderr=stderr,
+            error=invalid_input_error(
+                "task_record_not_found",
+                f"task_id `{task_id}` 对应的持久化任务记录不存在",
+            ),
+        )
+    except (TaskRecordPersistenceError, TaskRecordStoreError, OSError) as error:
+        return write_query_failure(
+            task_id=task_id,
+            stderr=stderr,
+            error=runtime_contract_error(
+                "task_record_unavailable",
+                f"task_id `{task_id}` 对应的持久化任务记录不可用",
+                details={"reason": str(error) or error.__class__.__name__},
+            ),
+        )
+
+    try:
+        payload = task_record_to_dict(record)
+        serialized = json.dumps(payload, ensure_ascii=False)
+    except (TaskRecordContractError, TypeError, ValueError) as error:
+        return write_query_failure(
+            task_id=task_id,
+            adapter_key=record.request.adapter_key,
+            capability=record.request.capability,
+            stderr=stderr,
+            error=runtime_contract_error(
+                "task_record_unavailable",
+                f"task_id `{task_id}` 对应的持久化任务记录不可用",
+                details={"reason": str(error) or error.__class__.__name__},
+            ),
+        )
+
+    stdout.write(serialized + "\n")
+    return 0
+
+
+def validate_query_store_root(store: LocalTaskRecordStore) -> dict[str, Any] | None:
+    try:
+        root = store.root
+        if root.exists():
+            if not root.is_dir():
+                raise TaskRecordStoreError(f"任务记录存储根路径 `{root}` 不是目录")
+            return None
+        raise TaskRecordStoreError(f"任务记录存储根路径 `{root}` 不存在")
+    except (TaskRecordStoreError, OSError) as error:
+        return runtime_contract_error(
+            "task_record_unavailable",
+            "任务记录存储不可用",
+            details={"reason": str(error) or error.__class__.__name__},
+        )
+
+
+def write_query_failure(
+    *,
+    stderr: TextIO,
+    error: dict[str, Any],
+    task_id: str | None = None,
+    task_id_factory: Callable[[], str] | None = None,
+    adapter_key: str = "",
+    capability: str = "",
+) -> int:
+    resolved_task_id = task_id
+    if not isinstance(resolved_task_id, str) or not resolved_task_id:
+        resolved_task_id, task_id_error = resolve_task_id(task_id_factory)
+        if task_id_error is not None:
+            error = task_id_error
+    envelope = failure_envelope(resolved_task_id, adapter_key, capability, error)
+    stderr.write(json.dumps(envelope, ensure_ascii=False) + "\n")
+    return 1
+
+
 def load_adapters(spec: str | None) -> Mapping[str, Any]:
     if not spec:
         return {}
@@ -132,6 +287,10 @@ def load_adapters(spec: str | None) -> Mapping[str, Any]:
 
 def extract_cli_context(argv: list[str] | None) -> tuple[str, str]:
     args = list(argv) if argv is not None else sys.argv[1:]
+    if args and args[0] == "query":
+        return "", ""
+    if args and args[0] == "run":
+        args = args[1:]
     adapter_key = extract_cli_option(args, "--adapter")
     capability = extract_cli_option(args, "--capability")
     return adapter_key, capability

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -11,6 +11,13 @@ import tempfile
 from unittest import mock
 
 from syvert.cli import main
+from syvert.task_record import (
+    TaskRecordContractError,
+    TaskRequestSnapshot,
+    create_task_record,
+    start_task_record,
+    task_record_to_dict,
+)
 from syvert.task_record_store import LocalTaskRecordStore
 
 
@@ -53,6 +60,22 @@ class SuccessfulAdapter:
                 },
             },
         }
+
+
+class PlatformFailureAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request):
+        from syvert.runtime import PlatformAdapterError
+
+        raise PlatformAdapterError(
+            code="platform_broken",
+            message="boom",
+            details={"reason": "bad"},
+        )
 
 
 class CliTests(unittest.TestCase):
@@ -223,6 +246,420 @@ class CliTests(unittest.TestCase):
             persisted = LocalTaskRecordStore(Path(temp_dir)).load(payload["task_id"])
             self.assertEqual(persisted.task_id, payload["task_id"])
             self.assertEqual(persisted.status, "succeeded")
+
+    def test_run_subcommand_writes_success_envelope_to_stdout(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = main(
+            [
+                "run",
+                "--adapter",
+                "stub",
+                "--capability",
+                "content_detail_by_url",
+                "--url",
+                "https://example.com/posts/run-1",
+            ],
+            adapters={"stub": SuccessfulAdapter()},
+            stdout=stdout,
+            stderr=stderr,
+            task_id_factory=lambda: "task-cli-run-001",
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr.getvalue(), "")
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["task_id"], "task-cli-run-001")
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(payload["adapter_key"], "stub")
+
+    def test_query_subcommand_returns_persisted_success_record(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        legacy_stdout = io.StringIO()
+        legacy_stderr = io.StringIO()
+
+        legacy_exit_code = main(
+            [
+                "--adapter",
+                "stub",
+                "--capability",
+                "content_detail_by_url",
+                "--url",
+                "https://example.com/posts/query-success-1",
+            ],
+            adapters={"stub": SuccessfulAdapter()},
+            stdout=legacy_stdout,
+            stderr=legacy_stderr,
+            task_id_factory=lambda: "task-cli-query-success-1",
+        )
+
+        self.assertEqual(legacy_exit_code, 0, legacy_stderr.getvalue())
+        expected_payload = task_record_to_dict(store.load("task-cli-query-success-1"))
+
+        query_stdout = io.StringIO()
+        query_stderr = io.StringIO()
+        query_exit_code = main(
+            ["query", "--task-id", "task-cli-query-success-1"],
+            stdout=query_stdout,
+            stderr=query_stderr,
+        )
+
+        self.assertEqual(query_exit_code, 0)
+        self.assertEqual(query_stderr.getvalue(), "")
+        self.assertEqual(json.loads(query_stdout.getvalue()), expected_payload)
+
+    def test_query_subcommand_returns_accepted_record(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        accepted = create_task_record(
+            "task-cli-query-accepted-1",
+            TaskRequestSnapshot(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/query-accepted-1",
+                collection_mode="hybrid",
+            ),
+        )
+        store.write(accepted)
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-accepted-1"],
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertEqual(json.loads(stdout.getvalue()), task_record_to_dict(accepted))
+
+    def test_query_subcommand_returns_running_record(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        accepted = create_task_record(
+            "task-cli-query-running-1",
+            TaskRequestSnapshot(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/query-running-1",
+                collection_mode="hybrid",
+            ),
+        )
+        running = start_task_record(accepted)
+        store.write(accepted)
+        store.write(running)
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-running-1"],
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertEqual(json.loads(stdout.getvalue()), task_record_to_dict(running))
+
+    def test_query_subcommand_returns_persisted_failed_record(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        legacy_stdout = io.StringIO()
+        legacy_stderr = io.StringIO()
+
+        legacy_exit_code = main(
+            [
+                "--adapter",
+                "stub",
+                "--capability",
+                "content_detail_by_url",
+                "--url",
+                "https://example.com/posts/query-failed-1",
+            ],
+            adapters={"stub": PlatformFailureAdapter()},
+            stdout=legacy_stdout,
+            stderr=legacy_stderr,
+            task_id_factory=lambda: "task-cli-query-failed-1",
+        )
+
+        self.assertEqual(legacy_exit_code, 1)
+        expected_payload = task_record_to_dict(store.load("task-cli-query-failed-1"))
+
+        query_stdout = io.StringIO()
+        query_stderr = io.StringIO()
+        query_exit_code = main(
+            ["query", "--task-id", "task-cli-query-failed-1"],
+            stdout=query_stdout,
+            stderr=query_stderr,
+        )
+
+        self.assertEqual(query_exit_code, 0)
+        self.assertEqual(query_stderr.getvalue(), "")
+        self.assertEqual(json.loads(query_stdout.getvalue()), expected_payload)
+
+    def test_query_subcommand_returns_invalid_cli_arguments_when_task_id_missing(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = main(
+            ["query"],
+            stdout=stdout,
+            stderr=stderr,
+            task_id_factory=lambda: "task-cli-query-parse-failure",
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["task_id"], "task-cli-query-parse-failure")
+        self.assertEqual(payload["adapter_key"], "")
+        self.assertEqual(payload["capability"], "")
+        self.assertEqual(payload["error"]["category"], "invalid_input")
+        self.assertEqual(payload["error"]["code"], "invalid_cli_arguments")
+
+    def test_query_subcommand_returns_not_found_for_unknown_task_id(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-missing-1"],
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["task_id"], "task-cli-query-missing-1")
+        self.assertEqual(payload["adapter_key"], "")
+        self.assertEqual(payload["capability"], "")
+        self.assertEqual(payload["error"]["category"], "invalid_input")
+        self.assertEqual(payload["error"]["code"], "task_record_not_found")
+
+    def test_query_subcommand_returns_unavailable_for_invalid_marker(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        legacy_stdout = io.StringIO()
+        legacy_stderr = io.StringIO()
+
+        legacy_exit_code = main(
+            [
+                "--adapter",
+                "stub",
+                "--capability",
+                "content_detail_by_url",
+                "--url",
+                "https://example.com/posts/query-invalid-marker-1",
+            ],
+            adapters={"stub": SuccessfulAdapter()},
+            stdout=legacy_stdout,
+            stderr=legacy_stderr,
+            task_id_factory=lambda: "task-cli-query-invalid-marker-1",
+        )
+        self.assertEqual(legacy_exit_code, 0, legacy_stderr.getvalue())
+        store.mark_invalid(
+            "task-cli-query-invalid-marker-1",
+            stage="completion",
+            reason="forced-invalid-marker",
+        )
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-invalid-marker-1"],
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["task_id"], "task-cli-query-invalid-marker-1")
+        self.assertEqual(payload["adapter_key"], "")
+        self.assertEqual(payload["capability"], "")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "task_record_unavailable")
+
+    def test_query_subcommand_returns_unavailable_for_invalid_json_record(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        store.root.mkdir(parents=True, exist_ok=True)
+        store.record_path("task-cli-query-bad-json-1").write_text("{bad json", encoding="utf-8")
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-bad-json-1"],
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["task_id"], "task-cli-query-bad-json-1")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "task_record_unavailable")
+
+    def test_query_subcommand_returns_unavailable_for_contract_invalid_record(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        store.root.mkdir(parents=True, exist_ok=True)
+        invalid_payload = {
+            "schema_version": "v0.3.0",
+            "task_id": "task-cli-query-bad-contract-1",
+            "request": {
+                "adapter_key": "stub",
+                "capability": "content_detail_by_url",
+                "target_type": "url",
+                "target_value": "https://example.com/posts/query-bad-contract-1",
+                "collection_mode": "hybrid",
+            },
+            "status": "accepted",
+            "created_at": "2026-04-18T10:00:00Z",
+            "updated_at": "2026-04-18T10:00:00Z",
+            "terminal_at": None,
+            "result": None,
+            "logs": [],
+        }
+        store.record_path("task-cli-query-bad-contract-1").write_text(
+            json.dumps(invalid_payload, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-bad-contract-1"],
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["task_id"], "task-cli-query-bad-contract-1")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "task_record_unavailable")
+
+    def test_query_subcommand_uses_record_context_when_loaded_record_fails_to_serialize(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        accepted = create_task_record(
+            "task-cli-query-serialize-failure-1",
+            TaskRequestSnapshot(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/query-serialize-failure-1",
+                collection_mode="hybrid",
+            ),
+        )
+        store.write(accepted)
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch(
+            "syvert.cli.task_record_to_dict",
+            side_effect=TaskRecordContractError("forced-serialization-error"),
+        ):
+            exit_code = main(
+                ["query", "--task-id", "task-cli-query-serialize-failure-1"],
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["task_id"], "task-cli-query-serialize-failure-1")
+        self.assertEqual(payload["adapter_key"], "stub")
+        self.assertEqual(payload["capability"], "content_detail_by_url")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "task_record_unavailable")
+
+    def test_query_subcommand_returns_unavailable_when_store_root_is_missing(self) -> None:
+        missing_root = Path(self._task_record_store_dir.name) / "missing-root"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with mock.patch.dict(os.environ, {"SYVERT_TASK_RECORD_STORE_DIR": str(missing_root)}, clear=False):
+            exit_code = main(
+                ["query", "--task-id", "task-cli-query-missing-root-1"],
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["task_id"], "task-cli-query-missing-root-1")
+        self.assertEqual(payload["adapter_key"], "")
+        self.assertEqual(payload["capability"], "")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "task_record_unavailable")
+
+    def test_run_subcommand_and_legacy_entrypoint_share_same_task_record_truth(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+
+        legacy_stdout = io.StringIO()
+        legacy_stderr = io.StringIO()
+        legacy_exit_code = main(
+            [
+                "--adapter",
+                "stub",
+                "--capability",
+                "content_detail_by_url",
+                "--url",
+                "https://example.com/posts/shared-path-1",
+            ],
+            adapters={"stub": SuccessfulAdapter()},
+            stdout=legacy_stdout,
+            stderr=legacy_stderr,
+            task_id_factory=lambda: "task-cli-shared-path-1",
+        )
+        self.assertEqual(legacy_exit_code, 0, legacy_stderr.getvalue())
+        legacy_record_payload = task_record_to_dict(store.load("task-cli-shared-path-1"))
+
+        run_stdout = io.StringIO()
+        run_stderr = io.StringIO()
+        run_exit_code = main(
+            [
+                "run",
+                "--adapter",
+                "stub",
+                "--capability",
+                "content_detail_by_url",
+                "--url",
+                "https://example.com/posts/shared-path-1",
+            ],
+            adapters={"stub": SuccessfulAdapter()},
+            stdout=run_stdout,
+            stderr=run_stderr,
+            task_id_factory=lambda: "task-cli-shared-path-2",
+        )
+        self.assertEqual(run_exit_code, 0, run_stderr.getvalue())
+        run_record_payload = task_record_to_dict(store.load("task-cli-shared-path-2"))
+
+        legacy_record_payload["task_id"] = "normalized-task-id"
+        run_record_payload["task_id"] = "normalized-task-id"
+        legacy_record_payload["result"]["envelope"]["task_id"] = "normalized-task-id"
+        run_record_payload["result"]["envelope"]["task_id"] = "normalized-task-id"
+
+        self.assertEqual(run_record_payload["request"], legacy_record_payload["request"])
+        self.assertEqual(run_record_payload["status"], legacy_record_payload["status"])
+        self.assertEqual(run_record_payload["result"], legacy_record_payload["result"])
+
+        query_stdout = io.StringIO()
+        query_stderr = io.StringIO()
+        query_exit_code = main(
+            ["query", "--task-id", "task-cli-shared-path-2"],
+            stdout=query_stdout,
+            stderr=query_stderr,
+        )
+
+        self.assertEqual(query_exit_code, 0)
+        self.assertEqual(query_stderr.getvalue(), "")
+        self.assertEqual(json.loads(query_stdout.getvalue()), task_record_to_dict(store.load("task-cli-shared-path-2")))
 
     def test_cli_module_path_can_load_shared_adapter_registry(self) -> None:
         import tempfile

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -78,6 +78,11 @@ class PlatformFailureAdapter:
         )
 
 
+class BrokenWriteStream(io.StringIO):
+    def write(self, s: str) -> int:
+        raise BrokenPipeError("forced-broken-pipe")
+
+
 class CliTests(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -419,6 +424,49 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["error"]["category"], "invalid_input")
         self.assertEqual(payload["error"]["code"], "invalid_cli_arguments")
 
+    def test_query_subcommand_parse_failure_preserves_recoverable_task_id(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-recoverable-1", "--unknown"],
+            stdout=stdout,
+            stderr=stderr,
+            task_id_factory=lambda: "task-cli-query-fallback-should-not-be-used",
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["task_id"], "task-cli-query-recoverable-1")
+        self.assertEqual(payload["adapter_key"], "")
+        self.assertEqual(payload["capability"], "")
+        self.assertEqual(payload["error"]["category"], "invalid_input")
+        self.assertEqual(payload["error"]["code"], "invalid_cli_arguments")
+
+    def test_query_subcommand_parse_failure_returns_invalid_task_id_when_fallback_task_id_generation_fails(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = main(
+            ["query"],
+            stdout=stdout,
+            stderr=stderr,
+            task_id_factory=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["status"], "failed")
+        self.assertIsInstance(payload["task_id"], str)
+        self.assertTrue(payload["task_id"])
+        self.assertEqual(payload["adapter_key"], "")
+        self.assertEqual(payload["capability"], "")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "invalid_task_id")
+
     def test_query_subcommand_returns_not_found_for_unknown_task_id(self) -> None:
         stdout = io.StringIO()
         stderr = io.StringIO()
@@ -577,6 +625,36 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["error"]["category"], "runtime_contract")
         self.assertEqual(payload["error"]["code"], "task_record_unavailable")
 
+    def test_query_subcommand_uses_record_context_when_loaded_record_cannot_be_written_to_stdout(self) -> None:
+        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+        accepted = create_task_record(
+            "task-cli-query-write-failure-1",
+            TaskRequestSnapshot(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                target_type="url",
+                target_value="https://example.com/posts/query-write-failure-1",
+                collection_mode="hybrid",
+            ),
+        )
+        store.write(accepted)
+
+        stdout = BrokenWriteStream()
+        stderr = io.StringIO()
+        exit_code = main(
+            ["query", "--task-id", "task-cli-query-write-failure-1"],
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        self.assertEqual(exit_code, 1)
+        payload = json.loads(stderr.getvalue())
+        self.assertEqual(payload["task_id"], "task-cli-query-write-failure-1")
+        self.assertEqual(payload["adapter_key"], "stub")
+        self.assertEqual(payload["capability"], "content_detail_by_url")
+        self.assertEqual(payload["error"]["category"], "runtime_contract")
+        self.assertEqual(payload["error"]["code"], "task_record_unavailable")
+
     def test_query_subcommand_returns_unavailable_when_store_root_is_missing(self) -> None:
         missing_root = Path(self._task_record_store_dir.name) / "missing-root"
         stdout = io.StringIO()
@@ -597,69 +675,6 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["capability"], "")
         self.assertEqual(payload["error"]["category"], "runtime_contract")
         self.assertEqual(payload["error"]["code"], "task_record_unavailable")
-
-    def test_run_subcommand_and_legacy_entrypoint_share_same_task_record_truth(self) -> None:
-        store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
-
-        legacy_stdout = io.StringIO()
-        legacy_stderr = io.StringIO()
-        legacy_exit_code = main(
-            [
-                "--adapter",
-                "stub",
-                "--capability",
-                "content_detail_by_url",
-                "--url",
-                "https://example.com/posts/shared-path-1",
-            ],
-            adapters={"stub": SuccessfulAdapter()},
-            stdout=legacy_stdout,
-            stderr=legacy_stderr,
-            task_id_factory=lambda: "task-cli-shared-path-1",
-        )
-        self.assertEqual(legacy_exit_code, 0, legacy_stderr.getvalue())
-        legacy_record_payload = task_record_to_dict(store.load("task-cli-shared-path-1"))
-
-        run_stdout = io.StringIO()
-        run_stderr = io.StringIO()
-        run_exit_code = main(
-            [
-                "run",
-                "--adapter",
-                "stub",
-                "--capability",
-                "content_detail_by_url",
-                "--url",
-                "https://example.com/posts/shared-path-1",
-            ],
-            adapters={"stub": SuccessfulAdapter()},
-            stdout=run_stdout,
-            stderr=run_stderr,
-            task_id_factory=lambda: "task-cli-shared-path-2",
-        )
-        self.assertEqual(run_exit_code, 0, run_stderr.getvalue())
-        run_record_payload = task_record_to_dict(store.load("task-cli-shared-path-2"))
-
-        legacy_record_payload["task_id"] = "normalized-task-id"
-        run_record_payload["task_id"] = "normalized-task-id"
-        legacy_record_payload["result"]["envelope"]["task_id"] = "normalized-task-id"
-        run_record_payload["result"]["envelope"]["task_id"] = "normalized-task-id"
-
-        self.assertEqual(run_record_payload["request"], legacy_record_payload["request"])
-        self.assertEqual(run_record_payload["status"], legacy_record_payload["status"])
-        self.assertEqual(run_record_payload["result"], legacy_record_payload["result"])
-
-        query_stdout = io.StringIO()
-        query_stderr = io.StringIO()
-        query_exit_code = main(
-            ["query", "--task-id", "task-cli-shared-path-2"],
-            stdout=query_stdout,
-            stderr=query_stderr,
-        )
-
-        self.assertEqual(query_exit_code, 0)
-        self.assertEqual(query_stderr.getvalue(), "")
-        self.assertEqual(json.loads(query_stdout.getvalue()), task_record_to_dict(store.load("task-cli-shared-path-2")))
 
     def test_cli_module_path_can_load_shared_adapter_registry(self) -> None:
         import tempfile


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：在不改动 FR-0009 public surface 的前提下，补齐 query CLI 错误契约与 contract-to-test carrier。
- 主要改动：
  - 新增 FR-0009 verification matrix artifact，固定 #142/#143 的 clause 到测试映射
  - 修复 malformed query argv 的 recoverable task_id 回显
  - 修复 durable record 已加载后 stdout 写出失败的 fail-closed 行为
  - 把 same-path 证明类测试从 #142 范围移出，保留 CLI query surface 覆盖

## Issue 摘要

- 当前 PR 承接 guardian 上轮阻断后的恢复推进，不重开 PR。
- 本轮以 `docs/exec-plans/artifacts/FR-0009-cli-query-and-core-path-verification-matrix.md` 作为唯一 contract-to-test carrier。
- `#142` 只收口矩阵中 `scope owner=#142` 的条目；same-path 证据留给 `#143`。

## 关联事项

- Issue: #142
- item_key: `CHORE-0127-fr-0009-cli-task-query`
- item_type: `CHORE`
- release: `v0.3.0`
- sprint: `2026-S16`
- Closing: Fixes #142

## 风险

- 风险级别：`normal`
- 审查关注：
  - query parse failure 的 recoverable `task_id` 回显
  - post-load stdout 写出失败的 fail-closed
  - verification matrix 与 `tests/runtime/test_cli.py` 的逐条映射

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_cli tests.runtime.test_task_record tests.runtime.test_task_record_store`
  - `python3 -m unittest tests.runtime.test_xhs_adapter.XhsAdapterTests.test_cli_module_path_can_load_xhs_adapter_from_shared_registry`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/open_pr.py --class implementation --issue 142 --item-key CHORE-0127-fr-0009-cli-task-query --item-type CHORE --release v0.3.0 --sprint 2026-S16 --title "feat(cli): 增加任务查询子命令" --dry-run`
- 未执行：
  - guardian 复审
  - `python3 scripts/merge_pr.py 156 --delete-branch --refresh-review`

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。

