### PR TITLE
docs(release): 收口 v0.3.0 phase 与发布

### DIFF
--- a/docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -1,0 +1,34 @@
+# ADR-GOV-0033 Close out v0.3.0 phase and publish anchors in a single governed round
+
+## 关联信息
+
+- Issue：`#159`
+- item_key：`GOV-0033-v0-3-0-phase-and-release-closeout`
+- item_type：`GOV`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+
+## 背景
+
+`v0.3.0` 的功能、formal spec、implementation 与 parent closeout 已经全部合入主干，`#127/#128` 及其下属 Work Item 也都已关闭。
+
+但当前仓内与 GitHub 仍停留在“版本 closeout 已完成、发布锚点尚未建立”的中间态：
+
+- `#126` Phase 仍未关闭，正文与 Project 状态仍停留在开始前口径
+- `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 仍保留 closeout 过渡叙述
+- 仓库还没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`
+
+如果继续把这些动作分散处理，会再次制造“主干真相已完成，但 Phase / 发布锚点仍滞后”的分叉。
+
+## 决策
+
+- 使用单一治理 Work Item `#159 / GOV-0033-v0-3-0-phase-and-release-closeout` 承接 `v0.3.0` 的最后一段 phase / release 收口。
+- 当前回合只允许修改 release / sprint 索引与本事项 decision / exec-plan，不重新打开 `FR-0008`、`FR-0009` 或任何 runtime / formal spec 语义。
+- 受控 docs PR 合入后，立即在主干上创建 `v0.3.0` tag 与 GitHub Release，并把 `#126` / `#159` 的正文、Project 状态与关闭语义对齐。
+- 发布锚点必须后置于 closeout PR 合入，避免 tag 或 GitHub Release 指向非主干事实。
+
+## 影响
+
+- `v0.3.0` 将从“功能与 closeout 已完成”推进到“Phase、索引、tag 与 GitHub Release 全部一致”的正式发布态。
+- `#126` 不再继续停留在 `OPEN` / `Todo` 的滞后状态。
+- `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 会切换为完成态索引，不再误导后续执行轮次把 `v0.3.0` 视为仍在收口。

--- a/docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -23,12 +23,14 @@
 ## 决策
 
 - 使用单一治理 Work Item `#159 / GOV-0033-v0-3-0-phase-and-release-closeout` 承接 `v0.3.0` 的最后一段 phase / release 收口。
-- 当前回合只允许修改 release / sprint 索引与本事项 decision / exec-plan，不重新打开 `FR-0008`、`FR-0009` 或任何 runtime / formal spec 语义。
-- 受控 docs PR 合入后，立即在主干上创建 `v0.3.0` tag 与 GitHub Release，并把 `#126` / `#159` 的正文、Project 状态与关闭语义对齐。
+- 本事项采用两个串行阶段，但仍保持同一个 Work Item：
+  - 阶段 A：通过受控 docs PR 收口仓内 carrier，包括 release / sprint 索引、本事项 decision 与 active exec-plan。
+  - 阶段 B：在阶段 A 合入主干后，立即创建 `v0.3.0` tag 与 GitHub Release，并把 `#126` / `#159` 的正文、Project 状态与关闭语义对齐。
+- 当前 PR 只允许修改 release / sprint 索引与本事项 decision / exec-plan，不重新打开 `FR-0008`、`FR-0009` 或任何 runtime / formal spec 语义。
 - 发布锚点必须后置于 closeout PR 合入，避免 tag 或 GitHub Release 指向非主干事实。
 
 ## 影响
 
-- `v0.3.0` 将从“功能与 closeout 已完成”推进到“Phase、索引、tag 与 GitHub Release 全部一致”的正式发布态。
+- `v0.3.0` 将沿同一 Work Item 从“功能与 closeout 已完成”推进到“仓内 carrier 完成”再推进到“Phase、索引、tag 与 GitHub Release 全部一致”的正式发布态。
 - `#126` 不再继续停留在 `OPEN` / `Todo` 的滞后状态。
 - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 会切换为完成态索引，不再误导后续执行轮次把 `v0.3.0` 视为仍在收口。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -137,5 +137,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `fd7f2dc9d9995c0e005752e18dd2d14e826e62d6`
