### PR TITLE
docs(release): 同步 v0.3.0 发布完成真相

### DIFF
--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -34,21 +34,20 @@
 
 ## 当前停点
 
-- `origin/main@eebeb9818e296736cadb43904ffa9072c27163ae` 已包含 `v0.3.0` 所需的全部功能与 closeout 前提：PR `#145/#147/#148/#149/#154/#156/#157/#158`。
+- `origin/main@2ee25c77f4a3595399a03c2a00543712842ad192` 已包含 `v0.3.0` 所需的全部功能、FR closeout 与阶段 A 仓内 carrier 收口：PR `#145/#147/#148/#149/#154/#156/#157/#158/#160`。
 - `#127/#128` 与其下属 Work Item 均已关闭，`v0.3.0` 的功能/contract 目标已经完成。
-- 本事项按同一 Work Item 的两阶段模型推进：阶段 A 负责仓内 carrier 收口，阶段 B 负责 merge 后的发布锚点与 GitHub closeout。
-- 当前分支 head 将 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 收口为阶段 A 完成态索引，并把后续发布动作明确保留在 `GOV-0033` 阶段 B。
+- 本事项按同一 Work Item 的两阶段模型推进：阶段 A 已完成仓内 carrier 收口，阶段 B 正在完成 merge 后的发布锚点与 GitHub closeout。
+- `v0.3.0` tag 已创建并推送，GitHub Release `v0.3.0` 已发布。
+- 当前分支为同一 Work Item 的阶段 B `metadata-only closeout follow-up`，只负责把 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 从阶段 A 真相同步到发布完成真相。
 - GitHub 侧仍残留 Phase `#126` 未关闭，正文仍写 `冲刺：待 project 排期`，Project 状态仍为 `Todo`。
-- 仓外发布载体仍未建立：当前仓库没有 `v0.3.0` tag，也没有 GitHub Release `v0.3.0`。
-- `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`。
-- 当前阶段 A 的仓内 closeout 工件已在当前分支落盘：`ADR-GOV-0033`、`GOV-0033` exec-plan 与 `v0.3.0` / `2026-S16` 完成态索引已同步补齐。
+- `#159` 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-159-chore-v0-3-0-phase`，当前分支为 `issue-159-chore-v0-3-0-phase-b`。
+- 当前阶段 B 的发布锚点已经建立；当前分支只补仓内最终发布真相与 closeout 恢复入口。
 
 ## 下一步动作
 
-- 确认 `GOV-0033` exec-plan 与 release / sprint 索引已经收口为完成态，并以受控 docs PR 合入主干。
+- 确认 `GOV-0033` exec-plan 与 release / sprint 索引已经同步到发布完成真相，并以受控 docs PR 合入主干。
 - 在当前 head 上完成受控 PR 创建、guardian 与 merge gate，合入主干。
-- 合并后进入阶段 B：同步 `main`，创建 tag `v0.3.0`，发布 GitHub Release `v0.3.0`。
-- 阶段 B 完成后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
+- 合并后回写并关闭 `#126` 与 `#159`，确认 Project 状态、tag / release 与仓内真相一致。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -59,7 +58,7 @@
 - 角色：`v0.3.0` 的 phase / release 发布 closeout Work Item。
 - 阻塞：
   - `#126` 不能直接作为执行入口，必须由 `#159` 承接 docs / release 发布动作。
-  - Git tag 与 GitHub Release 只能在 closeout PR 合入主干后创建，避免 tag 指向未合入 head。
+  - `#126/#159` 与相关 Project 状态仍需在仓内最终发布真相合入后完成 GitHub closeout 对账。
 
 ## 已验证项
 
@@ -73,10 +72,10 @@
   - 结果：`#127` 为 `CLOSED`。
 - `gh issue view 128 --json state`
   - 结果：`#128` 为 `CLOSED`。
-- `gh release list`
-  - 结果：当前仅有 `v0.1.0`、`v0.2.0`，尚无 `v0.3.0`。
+- `gh release view v0.3.0`
+  - 结果：GitHub Release `v0.3.0` 已存在。
 - `git tag --list`
-  - 结果：当前仅有 `v0.1.0`、`v0.2.0`，尚无 `v0.3.0`。
+  - 结果：当前已存在 `v0.3.0`。
 - `python3 scripts/spec_guard.py --mode ci --all`
   - 结果：通过
 - `python3 scripts/docs_guard.py --mode ci`
