### PR TITLE
fix(runtime): 修复 FR-0007 泄漏边界与版本门禁基线漂移

### DIFF
--- a/docs/exec-plans/CHORE-0135-fr-0007-regression-baseline-repair.md
+++ b/docs/exec-plans/CHORE-0135-fr-0007-regression-baseline-repair.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S17`
 - 关联 spec：`docs/specs/FR-0007-release-gate-and-regression-checks/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#180`
 - active 收口事项：`CHORE-0135-fr-0007-regression-baseline-repair`
 
 ## 目标
@@ -37,6 +37,7 @@
 
 - 当前执行现场：`/Users/mc/code/worktrees/syvert/issue-179-fr-0007`
 - 当前执行分支：`issue-179-fr-0007`
+- 当前受审 PR：`#180`
 - 基线 head：`2c71a6d1be6eb965198cd984f2bcb17439ae6a02`
 - 当前实现 checkpoint：`cb5eaadbeff4cd3efa9a8f235cb72ef6297ddc85`
 - 当前代码已收口两类修复：
@@ -90,3 +91,4 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - `cb5eaadbeff4cd3efa9a8f235cb72ef6297ddc85`
+- 当前回合已进入 `metadata-only closeout follow-up`；后续 PR / review / merge gate 元数据同步不要求该 checkpoint SHA 与最新 HEAD 完全一致。

--- a/docs/exec-plans/CHORE-0135-fr-0007-regression-baseline-repair.md
+++ b/docs/exec-plans/CHORE-0135-fr-0007-regression-baseline-repair.md
@@ -1,0 +1,79 @@
+# CHORE-0135 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0135-fr-0007-regression-baseline-repair`
+- Issue：`#179`
+- item_type：`CHORE`
+- release：`v0.4.0`
+- sprint：`2026-S17`
+- 关联 spec：`docs/specs/FR-0007-release-gate-and-regression-checks/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`CHORE-0135-fr-0007-regression-baseline-repair`
+
+## 目标
+
+- 修复 `platform_leakage` 对 `execute_task()` success / failure return path 的边界归类漂移。
+- 修复 `tests.runtime.test_real_adapter_regression` 中 platform leakage payload 与 `version_gate` canonical evidence refs 不一致的问题。
+- 在不修改 formal spec、不放宽 `version_gate` validator 的前提下，消除主干既有 3 个失败。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/platform_leakage.py`
+  - `tests/runtime/test_platform_leakage.py`
+  - `tests/runtime/test_real_adapter_regression.py`
+  - `tests/runtime/test_version_gate.py`
+  - `tests/runtime/platform_leakage_fixtures.py`
+  - 当前 active `exec-plan`
+- 本次不纳入：
+  - `FR-0010` / `FR-0011` / `FR-0012`
+  - `syvert/version_gate.py` contract 放宽
+  - CLI / adapter runtime surface 变更
+  - formal spec 改写
+
+## 当前停点
+
+- 当前执行现场：`/Users/mc/code/worktrees/syvert/issue-179-fr-0007`
+- 当前执行分支：`issue-179-fr-0007`
+- 基线 head：`2c71a6d1be6eb965198cd984f2bcb17439ae6a02`
+- 已确认主干存在 3 个既有失败：
+  - `tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_success_envelope_leak_to_shared_result_contract`
+  - `tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_exception_failure_return_to_shared_error_model`
+  - `tests.runtime.test_real_adapter_regression.RealAdapterRegressionTests.test_end_to_end_real_adapter_regression_report_feeds_version_gate`
+- 已确认第三项失败的真实根因是测试 payload 漂移，而不是 `real_adapter_regression` 逻辑回归。
+
+## 下一步动作
+
+- 为 `execute_task()` 构建语句级 boundary override，并补针对 return dict / failure envelope 参数行的回归。
+- 抽出共享 platform leakage payload fixture，统一 `test_version_gate` 与 `test_real_adapter_regression` 的 canonical evidence refs。
+- 先跑 3 个既有失败用例，再跑 `platform_leakage / version_gate / real_adapter_regression` 与 executor/runtime/registry 回归收口。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.4.0` 清理 FR-0007 历史回归噪音，恢复版本门禁与平台泄漏检查的主干测试真相。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：清理主干既有回归噪音，恢复 FR-0007 相关 gate 的可信基线。
+- 阻塞：待实现修复并完成回归验证后进入 PR / guardian。
+
+## 已验证项
+
+- `gh issue create` 已创建 Work Item `#179`
+- `python3 scripts/create_worktree.py --issue 179 --class implementation`
+  - 结果：已创建 worktree `/Users/mc/code/worktrees/syvert/issue-179-fr-0007`
+
+## 未决风险
+
+- `platform_leakage` 当前按行号归类，若 override 设计不精确，可能影响非 `execute_task()` 语句的既有边界判断。
+- 测试 helper 抽取如果直接复用测试类静态方法，容易引入循环依赖；需要落独立 fixture 模块。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对应的实现与测试调整。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `2c71a6d1be6eb965198cd984f2bcb17439ae6a02`