-- 说明：该 checkpoint 首次把 `ADR-GOV-0033`、两阶段 Work Item 决策、`v0.3.0` / `2026-S16` 完成态索引与阶段 A/阶段 B 分界收口到同一条仓内真相。当前受审 head 若继续存在后续 commit，只允许用于 review / merge gate / GitHub carrier 同步，不再改写该 checkpoint 语义。
+- `73542aef650ee76b2573c4ea3315b52d4b6f1676`
+- 说明：该 checkpoint 把 `ADR-GOV-0033` 的两阶段 Work Item 决策、`v0.3.0` / `2026-S16` 的阶段 A 收口真相，以及 `GOV-0033` 继续承接阶段 B 发布动作的边界固定到同一条仓内语义链。当前受审 head 若继续存在后续 commit，只允许用于 review / merge gate / GitHub carrier 同步，不再改写该 checkpoint 语义。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -1,0 +1,133 @@
+# GOV-0033-v0.3.0-phase-and-release-closeout 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0033-v0-3-0-phase-and-release-closeout`
+- Issue：`#159`
+- item_type：`GOV`
+- release：`v0.3.0`
+- sprint：`2026-S16`
+- 关联 spec：无（发布/治理收口事项）
+- 关联 decision：`docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
+- 关联 PR：
+- 状态：`active`
+- active 收口事项：`GOV-0033-v0-3-0-phase-and-release-closeout`
+
+## 目标
+
+- 在不引入新 runtime、formal spec 或测试语义的前提下，通过合法 Work Item `#159` 完成 `v0.3.0` 的 phase / release 发布收口。
+- 把 `#126` Phase、`docs/releases/v0.3.0.md`、`docs/sprints/2026-S16.md`、Git tag、GitHub Release 与 GitHub issue / project 真相收口到同一条版本 closeout 证据链。
+
+## 范围
+
+- 本次纳入：
+  - `docs/exec-plans/CHORE-0130-v0-3-0-phase-and-release-closeout.md`
+  - `docs/releases/v0.3.0.md`
+  - `docs/sprints/2026-S16.md`
+  - GitHub `#126` / `#159` issue 正文、Project 状态与关闭语义对齐
+  - Git tag `v0.3.0`
+  - GitHub Release `v0.3.0`
+- 本次不纳入：
+  - 任何新的 runtime / adapter / test 实现
+  - `FR-0008` / `FR-0009` formal spec 语义改写
+  - `v0.4.0` 范围、资源系统或跨版本治理重构
+
+## 当前停点
+
+- `origin/main@eebeb9818e296736cadb43904ffa9072c27163ae` 已包含 `v0.3.0` 所需的全部功能与 closeout 前提：PR `#145/#147/#148/#149/#154/#156/#157/#158`。
+- `#127/#128` 与其下属 Work Item 均已关闭，`v0.3.0` 的功能/contract 目标已经完成。
+- 仓内仍残留“当前 active closeout 入口”为 `#144` 的过渡叙述；`docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 尚未切换到最终完成态。
+- GitHub 侧仍残留 Phase `#126` 未关闭，正文仍写 `冲刺：待 project 排期`，Project 状态仍为 `Todo`。
+- 仓外发布载体仍未建立：当前仓库没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`。
+- `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`。
+
+## 下一步动作
+
+- 落盘 `CHORE-0130` exec-plan，并把 release / sprint 索引改成最终完成态，不再保留 active closeout 入口。
+- 在当前 head 上完成 docs / workflow / governance 门禁与受控 PR 创建，合入主干。
+- 合并后同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
+- 随后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.3.0` 完成“从功能收口到正式发布”的最后一段链路，使阶段、索引、tag 与 GitHub Release 进入一致完成态。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`v0.3.0` 的 phase / release 发布 closeout Work Item。
+- 阻塞：
+  - `#126` 不能直接作为执行入口，必须由 `#159` 承接 docs / release 发布动作。
+  - Git tag 与 GitHub Release 只能在 closeout PR 合入主干后创建，避免 tag 指向未合入 head。
+
+## 已验证项
+
+- `gh issue view 126 --json state,title,url,body,projectItems`
+  - 结果：`#126` 为 `OPEN`，Project 状态为 `Todo`，正文仍停留在阶段进行前口径。
+- `gh issue view 159 --json state,title,url,body`
+  - 结果：`#159` 为 `OPEN`，已建立为承接 `v0.3.0` phase / release closeout 的合法治理 Work Item。
+- `python3 scripts/create_worktree.py --issue 159 --class docs`
+  - 结果：已创建独立 worktree `/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`
+- `gh issue view 127 --json state`
+  - 结果：`#127` 为 `CLOSED`。
+- `gh issue view 128 --json state`
+  - 结果：`#128` 为 `CLOSED`。
+- `gh release list`
+  - 结果：当前仅有 `v0.1.0`、`v0.2.0`，尚无 `v0.3.0`。
+- `git tag --list`
+  - 结果：当前仅有 `v0.1.0`、`v0.2.0`，尚无 `v0.3.0`。
+- `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/governance_gate.py --mode ci --base-sha $(git merge-base origin/main HEAD) --head-sha $(git rev-parse HEAD) --head-ref issue-159-chore-v0-3-0-phase`
+  - 结果：通过
+
+## closeout 证据
+
+- 功能完成证据：
+  - `FR-0008` formal spec / implementation / parent closeout 已由 PR `#145/#147/#148/#149` 合入主干
+  - `FR-0009` formal spec / implementation / parent closeout 已由 PR `#154/#156/#157/#158` 合入主干
+- release / sprint 证据：
+  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 将在本回合改为“版本完成态”索引，不再保留 active closeout 入口
+- 发布证据：
+  - tag：`v0.3.0`
+  - GitHub Release：`v0.3.0`
+- GitHub closeout 证据：
+  - `#126` Phase 正文 / Project 状态 /关闭语义与 `#159` 完成事实对齐
+
+## GitHub closeout 工件
+
+- `#159` 正文修正目标：
+  - 执行状态改为 `已完成（PR #... 已 MERGED）`
+  - 回填 merge commit
+  - 明确本事项负责 phase / release closeout、tag 与 GitHub Release 发布
+- `#159` Project 状态目标：
+  - 执行期间如进入 Project，则保持 `In Progress`
+  - 完成后切到 `Done`
+- `#126` 正文修正目标：
+  - 明确 `#127/#128` 及其子 Work Item 已全部完成
+  - 明确 `v0.3.0` release / sprint / exec-plan / tag / GitHub Release 真相一致
+  - 冲刺字段不再保留 `待 project 排期`
+- `#126` Project 状态目标：
+  - 在 closeout 完成前保持当前状态
+  - `#159` 合入、tag / release 发布完成后切到 `Done`
+
+## 未决风险
+
+- 若 tag / GitHub Release 早于 closeout PR 合入，会造成发布锚点指向非主干事实。
+- 若 release / sprint 索引仍保留 active closeout 入口，会把已完成版本错误表述为仍在收口。
+- 若只创建 tag 而不更新 `#126` Phase，GitHub 上位阶段真相仍会滞后于已发布状态。
+
+## 回滚方式
+
+- 仓内回滚：如需回滚，使用独立 revert PR 撤销本事项对 `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md`、`docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 的增量修改。
+- 仓外回滚：
+  - 若 closeout PR 未合入，恢复 `#126/#159` 正文并停止发布动作
+  - 若 tag / GitHub Release 已创建但发现主干事实有误，先修正主干与 GitHub 事实，再按独立回合决定是否删除 / 重建发布锚点
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- 前置完成基线：`eebeb9818e296736cadb43904ffa9072c27163ae`
+- 说明：该基线已经包含 `v0.3.0` 所需的全部功能与父事项 closeout 真相；本回合只负责发布态索引、Phase closeout 与发布锚点收口。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -137,5 +137,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `201ddef800eff91d57dff4c338237434da2b2045`
-- 说明：该 checkpoint 首次把 `ADR-GOV-0033`、两阶段 Work Item 决策、`v0.3.0` / `2026-S16` 完成态索引与阶段 A/阶段 B 分界收口到同一条仓内真相。当前 PR head 上的后续变更只用于 review / merge gate / GitHub carrier 同步，属于 `metadata-only closeout follow-up`。
+- `fd7f2dc9d9995c0e005752e18dd2d14e826e62d6`
+- 说明：该 checkpoint 首次把 `ADR-GOV-0033`、两阶段 Work Item 决策、`v0.3.0` / `2026-S16` 完成态索引与阶段 A/阶段 B 分界收口到同一条仓内真相。当前受审 head 若继续存在后续 commit，只允许用于 review / merge gate / GitHub carrier 同步，不再改写该 checkpoint 语义。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -128,7 +128,7 @@
   - 若 closeout PR 未合入，恢复 `#126/#159` 正文并停止发布动作
   - 若 tag / GitHub Release 已创建但发现主干事实有误，先修正主干与 GitHub 事实，再按独立回合决定是否删除 / 重建发布锚点
 