@@ -92,15 +91,13 @@
   - `FR-0008` formal spec / implementation / parent closeout 已由 PR `#145/#147/#148/#149` 合入主干
   - `FR-0009` formal spec / implementation / parent closeout 已由 PR `#154/#156/#157/#158` 合入主干
 - release / sprint 证据：
-  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 已在当前 head 收口为阶段 A 完成态索引，并明确 `GOV-0033` 仍承接阶段 B 发布收口
+  - `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 已在当前 head 同步到发布完成真相
 - 阶段 A 仓内工件证据：
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
   - `docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 阶段 B 待执行发布动作
+## 剩余 closeout 动作
 
-- 创建 tag：`v0.3.0`
-- 创建 GitHub Release：`v0.3.0`
 - 回写并关闭 `#126`
 - 回写并关闭 `#159`
 - 对齐相关 Project 状态
@@ -120,12 +117,11 @@
   - 冲刺字段不再保留 `待 project 排期`
 - `#126` Project 状态目标：
   - 在 closeout 完成前保持当前状态
-  - `#159` 合入、tag / release 发布完成后切到 `Done`
+  - `#159` 合入并完成 GitHub closeout 对账后切到 `Done`
 
 ## 未决风险
 
-- 若 tag / GitHub Release 早于 closeout PR 合入，会造成发布锚点指向非主干事实。
-- 若 release / sprint 索引仍保留 active closeout 入口，会把已完成版本错误表述为仍在收口。
+- 若 release / sprint 索引未及时同步到发布完成真相，会让主干仓内索引滞后于已发布版本。
 - 若只创建 tag 而不更新 `#126` Phase，GitHub 上位阶段真相仍会滞后于已发布状态。
 
 ## 回滚方式
@@ -137,5 +133,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `73542ae7909f34f68d7fee668ac00fc7e26a5ef5`
-- 说明：该 checkpoint 把 `ADR-GOV-0033` 的两阶段 Work Item 决策、`v0.3.0` / `2026-S16` 的阶段 A 收口真相，以及 `GOV-0033` 继续承接阶段 B 发布动作的边界固定到同一条仓内语义链。当前受审 head 若继续存在后续 commit，只允许用于 review / merge gate / GitHub carrier 同步，不再改写该 checkpoint 语义。
+- `2ee25c77f4a3595399a03c2a00543712842ad192`
+- 说明：该 checkpoint 对应阶段 A 合入后的主干事实，已经包含 `GOV-0033` 的两阶段决策与仓内 carrier 收口。当前分支只作为阶段 B `metadata-only closeout follow-up`，把已建立的 tag / GitHub Release 与仓内 release / sprint 最终发布真相对齐。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -133,5 +133,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `2ee25c77f4a3595399a03c2a00543712842ad192`
-- 说明：该 checkpoint 对应阶段 A 合入后的主干事实，已经包含 `GOV-0033` 的两阶段决策与仓内 carrier 收口。当前分支只作为阶段 B `metadata-only closeout follow-up`，把已建立的 tag / GitHub Release 与仓内 release / sprint 最终发布真相对齐。
+- `4b6040aaf1a263584ee53b49213fef59abfc17ef`
+- 说明：该 checkpoint 把已建立的 `v0.3.0` tag / GitHub Release 与 `docs/releases/v0.3.0.md`、`docs/sprints/2026-S16.md` 的发布完成真相同步到同一条仓内语义链。当前受审 head 若继续存在后续 commit，只允许用于 review / merge gate / GitHub carrier 同步，不再改写该 checkpoint 语义。

--- a/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0033-v0-3-0-phase-and-release-closeout.md
@@ -82,7 +82,7 @@
   - 结果：通过
 - `python3 scripts/workflow_guard.py --mode ci`
   - 结果：通过
-- `python3 scripts/governance_gate.py --mode ci --base-sha $(git merge-base origin/main HEAD) --head-sha $(git rev-parse HEAD) --head-ref issue-159-chore-v0-3-0-phase`
+- `python3 scripts/governance_gate.py --mode ci --base-sha $(git merge-base origin/main HEAD) --head-sha $(git rev-parse HEAD) --head-ref issue-159-chore-v0-3-0-phase-b`
   - 结果：通过
 
 ## closeout 证据

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -66,7 +66,7 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前阶段 A 完成真相
+## 当前发布完成真相
 
 - `FR-0008` formal spec 已由 PR `#145` 合入主干。
 - `FR-0008` 的共享模型实现已由 PR `#147` 合入主干。