--- a/docs/exec-plans/CHORE-0135-fr-0007-regression-baseline-repair.md
+++ b/docs/exec-plans/CHORE-0135-fr-0007-regression-baseline-repair.md
@@ -38,17 +38,16 @@
 - 当前执行现场：`/Users/mc/code/worktrees/syvert/issue-179-fr-0007`
 - 当前执行分支：`issue-179-fr-0007`
 - 基线 head：`2c71a6d1be6eb965198cd984f2bcb17439ae6a02`
-- 已确认主干存在 3 个既有失败：
-  - `tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_success_envelope_leak_to_shared_result_contract`
-  - `tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_exception_failure_return_to_shared_error_model`
-  - `tests.runtime.test_real_adapter_regression.RealAdapterRegressionTests.test_end_to_end_real_adapter_regression_report_feeds_version_gate`
-- 已确认第三项失败的真实根因是测试 payload 漂移，而不是 `real_adapter_regression` 逻辑回归。
+- 当前实现 checkpoint：`cb5eaadbeff4cd3efa9a8f235cb72ef6297ddc85`
+- 当前代码已收口两类修复：
+  - `syvert/platform_leakage.py` 对 `execute_task` / `execute_task_internal` 内 success envelope dict 与 `failure_envelope(...)` 语句值做 statement-level boundary override，success 归 `shared_result_contract`、failure 归 `shared_error_model`。
+  - `tests/runtime/platform_leakage_fixtures.py` 已成为 canonical platform leakage payload 的单一测试真相源，`test_version_gate` 与 `test_real_adapter_regression` 已去除漂移副本。
 
 ## 下一步动作
 
-- 为 `execute_task()` 构建语句级 boundary override，并补针对 return dict / failure envelope 参数行的回归。
-- 抽出共享 platform leakage payload fixture，统一 `test_version_gate` 与 `test_real_adapter_regression` 的 canonical evidence refs。
-- 先跑 3 个既有失败用例，再跑 `platform_leakage / version_gate / real_adapter_regression` 与 executor/runtime/registry 回归收口。
+- 运行 `pr_scope_guard` 与 `open_pr --dry-run`，确认 implementation PR carrier 干净。
+- 推送当前分支并创建 PR。
+- 提交 reviewer / guardian，若未获 `APPROVE`，优先做同类阻断复盘而不是逐条被动补丁。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -57,18 +56,32 @@
 ## 当前事项在 sprint 中的角色 / 阻塞
 
 - 角色：清理主干既有回归噪音，恢复 FR-0007 相关 gate 的可信基线。
-- 阻塞：待实现修复并完成回归验证后进入 PR / guardian。
+- 阻塞：待 PR、review、guardian 与 merge gate 收口。
 
 ## 已验证项
 
 - `gh issue create` 已创建 Work Item `#179`
 - `python3 scripts/create_worktree.py --issue 179 --class implementation`
   - 结果：已创建 worktree `/Users/mc/code/worktrees/syvert/issue-179-fr-0007`
+- `python3 -m unittest -q tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_success_envelope_leak_to_shared_result_contract tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_exception_failure_return_to_shared_error_model tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_keeps_non_envelope_execute_task_statement_in_core_runtime tests.runtime.test_real_adapter_regression.RealAdapterRegressionTests.test_end_to_end_real_adapter_regression_report_feeds_version_gate`
+  - 结果：`Ran 4 tests in 24.822s`，`OK`
+- `python3 -m unittest -q tests.runtime.test_executor tests.runtime.test_runtime tests.runtime.test_registry`
+  - 结果：`Ran 48 tests in 0.020s`，`OK`
+- `python3 -m unittest -q tests.runtime.test_real_adapter_regression`
+  - 结果：`Ran 20 tests in 0.185s`，`OK`
+- `python3 -m unittest -q tests.runtime.test_version_gate`
+  - 结果：`Ran 99 tests in 30.849s`，`OK`
+- `python3 -m unittest -q tests.runtime.test_platform_leakage`
+  - 结果：`Ran 111 tests in 775.039s`，`OK (skipped=6)`
+- `python3 -m unittest -q tests.runtime.test_platform_leakage tests.runtime.test_version_gate tests.runtime.test_real_adapter_regression`
+  - 结果：`Ran 229 tests in 823.275s`，`OK (skipped=6)`
+- `python3 -m py_compile syvert/platform_leakage.py tests/runtime/test_platform_leakage.py tests/runtime/platform_leakage_fixtures.py tests/runtime/test_real_adapter_regression.py tests/runtime/test_version_gate.py`
+  - 结果：通过
 
 ## 未决风险
 