-## 最近一次 checkpoint 对应的 head
+## 最近一次 checkpoint 对应的 head SHA
 
 - 前置完成基线：`eebeb9818e296736cadb43904ffa9072c27163ae`
 - 实质 closeout checkpoint：当前分支最新 head（待合入 PR `#160`）

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -137,5 +137,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `73542aef650ee76b2573c4ea3315b52d4b6f1676`
+- `73542ae7909f34f68d7fee668ac00fc7e26a5ef5`
 - 说明：该 checkpoint 把 `ADR-GOV-0033` 的两阶段 Work Item 决策、`v0.3.0` / `2026-S16` 的阶段 A 收口真相，以及 `GOV-0033` 继续承接阶段 B 发布动作的边界固定到同一条仓内语义链。当前受审 head 若继续存在后续 commit，只允许用于 review / merge gate / GitHub carrier 同步，不再改写该 checkpoint 语义。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -36,15 +36,15 @@
 
 - `origin/main@eebeb9818e296736cadb43904ffa9072c27163ae` 已包含 `v0.3.0` 所需的全部功能与 closeout 前提：PR `#145/#147/#148/#149/#154/#156/#157/#158`。
 - `#127/#128` 与其下属 Work Item 均已关闭，`v0.3.0` 的功能/contract 目标已经完成。