@@ -76,5 +76,6 @@
 - `FR-0009` 的 CLI query public surface 已由 PR `#156` 合入主干。
 - `FR-0009` 的 same-path 判别式证据已由 PR `#157` 合入主干。
 - `FR-0009` 的父事项 closeout 已由 PR `#158` 合入主干。
-- `v0.3.0` 的功能、formal spec、implementation 与 parent closeout 已全部完成，仓内版本索引已完成阶段 A 收口。
-- `GOV-0033` 仍作为阶段 B 的 active closeout 入口，负责 merge 后的 tag、GitHub Release 与 `#126/#159` 同步关闭。
+- `v0.3.0` 的功能、formal spec、implementation 与 parent closeout 已全部完成，并已由主干提交 `2ee25c77f4a3595399a03c2a00543712842ad192` 发布为 tag `v0.3.0`。
+- GitHub Release `v0.3.0` 已创建，发布锚点已经建立。
+- `GOV-0033` 当前仅剩 `#126/#159` 与相关 Project 状态的 GitHub closeout 同步。

--- a/docs/sprints/2026-S16.md
+++ b/docs/sprints/2026-S16.md
@@ -67,9 +67,9 @@
   - `docs/decisions/ADR-GOV-0032-legacy-metadata-only-review-sync-marker.md`
   - `docs/decisions/ADR-GOV-0033-v0-3-0-phase-and-release-closeout.md`
 
-## 当前阶段 A 完成真相
+## 当前发布完成真相
 
 - `FR-0008` formal spec、共享模型实现、本地持久化实现与父事项 closeout 已依次由 PR `#145`、`#147`、`#148`、`#149` 合入主干。
 - `FR-0009` formal spec、CLI query public surface、same-path 判别式证据与父事项 closeout 已依次由 PR `#154`、`#156`、`#157`、`#158` 合入主干。
-- `2026-S16` 的版本交付目标已经完成，`v0.3.0` 的仓内 release / sprint 索引已完成阶段 A 收口。
-- `GOV-0033` 仍作为阶段 B 的 active closeout 入口，负责 merge 后的发布锚点与 `#126/#159` closeout 同步。
+- `2026-S16` 的版本交付目标已经完成，`v0.3.0` 已发布为 tag `v0.3.0` 并建立 GitHub Release。
+- 当前 sprint 索引已进入发布完成态；`GOV-0033` 仅剩 GitHub closeout 对账与关闭动作。


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：把 `v0.3.0` 已建立的 tag / GitHub Release 同步回仓内 release / sprint 索引，完成 `GOV-0033` 的阶段 B repo-truth 收口。
- 主要改动：
  - 将 `docs/releases/v0.3.0.md` 与 `docs/sprints/2026-S16.md` 从“阶段 A 完成真相”推进到“发布完成真相”
  - 更新 `GOV-0033` active exec-plan，使其只剩 `#126/#159` 与 Project 状态的 GitHub closeout 对账
  - 不改 runtime / formal spec / release tag 本体，只同步仓内 carrier

## Issue 摘要

- `v0.3.0` tag 与 GitHub Release 已建立。
- 当前 PR 只负责同一 Work Item `#159` 的阶段 B docs follow-up，把仓内索引同步到已发布事实。
- `#126/#159` 的正文、Project 状态与关闭语义将在本 PR 合入后立即对齐，不在本 PR 中自动关闭。

## 关联事项

- Issue: #159
- item_key: `GOV-0033-v0-3-0-phase-and-release-closeout`
- item_type: `GOV`
- release: `v0.3.0`
- sprint: `2026-S16`
- Related: #159

## 风险

- 风险级别：`lightweight`
- 审查关注：确认当前 diff 只同步已存在的发布锚点事实，不把尚未发生的 `#126/#159` closeout 误写成既成事实。

## 验证

- 已执行：
  - `python3 scripts/spec_guard.py --mode ci --all`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-sha $(git merge-base origin/main HEAD) --head-sha $(git rev-parse HEAD) --head-ref issue-159-chore-v0-3-0-phase-b`
  - `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
- 未执行：
  - `#126/#159` closeout comment / body / Project 状态对齐与关闭

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