-- `platform_leakage` 当前按行号归类，若 override 设计不精确，可能影响非 `execute_task()` 语句的既有边界判断。
-- 测试 helper 抽取如果直接复用测试类静态方法，容易引入循环依赖；需要落独立 fixture 模块。
+- `tests.runtime.test_platform_leakage` 全量回归耗时较长；后续 guardian / closeout 需要避免把该慢用例误判为卡死。
+- 当前实现只修复 FR-0007 历史回归噪音，不触碰 formal spec 与 `version_gate` validator；后续若发现新的 evidence drift，应继续向共享 fixture 收敛，而不是放宽 contract。
 
 ## 回滚方式
 
@@ -76,4 +89,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `2c71a6d1be6eb965198cd984f2bcb17439ae6a02`
+- `cb5eaadbeff4cd3efa9a8f235cb72ef6297ddc85`

--- a/syvert/platform_leakage.py
+++ b/syvert/platform_leakage.py
@@ -307,29 +307,45 @@ def _build_boundary_resolver(relative_name: str, source_text: str) -> Any:
 def _collect_runtime_statement_boundary_overrides(module: ast.Module) -> list[tuple[int, int, str]]:
     ranges: list[tuple[int, int, str]] = []
     for node in module.body:
-        if not isinstance(node, ast.FunctionDef) or node.name != "execute_task":
+        if not isinstance(node, ast.FunctionDef) or node.name != "execute_task_internal":
             continue
         for statement in sorted(
-            (child for child in ast.walk(node) if isinstance(child, ast.Return)),
+            (
+                child
+                for child in ast.walk(node)
+                if isinstance(child, (ast.Assign, ast.AnnAssign, ast.Return))
+            ),
             key=lambda child: (child.lineno, getattr(child, "end_lineno", child.lineno)),
         ):
-            boundary = _classify_execute_task_return_boundary(statement)
+            boundary = _classify_execute_task_statement_boundary(statement)
             if boundary is None:
                 continue
             ranges.append((statement.lineno, getattr(statement, "end_lineno", statement.lineno), boundary))
     return ranges
 
 
-def _classify_execute_task_return_boundary(statement: ast.Return) -> str | None:
-    if _is_failure_envelope_return(statement):
+def _classify_execute_task_statement_boundary(statement: ast.stmt) -> str | None:
+    value = _statement_value(statement)
+    if isinstance(statement, ast.Return) and _return_contains_failure_envelope(value):
         return "shared_error_model"
-    if _is_success_envelope_return(statement):
+    if isinstance(statement, (ast.Assign, ast.AnnAssign)) and _is_failure_envelope_expr(value):
+        return "shared_error_model"
+    if _is_success_envelope_expr(value):
         return "shared_result_contract"
     return None
 
 
-def _is_failure_envelope_return(statement: ast.Return) -> bool:
-    value = statement.value
+def _statement_value(statement: ast.stmt) -> ast.AST | None:
+    if isinstance(statement, ast.Return):
+        return statement.value
+    if isinstance(statement, ast.Assign):
+        return statement.value
+    if isinstance(statement, ast.AnnAssign):
+        return statement.value
+    return None
+
+
+def _is_failure_envelope_expr(value: ast.AST | None) -> bool:
     return (
         isinstance(value, ast.Call)
         and isinstance(value.func, ast.Name)
@@ -337,8 +353,13 @@ def _is_failure_envelope_return(statement: ast.Return) -> bool:
     )
 
 
-def _is_success_envelope_return(statement: ast.Return) -> bool:
-    value = statement.value
+def _return_contains_failure_envelope(value: ast.AST | None) -> bool:
+    if value is None:
+        return False
+    return any(_is_failure_envelope_expr(node) for node in ast.walk(value))
+
+
+def _is_success_envelope_expr(value: ast.AST | None) -> bool:
     if not isinstance(value, ast.Dict):
         return False
     keys = {key.value for key in value.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}