-- 仓内仍残留“当前 active closeout 入口”为 `#144` 的过渡叙述；`docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 需要先切换到由 `GOV-0033` 承接的发布前过渡态，再在全部发布动作完成后回写最终完成真相。
+- 当前分支 head 将 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 收口为完成态索引，去除了 `#144` 的旧 active closeout 入口。
 - GitHub 侧仍残留 Phase `#126` 未关闭，正文仍写 `冲刺：待 project 排期`，Project 状态仍为 `Todo`。
 - 仓外发布载体仍未建立：当前仓库没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`。
 - `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`。
-- 当前发布 closeout 工件已在 checkpoint `def9d704d0de4c3175179c058c21fe02c202d1d5` 落盘：`ADR-GOV-0033`、`GOV-0033` exec-plan 与 `v0.3.0` / `2026-S16` 完成态索引已同步补齐。
+- 当前发布 closeout 工件已在当前分支最新 head 落盘：`ADR-GOV-0033`、`GOV-0033` exec-plan 与 `v0.3.0` / `2026-S16` 完成态索引已同步补齐。
 
 ## 下一步动作
 
-- 落盘 `GOV-0033` exec-plan，并把 release / sprint 索引改成由 `GOV-0033` 承接的发布前过渡态，去除 `#144` 的旧 active closeout 入口。
+- 确认 `GOV-0033` exec-plan 与 release / sprint 索引已经收口为完成态，并以受控 docs PR 合入主干。
 - 在当前 head 上完成受控 PR 创建、guardian 与 merge gate，合入主干。
 - 合并后同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
 - 随后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
@@ -91,7 +91,7 @@
   - `FR-0008` formal spec / implementation / parent closeout 已由 PR `#145/#147/#148/#149` 合入主干
   - `FR-0009` formal spec / implementation / parent closeout 已由 PR `#154/#156/#157/#158` 合入主干
 - release / sprint 证据：
-  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 将在本回合改为由 `GOV-0033` 承接的发布前过渡态索引，待全部发布动作完成后再回写最终完成真相
+  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 已在当前 head 收口为完成态索引，不再保留 active closeout 入口
 - 发布证据：
   - tag：`v0.3.0`
   - GitHub Release：`v0.3.0`
@@ -128,8 +128,8 @@
   - 若 closeout PR 未合入，恢复 `#126/#159` 正文并停止发布动作
   - 若 tag / GitHub Release 已创建但发现主干事实有误，先修正主干与 GitHub 事实，再按独立回合决定是否删除 / 重建发布锚点
 
-## 最近一次 checkpoint 对应的 head SHA
+## 最近一次 checkpoint 对应的 head
 
 - 前置完成基线：`eebeb9818e296736cadb43904ffa9072c27163ae`
-- 实质 closeout checkpoint：`def9d704d0de4c3175179c058c21fe02c202d1d5`
-- 说明：`eebeb98...` 是 `v0.3.0` 功能与 FR closeout 已全部合入后的主干基线；`def9d70...` 首次把治理 decision、phase/release closeout exec-plan 与完成态 release / sprint 索引收口到同一条发布前真相。
+- 实质 closeout checkpoint：当前分支最新 head（待合入 PR `#160`）
+- 说明：`eebeb98...` 是 `v0.3.0` 功能与 FR closeout 已全部合入后的主干基线；当前分支最新 head 把治理 decision、phase/release closeout exec-plan 与完成态 release / sprint 索引收口到同一条仓内最终真相。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -40,11 +40,12 @@
 - GitHub 侧仍残留 Phase `#126` 未关闭，正文仍写 `冲刺：待 project 排期`，Project 状态仍为 `Todo`。
 - 仓外发布载体仍未建立：当前仓库没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`。
 - `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`。
+- 当前发布 closeout 工件已在 checkpoint `def9d704d0de4c3175179c058c21fe02c202d1d5` 落盘：`ADR-GOV-0033`、`GOV-0033` exec-plan 与 `v0.3.0` / `2026-S16` 完成态索引已同步补齐。
 
 ## 下一步动作
 
 - 落盘 `CHORE-0130` exec-plan，并把 release / sprint 索引改成最终完成态，不再保留 active closeout 入口。
-- 在当前 head 上完成 docs / workflow / governance 门禁与受控 PR 创建，合入主干。
+- 在当前 head 上完成受控 PR 创建、guardian 与 merge gate，合入主干。
 - 合并后同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
 - 随后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
 
@@ -130,4 +131,5 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - 前置完成基线：`eebeb9818e296736cadb43904ffa9072c27163ae`
-- 说明：该基线已经包含 `v0.3.0` 所需的全部功能与父事项 closeout 真相；本回合只负责发布态索引、Phase closeout 与发布锚点收口。
+- 实质 closeout checkpoint：`def9d704d0de4c3175179c058c21fe02c202d1d5`
+- 说明：`eebeb98...` 是 `v0.3.0` 功能与 FR closeout 已全部合入后的主干基线；`def9d70...` 首次把治理 decision、phase/release closeout exec-plan 与完成态 release / sprint 索引收口到同一条发布前真相。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -37,7 +37,7 @@
 - `origin/main@eebeb9818e296736cadb43904ffa9072c27163ae` 已包含 `v0.3.0` 所需的全部功能与 closeout 前提：PR `#145/#147/#148/#149/#154/#156/#157/#158`。
 - `#127/#128` 与其下属 Work Item 均已关闭，`v0.3.0` 的功能/contract 目标已经完成。
 - 本事项按同一 Work Item 的两阶段模型推进：阶段 A 负责仓内 carrier 收口，阶段 B 负责 merge 后的发布锚点与 GitHub closeout。
-- 当前分支 head 将 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 收口为完成态索引，去除了 `#144` 的旧 active closeout 入口。
+- 当前分支 head 将 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 收口为阶段 A 完成态索引，并把后续发布动作明确保留在 `GOV-0033` 阶段 B。
 - GitHub 侧仍残留 Phase `#126` 未关闭，正文仍写 `冲刺：待 project 排期`，Project 状态仍为 `Todo`。
 - 仓外发布载体仍未建立：当前仓库没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`。
 - `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`。
@@ -92,7 +92,7 @@
   - `FR-0008` formal spec / implementation / parent closeout 已由 PR `#145/#147/#148/#149` 合入主干
   - `FR-0009` formal spec / implementation / parent closeout 已由 PR `#154/#156/#157/#158` 合入主干
 - release / sprint 证据：
-  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 已在当前 head 收口为完成态索引，不再保留 active closeout 入口
+  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 已在当前 head 收口为阶段 A 完成态索引，并明确 `GOV-0033` 仍承接阶段 B 发布收口
 - 阶段 A 仓内工件证据：
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
   - `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md`

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -36,18 +36,19 @@
 
 - `origin/main@eebeb9818e296736cadb43904ffa9072c27163ae` 已包含 `v0.3.0` 所需的全部功能与 closeout 前提：PR `#145/#147/#148/#149/#154/#156/#157/#158`。
 - `#127/#128` 与其下属 Work Item 均已关闭，`v0.3.0` 的功能/contract 目标已经完成。
+- 本事项按同一 Work Item 的两阶段模型推进：阶段 A 负责仓内 carrier 收口，阶段 B 负责 merge 后的发布锚点与 GitHub closeout。
 - 当前分支 head 将 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 收口为完成态索引，去除了 `#144` 的旧 active closeout 入口。
 - GitHub 侧仍残留 Phase `#126` 未关闭，正文仍写 `冲刺：待 project 排期`，Project 状态仍为 `Todo`。
 - 仓外发布载体仍未建立：当前仓库没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`。
 - `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`。
-- 当前发布 closeout 工件已在当前分支最新 head 落盘：`ADR-GOV-0033`、`GOV-0033` exec-plan 与 `v0.3.0` / `2026-S16` 完成态索引已同步补齐。
+- 当前阶段 A 的仓内 closeout 工件已在当前分支落盘：`ADR-GOV-0033`、`GOV-0033` exec-plan 与 `v0.3.0` / `2026-S16` 完成态索引已同步补齐。
 
 ## 下一步动作
 
 - 确认 `GOV-0033` exec-plan 与 release / sprint 索引已经收口为完成态，并以受控 docs PR 合入主干。
 - 在当前 head 上完成受控 PR 创建、guardian 与 merge gate，合入主干。
-- 合并后同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
-- 随后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
+- 合并后进入阶段 B：同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
+- 阶段 B 完成后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -92,11 +93,17 @@
   - `FR-0009` formal spec / implementation / parent closeout 已由 PR `#154/#156/#157/#158` 合入主干
 - release / sprint 证据：
   - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 已在当前 head 收口为完成态索引，不再保留 active closeout 入口
-- 发布证据：
-  - tag：`v0.3.0`
-  - GitHub Release：`v0.3.0`
-- GitHub closeout 证据：
-  - `#126` Phase 正文 / Project 状态 /关闭语义与 `#159` 完成事实对齐
+- 阶段 A 仓内工件证据：
+  - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
+  - `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md`
+
+## 阶段 B 待执行发布动作
+
+- 创建 tag：`v0.3.0`
+- 创建 GitHub Release：`v0.3.0`
+- 回写并关闭 `#126`
+- 回写并关闭 `#159`
+- 对齐相关 Project 状态
 
 ## GitHub closeout 工件
 
@@ -130,6 +137,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- 前置完成基线：`eebeb9818e296736cadb43904ffa9072c27163ae`
-- 实质 closeout checkpoint：当前分支最新 head（待合入 PR `#160`）
-- 说明：`eebeb98...` 是 `v0.3.0` 功能与 FR closeout 已全部合入后的主干基线；当前分支最新 head 把治理 decision、phase/release closeout exec-plan 与完成态 release / sprint 索引收口到同一条仓内最终真相。
+- `201ddef800eff91d57dff4c338237434da2b2045`
+- 说明：该 checkpoint 首次把 `ADR-GOV-0033`、两阶段 Work Item 决策、`v0.3.0` / `2026-S16` 完成态索引与阶段 A/阶段 B 分界收口到同一条仓内真相。当前 PR head 上的后续变更只用于 review / merge gate / GitHub carrier 同步，属于 `metadata-only closeout follow-up`。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -21,7 +21,7 @@
 ## 范围
 
 - 本次纳入：