--- a/tests/runtime/platform_leakage_fixtures.py
+++ b/tests/runtime/platform_leakage_fixtures.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+
+def canonical_platform_leakage_evidence_refs() -> list[str]:
+    return [
+        "platform_leakage:scan:syvert/registry.py",
+        "platform_leakage:scan:syvert/runtime.py",
+        "platform_leakage:scan:syvert/version_gate.py",
+    ]
+
+
+def canonical_platform_leakage_payload(*, version: str = "v0.2.0") -> dict[str, object]:
+    return {
+        "version": version,
+        "boundary_scope": [
+            "core_runtime",
+            "shared_input_model",
+            "shared_error_model",
+            "adapter_registry",
+            "shared_result_contract",
+            "version_gate_logic",
+        ],
+        "verdict": "pass",
+        "summary": "platform leakage checks are clean",
+        "findings": [],
+        "evidence_refs": canonical_platform_leakage_evidence_refs(),
+    }

--- a/tests/runtime/test_platform_leakage.py
+++ b/tests/runtime/test_platform_leakage.py
@@ -125,6 +125,24 @@ class PlatformLeakageTests(unittest.TestCase):
         self.assertIn("single_platform_shared_semantic", {item["code"] for item in report["details"]["findings"]})
         self.assertEqual({item["boundary"] for item in report["details"]["findings"]}, {"shared_result_contract"})
 