-  - `docs/exec-plans/CHORE-0130-v0-3-0-phase-and-release-closeout.md`
+  - `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md`
   - `docs/releases/v0.3.0.md`
   - `docs/sprints/2026-S16.md`
   - GitHub `#126` / `#159` issue 正文、Project 状态与关闭语义对齐
@@ -44,7 +44,7 @@
 
 ## 下一步动作
 
-- 落盘 `CHORE-0130` exec-plan，并把 release / sprint 索引改成最终完成态，不再保留 active closeout 入口。
+- 落盘 `GOV-0033` exec-plan，并把 release / sprint 索引改成最终完成态，不再保留 active closeout 入口。
 - 在当前 head 上完成受控 PR 创建、guardian 与 merge gate，合入主干。
 - 合并后同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
 - 随后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -36,7 +36,7 @@
 
 - `origin/main@eebeb9818e296736cadb43904ffa9072c27163ae` 已包含 `v0.3.0` 所需的全部功能与 closeout 前提：PR `#145/#147/#148/#149/#154/#156/#157/#158`。
 - `#127/#128` 与其下属 Work Item 均已关闭，`v0.3.0` 的功能/contract 目标已经完成。
-- 仓内仍残留“当前 active closeout 入口”为 `#144` 的过渡叙述；`docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 尚未切换到最终完成态。
+- 仓内仍残留“当前 active closeout 入口”为 `#144` 的过渡叙述；`docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 需要先切换到由 `GOV-0033` 承接的发布前过渡态，再在全部发布动作完成后回写最终完成真相。
 - GitHub 侧仍残留 Phase `#126` 未关闭，正文仍写 `冲刺：待 project 排期`，Project 状态仍为 `Todo`。
 - 仓外发布载体仍未建立：当前仓库没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`。
 - `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`。
@@ -44,7 +44,7 @@
 
 ## 下一步动作
 
-- 落盘 `GOV-0033` exec-plan，并把 release / sprint 索引改成最终完成态，不再保留 active closeout 入口。
+- 落盘 `GOV-0033` exec-plan，并把 release / sprint 索引改成由 `GOV-0033` 承接的发布前过渡态，去除 `#144` 的旧 active closeout 入口。
 - 在当前 head 上完成受控 PR 创建、guardian 与 merge gate，合入主干。
 - 合并后同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
 - 随后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
@@ -91,7 +91,7 @@
   - `FR-0008` formal spec / implementation / parent closeout 已由 PR `#145/#147/#148/#149` 合入主干
   - `FR-0009` formal spec / implementation / parent closeout 已由 PR `#154/#156/#157/#158` 合入主干
 - release / sprint 证据：
-  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 将在本回合改为“版本完成态”索引，不再保留 active closeout 入口
+  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 将在本回合改为由 `GOV-0033` 承接的发布前过渡态索引，待全部发布动作完成后再回写最终完成真相
 - 发布证据：
   - tag：`v0.3.0`
   - GitHub Release：`v0.3.0`

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -66,7 +66,7 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前完成真相
+## 当前阶段 A 完成真相
 
 - `FR-0008` formal spec 已由 PR `#145` 合入主干。
 - `FR-0008` 的共享模型实现已由 PR `#147` 合入主干。
@@ -76,5 +76,5 @@
 - `FR-0009` 的 CLI query public surface 已由 PR `#156` 合入主干。
 - `FR-0009` 的 same-path 判别式证据已由 PR `#157` 合入主干。
 - `FR-0009` 的父事项 closeout 已由 PR `#158` 合入主干。
-- `v0.3.0` 的功能、formal spec、implementation 与 parent closeout 已全部完成，仓内版本索引已进入完成态。
-- 当前 release 文档只保留完成态索引语义，不再保留 active closeout 入口。
+- `v0.3.0` 的功能、formal spec、implementation 与 parent closeout 已全部完成，仓内版本索引已完成阶段 A 收口。
+- `GOV-0033` 仍作为阶段 B 的 active closeout 入口，负责 merge 后的 tag、GitHub Release 与 `#126/#159` 同步关闭。

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -32,6 +32,7 @@
 - `CHORE-0129-fr-0009-parent-closeout`：`FR-0009` 父事项 closeout Work Item，对应 Issue `#144`
 - `GOV-0031-guardian-live-head-binding`：修复 guardian 对 metadata-only closeout head 的自引用追逐，对应 Issue `#150`
 - `GOV-0032-legacy-metadata-only-review-sync-marker`：锁定 legacy metadata-only review sync marker 兼容回归，对应 Issue `#152`
+- `GOV-0033-v0-3-0-phase-and-release-closeout`：`v0.3.0` phase 与发布收口，对应 Issue `#159`
 
 ## 相关前提
 
@@ -59,9 +60,11 @@
   - `docs/exec-plans/CHORE-0129-fr-0009-parent-closeout.md`
   - `docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
   - `docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md`
+  - `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md`
 - decision：
   - `docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
+  - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
 ## 当前 closeout 真相
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -66,7 +66,7 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前发布前真相
+## 当前完成真相
 
 - `FR-0008` formal spec 已由 PR `#145` 合入主干。
 - `FR-0008` 的共享模型实现已由 PR `#147` 合入主干。
@@ -76,5 +76,5 @@
 - `FR-0009` 的 CLI query public surface 已由 PR `#156` 合入主干。
 - `FR-0009` 的 same-path 判别式证据已由 PR `#157` 合入主干。
 - `FR-0009` 的父事项 closeout 已由 PR `#158` 合入主干。
-- `v0.3.0` 的功能目标已经全部满足，但发布锚点与 Phase closeout 尚未完成。
-- 当前版本仍处于发布前过渡态；最终完成真相将在 `GOV-0033` 合入主干、tag / GitHub Release 建立、`#126/#159` 完成关闭后再回写。
+- `v0.3.0` 的功能、formal spec、implementation 与 parent closeout 已全部完成，仓内版本索引已进入完成态。
+- 当前 release 文档只保留完成态索引语义，不再保留 active closeout 入口。

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -72,5 +72,6 @@
 - `FR-0009` formal spec 已由 PR `#154` 合入主干。
 - `FR-0009` 的 CLI query public surface 已由 PR `#156` 合入主干。
 - `FR-0009` 的 same-path 判别式证据已由 PR `#157` 合入主干。
-- 当前 active closeout 入口包括：
-  - `docs/exec-plans/CHORE-0129-fr-0009-parent-closeout.md`：收口 `#128/#144` 与 `FR-0009` 已合入主干事实
+- `FR-0009` 的父事项 closeout 已由 PR `#158` 合入主干。
+- `v0.3.0` 的功能与 closeout 目标已经全部满足；剩余动作只包括发布锚点与 Phase closeout。
+- `v0.3.0` 的最终发布收口由 `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md` 承接。

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -66,7 +66,7 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前 closeout 真相
+## 当前发布前真相
 
 - `FR-0008` formal spec 已由 PR `#145` 合入主干。
 - `FR-0008` 的共享模型实现已由 PR `#147` 合入主干。
@@ -76,5 +76,5 @@
 - `FR-0009` 的 CLI query public surface 已由 PR `#156` 合入主干。
 - `FR-0009` 的 same-path 判别式证据已由 PR `#157` 合入主干。
 - `FR-0009` 的父事项 closeout 已由 PR `#158` 合入主干。
-- `v0.3.0` 的功能与 closeout 目标已经全部满足；剩余动作只包括发布锚点与 Phase closeout。
-- `v0.3.0` 的最终发布收口由 `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md` 承接。
+- `v0.3.0` 的功能目标已经全部满足，但发布锚点与 Phase closeout 尚未完成。
+- 当前版本仍处于发布前过渡态；最终完成真相将在 `GOV-0033` 合入主干、tag / GitHub Release 建立、`#126/#159` 完成关闭后再回写。

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -23,6 +23,7 @@
 - `CHORE-0129-fr-0009-parent-closeout`：`FR-0009` 父事项 closeout Work Item，对应 Issue `#144`
 - `GOV-0031-guardian-live-head-binding`：修复 guardian 对 metadata-only closeout head 的自引用追逐，对应 Issue `#150`
 - `GOV-0032-legacy-metadata-only-review-sync-marker`：锁定 legacy metadata-only review sync marker 兼容回归，对应 Issue `#152`
+- `GOV-0033-v0-3-0-phase-and-release-closeout`：`v0.3.0` phase 与发布收口，对应 Issue `#159`
 
 ## 进入前依赖
 
@@ -39,7 +40,7 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
-- 相关 Issue / PR：`#126`、`#127`、`#128`、`#137`、`#138`、`#139`、`#140`、`#141`、`#142`、`#143`、`#144`、`#150`、`#152`
+- 相关 Issue / PR：`#126`、`#127`、`#128`、`#137`、`#138`、`#139`、`#140`、`#141`、`#142`、`#143`、`#144`、`#150`、`#152`、`#159`
 
 ## 关联工件
 
@@ -60,9 +61,11 @@
   - `docs/exec-plans/CHORE-0129-fr-0009-parent-closeout.md`
   - `docs/exec-plans/GOV-0031-guardian-live-head-binding.md`
   - `docs/exec-plans/GOV-0032-legacy-metadata-only-review-sync-marker.md`
+  - `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md`
 - decision：
   - `docs/decisions/ADR-GOV-0031-guardian-live-head-binding.md`
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
+  - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
 ## 当前 closeout 真相
 

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -67,7 +67,6 @@
 ## 当前 closeout 真相
 
 - `FR-0008` formal spec、共享模型实现、本地持久化实现与父事项 closeout 已依次由 PR `#145`、`#147`、`#148`、`#149` 合入主干。