+    def test_run_check_maps_direct_failure_return_to_shared_error_model(self) -> None:
+        report = self.run_with_fixture(
+            {
+                "syvert/runtime.py": (
+                    '                invalid_input_error("invalid_task_request", "task_request 顶层形状不合法"),\n',
+                    '                invalid_input_error(\n'
+                    '                    "invalid_task_request",\n'
+                    '                    "task_request 顶层形状不合法",\n'
+                    '                    details={"xhs_extra": "1"},\n'
+                    "                ),\n",
+                )
+            }
+        )
+
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn("single_platform_shared_semantic", {item["code"] for item in report["details"]["findings"]})
+        self.assertEqual({item["boundary"] for item in report["details"]["findings"]}, {"shared_error_model"})
+
     def test_run_check_maps_exception_failure_return_to_shared_error_model(self) -> None:
         report = self.run_with_fixture(
             {
@@ -139,6 +157,20 @@ class PlatformLeakageTests(unittest.TestCase):
         self.assertEqual(report["verdict"], "fail")
         self.assertIn("single_platform_shared_semantic", {item["code"] for item in report["details"]["findings"]})
         self.assertEqual({item["boundary"] for item in report["details"]["findings"]}, {"shared_error_model"})
+
+    def test_run_check_keeps_non_envelope_execute_task_statement_in_core_runtime(self) -> None:
+        report = self.run_with_fixture(
+            {
+                "syvert/runtime.py": (
+                    "    supported_targets = declaration.supported_targets\n",
+                    '    runtime_platform_hint = "xhs"\n    supported_targets = declaration.supported_targets\n',
+                )
+            }
+        )
+
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn("single_platform_shared_semantic", {item["code"] for item in report["details"]["findings"]})
+        self.assertEqual({item["boundary"] for item in report["details"]["findings"]}, {"core_runtime"})
 
     def test_run_check_fails_closed_when_boundary_scope_is_incomplete(self) -> None:
         report = run_platform_leakage_check(

--- a/tests/runtime/test_real_adapter_regression.py
+++ b/tests/runtime/test_real_adapter_regression.py
@@ -16,6 +16,7 @@ from syvert.version_gate import (
     validate_platform_leakage_source_report,
     validate_real_adapter_regression_source_report,
 )
+from tests.runtime.platform_leakage_fixtures import canonical_platform_leakage_payload
 
 
 class ShapeContractSpoofAdapter:
@@ -626,21 +627,7 @@ class RealAdapterRegressionTests(unittest.TestCase):
 
     @staticmethod
     def valid_platform_leakage_payload() -> dict[str, object]:
-        return {
-            "version": "v0.2.0",
-            "boundary_scope": [
-                "core_runtime",
-                "shared_input_model",
-                "shared_error_model",
-                "adapter_registry",
-                "shared_result_contract",
-                "version_gate_logic",
-            ],
-            "verdict": "pass",
-            "summary": "platform leakage checks are clean",
-            "findings": [],
-            "evidence_refs": ["leakage:scan:1"],
-        }
+        return canonical_platform_leakage_payload()
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_version_gate.py
+++ b/tests/runtime/test_version_gate.py
@@ -19,6 +19,7 @@ from syvert.version_gate import (
     validate_platform_leakage_source_report,
     validate_real_adapter_regression_source_report,
 )
+from tests.runtime.platform_leakage_fixtures import canonical_platform_leakage_payload
 
 
 DEFAULT_REQUIRED_HARNESS_SAMPLE_IDS = ["sample-success", "sample-legal-failure"]
@@ -2459,25 +2460,7 @@ class VersionGateTests(unittest.TestCase):
 
     @staticmethod
     def valid_platform_leakage_payload() -> dict[str, object]:
-        return {
-            "version": "v0.2.0",
-            "boundary_scope": [
-                "core_runtime",
-                "shared_input_model",
-                "shared_error_model",
-                "adapter_registry",
-                "shared_result_contract",
-                "version_gate_logic",
-            ],
-            "verdict": "pass",
-            "summary": "platform leakage checks are clean",
-            "findings": [],
-            "evidence_refs": [
-                "platform_leakage:scan:syvert/registry.py",
-                "platform_leakage:scan:syvert/runtime.py",
-                "platform_leakage:scan:syvert/version_gate.py",
-            ],
-        }
+        return canonical_platform_leakage_payload()
 
     def assert_source_report_contract_shape(self, source: str, report: dict[str, object]) -> None:
         self.assertEqual(report["source"], source)


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：修复 FR-0007 历史实现漂移导致的 3 个主干既有失败，恢复平台泄漏检查与 version gate 的可信基线。
- 主要改动：
  - 把 `platform_leakage` 对 `execute_task` / `execute_task_internal` 的 boundary attribution 从“只看 return”收紧为“识别 success/failure envelope 语句值”。
  - 抽出共享 `platform_leakage` canonical test fixture，统一 `test_version_gate` 与 `test_real_adapter_regression` 的 `evidence_refs` 真相源。
  - 补一条对照回归，固定非 envelope 的普通 runtime 语句仍归 `core_runtime`。

## Issue 摘要

- 目标：修复 `platform_leakage` success/failure envelope 归类漂移，以及 `real_adapter_regression -> version_gate` 的 evidence refs 夹具漂移。
- 非目标：不改 formal spec，不放宽 `version_gate` validator，不触碰 FR-0010/FR-0011/FR-0012。

## 关联事项

- Issue: #179
- item_key: `CHORE-0135-fr-0007-regression-baseline-repair`
- item_type: `CHORE`
- release: `v0.4.0`
- sprint: `2026-S17`
- Closing: Fixes #179

## 风险

- 风险级别：`normal`
- 审查关注：
  - `platform_leakage` 的 statement-level override 只应命中 success/failure envelope，不应把普通 runtime 语句误归到 shared boundary。
  - canonical platform leakage payload fixture 后续应继续作为单一测试真相源，避免再次出现 `evidence_refs` 漂移副本。

## 验证

- 已执行：
  - `python3 -m unittest -q tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_success_envelope_leak_to_shared_result_contract tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_maps_exception_failure_return_to_shared_error_model tests.runtime.test_platform_leakage.PlatformLeakageTests.test_run_check_keeps_non_envelope_execute_task_statement_in_core_runtime tests.runtime.test_real_adapter_regression.RealAdapterRegressionTests.test_end_to_end_real_adapter_regression_report_feeds_version_gate`
  - `python3 -m unittest -q tests.runtime.test_executor tests.runtime.test_runtime tests.runtime.test_registry`
  - `python3 -m unittest -q tests.runtime.test_real_adapter_regression`
  - `python3 -m unittest -q tests.runtime.test_version_gate`
  - `python3 -m unittest -q tests.runtime.test_platform_leakage`
  - `python3 -m unittest -q tests.runtime.test_platform_leakage tests.runtime.test_version_gate tests.runtime.test_real_adapter_regression`
  - `python3 -m py_compile syvert/platform_leakage.py tests/runtime/test_platform_leakage.py tests/runtime/platform_leakage_fixtures.py tests/runtime/test_real_adapter_regression.py tests/runtime/test_version_gate.py`
- 未执行：
  - guardian / merge gate

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: check_required
- shared_contract_changed: yes
- integration_ref: MC-and-his-Agents/Syvert#67
- external_dependency: none
- merge_gate: integration_check_required
- contract_surface: raw_normalized
- joint_acceptance_needed: no
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: yes
补充说明：

- 这是 FR-0007 历史实现回归修复，不新增 formal requirement，只把主干实现与既有 contract 拉回一致。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