-- `FR-0009` formal spec、CLI query public surface 与 same-path 判别式证据已经依次由 PR `#154`、`#156`、`#157` 合入主干。
-- 当前 active closeout 入口包括：
-  - `docs/exec-plans/CHORE-0129-fr-0009-parent-closeout.md`
-- 本 sprint 文档只保留上述 active closeout 证据链的索引语义。
+- `FR-0009` formal spec、CLI query public surface、same-path 判别式证据与父事项 closeout 已依次由 PR `#154`、`#156`、`#157`、`#158` 合入主干。
+- `2026-S16` 的版本交付目标已经完成；当前只剩 `v0.3.0` 的 phase / release 发布收口。
+- 本 sprint 文档只保留完成态索引语义；最终发布收口由 `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md` 承接。

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -67,9 +67,9 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前 closeout 真相
+## 当前发布前真相
 
 - `FR-0008` formal spec、共享模型实现、本地持久化实现与父事项 closeout 已依次由 PR `#145`、`#147`、`#148`、`#149` 合入主干。
 - `FR-0009` formal spec、CLI query public surface、same-path 判别式证据与父事项 closeout 已依次由 PR `#154`、`#156`、`#157`、`#158` 合入主干。
-- `2026-S16` 的版本交付目标已经完成；当前只剩 `v0.3.0` 的 phase / release 发布收口。
-- 本 sprint 文档只保留完成态索引语义；最终发布收口由 `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md` 承接。
+- `2026-S16` 的版本交付功能目标已经完成；当前只剩 `v0.3.0` 的 phase / release 发布收口。
+- 本 sprint 文档当前保留发布前过渡态索引语义；待 `GOV-0033` 合入、tag / GitHub Release 建立并完成 `#126/#159` closeout 后，再切换为最终完成真相。

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -67,9 +67,9 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前发布前真相
+## 当前完成真相
 
 - `FR-0008` formal spec、共享模型实现、本地持久化实现与父事项 closeout 已依次由 PR `#145`、`#147`、`#148`、`#149` 合入主干。
 - `FR-0009` formal spec、CLI query public surface、same-path 判别式证据与父事项 closeout 已依次由 PR `#154`、`#156`、`#157`、`#158` 合入主干。
-- `2026-S16` 的版本交付功能目标已经完成；当前只剩 `v0.3.0` 的 phase / release 发布收口。
-- 本 sprint 文档当前保留发布前过渡态索引语义；待 `GOV-0033` 合入、tag / GitHub Release 建立并完成 `#126/#159` closeout 后，再切换为最终完成真相。
+- `2026-S16` 的版本交付目标已经完成，`v0.3.0` 的仓内 release / sprint 索引已同步收口。
+- 本 sprint 文档只保留完成态索引语义，不再保留 active closeout 入口。

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -67,9 +67,9 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前完成真相
+## 当前阶段 A 完成真相
 
 - `FR-0008` formal spec、共享模型实现、本地持久化实现与父事项 closeout 已依次由 PR `#145`、`#147`、`#148`、`#149` 合入主干。
 - `FR-0009` formal spec、CLI query public surface、same-path 判别式证据与父事项 closeout 已依次由 PR `#154`、`#156`、`#157`、`#158` 合入主干。
-- `2026-S16` 的版本交付目标已经完成，`v0.3.0` 的仓内 release / sprint 索引已同步收口。
-- 本 sprint 文档只保留完成态索引语义，不再保留 active closeout 入口。
+- `2026-S16` 的版本交付目标已经完成，`v0.3.0` 的仓内 release / sprint 索引已完成阶段 A 收口。
+- `GOV-0033` 仍作为阶段 B 的 active closeout 入口，负责 merge 后的发布锚点与 `#126/#159` closeout 同步。


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：把 `GOV-0033 / #159` 明确为同一 Work Item 的两阶段发布收口，先合入仓内 carrier，再在主干执行发布锚点与 GitHub closeout。
- 主要改动：
  - 重写 `ADR-GOV-0033` 与 active `exec-plan`，明确阶段 A/阶段 B 边界
  - 将 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 收口为仓内完成态索引
  - 去除 `#144` 时代遗留的 active closeout 入口，不让 PR 自动关闭 `#159`

## Issue 摘要

- 当前 PR 只承接 `#159` 的阶段 A：仓内 carrier 收口。
- `v0.3.0` tag、GitHub Release、`#126/#159` closeout 与 Project 状态对齐属于同一 Work Item 的阶段 B，将在本 PR 合入主干后立即执行。

## 关联事项

- Issue: #159
- item_key: `GOV-0033-v0-3-0-phase-and-release-closeout`
- item_type: `GOV`
- release: `v0.3.0`
- sprint: `2026-S16`
- Related: #159

## 风险

- 风险级别：`lightweight`
- 审查关注：确认 active `exec-plan` 只记录已成立的仓内证据，把 tag / GitHub Release / Phase closeout 保持为 merge 后动作，而不是当前 head 的既成事实。

## 验证

- 已执行：
  - `python3 scripts/spec_guard.py --mode ci --all`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-sha $(git merge-base origin/main HEAD) --head-sha $(git rev-parse HEAD) --head-ref issue-159-chore-v0-3-0-phase`
  - `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
- 未执行：
  - `v0.3.0` tag
  - GitHub Release `v0.3.0`
  - `#126/#159` closeout 与 Project 状态对齐

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
