### PR TITLE
feat(runtime): 收口 FR-0012 资源包注入与参考适配器

### DIFF
--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -39,7 +39,7 @@
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
 - 当前受审 PR：`#182`
-- 当前实现 checkpoint：`062567d75c883ef6067e81c2bd6fe9c61b20026b`
+- 当前实现 checkpoint：`11bf9a948fef69d96be5c261dfc241aa09609776`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
   - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
@@ -56,12 +56,13 @@
     - 新增 `syvert/resource_bootstrap.py` 与 `syvert/resource_bootstrap_cli.py`，为真实 host-side 执行面提供受支持的 managed resource bootstrap / migration 路径
     - bootstrap 入口允许两种 account 来源：直接提供 canonical account material JSON，或读取 legacy `xhs` / `douyin` session 文件并迁移为 canonical account.material；两种路径都会在写入 store 前按 adapter runtime contract 做 host-side 校验
     - bootstrap 入口只在 host-side 解析默认 lifecycle store；adapter 层仍只消费 Core 注入的 `resource_bundle`，不重新打开 session-file 执行来源面
+    - bootstrap 入口最终落在 `syvert/` runtime 包内，而不是 `scripts/` governance 面，确保 `implementation` PR 的路径分类与交付边界保持一致
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
 
 ## 下一步动作
 
 - 推送包含 bootstrap / migration 入口的新 head，并同步 PR 描述中的 rollout truth。
-- 基于 `062567d75c883ef6067e81c2bd6fe9c61b20026b` 重新提交 guardian。
+- 基于 `11bf9a948fef69d96be5c261dfc241aa09609776` 重新提交 guardian。
 - 若 guardian 转为 `APPROVE`，直接进入受控 `merge_pr`。
 - 若仍有阻断，继续优先检查 host-side rollout / lifecycle truth 是否存在新的 contract 漂移。
 
@@ -89,8 +90,12 @@
   - 结果：`Ran 5 tests in 0.318s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 311 tests in 40.169s`，`OK`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
+  - 结果：`Ran 311 tests in 39.455s`，`OK`
 - `python3 -m py_compile syvert/resource_bootstrap.py syvert/resource_bootstrap_cli.py tests/runtime/test_resource_bootstrap.py`
   - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main`
+  - 结果：通过（最新 head 已不再触碰 `scripts/` governance 路径）
 - `python3 -m unittest tests.runtime.test_platform_leakage`
   - 结果：`Ran 111 tests in 990.270s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_runtime`

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -39,20 +39,23 @@
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
 - 当前受审 PR：`#182`
-- 当前实现 checkpoint：`8a2fa76e8292ad5fd8bc272d14449856d4628f53`
+- 当前实现 checkpoint：`0684d42d4d18eccb878290d3aea8ebf3e2b6b200`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
   - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
   - `release()` 失败会覆盖原始 adapter success / failure；非法 hint 与 pre-adapter bundle 校验失败都会先 settle 已 acquire 的 lease。
   - xhs / douyin reference adapter 已改为只接受 `AdapterExecutionContext`，执行材料只从 `resource_bundle.account.material` 派生。
   - runtime / CLI / contract harness / reference regression / version gate 均已接入 host-side resource store seed，避免 hybrid canonical 路径在测试中漂移到 `resource_unavailable`。
+  - guardian 首轮 review 指出的两条阻断已收口：
+    - host-side bundle 校验现在会绑定 live active lease truth，并在 cleanup 时始终 release 解析出的真实 lease，而不是盲信注入 bundle 的 `lease_id`
+    - 非法 `resource_disposition_hint` 已统一回到 `invalid_input / invalid_resource_disposition_hint`
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
 
 ## 下一步动作
 
-- 运行 `open_pr --dry-run` 校对 PR carrier，并推送当前分支。
-- 创建 implementation PR，补 reviewer / guardian 审查。
-- 若 guardian 未给出 `APPROVE`，优先按同类阻断聚类收口；通过后使用受控 `merge_pr` 执行 squash merge。
+- 基于 `0684d42d4d18eccb878290d3aea8ebf3e2b6b200` 重新提交 guardian。
+- 若 guardian 转为 `APPROVE`，直接进入受控 `merge_pr`。
+- 若仍有阻断，继续按同类 lifecycle truth / cleanup contract 聚类收口。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -67,7 +70,7 @@
 
 - `gh issue create` 已创建 Work Item `#181`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate`
-  - 结果：`Ran 294 tests in 42.461s`，`OK`
+  - 结果：`Ran 295 tests in 40.994s`，`OK`
 - `python3 -m unittest tests.runtime.test_platform_leakage`
   - 结果：`Ran 111 tests in 955.860s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_runtime`
@@ -76,6 +79,11 @@
   - 结果：通过
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main`
   - 结果：通过
+- `python3 scripts/pr_guardian.py review 182 --post-review`
+  - 结果：首轮 `REQUEST_CHANGES`
+  - 已修复阻断：
+    - host-side bundle 校验新增 live active lease 绑定，拒绝 bundle `lease_id` / `bundle_id` / slot resource ids 与真实 lease 漂移，并在 cleanup 时 release 真实 lease
+    - `resource_disposition_hint` 的类型、缺字段、lease mismatch、非法 `target_status_after_release` 统一映射为 `invalid_input / invalid_resource_disposition_hint`
 
 ## 未决风险
 
@@ -89,5 +97,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `8a2fa76e8292ad5fd8bc272d14449856d4628f53`
+- `0684d42d4d18eccb878290d3aea8ebf3e2b6b200`
 - 当前回合已进入 `metadata-only closeout follow-up`；后续 PR / review / merge gate 元数据同步不要求该 checkpoint SHA 与最新 HEAD 完全一致。

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -39,7 +39,7 @@
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
 - 当前受审 PR：`#182`
-- 当前实现 checkpoint：`0684d42d4d18eccb878290d3aea8ebf3e2b6b200`
+- 当前实现 checkpoint：`44ebe38f2a7e9d13cd239afe130407ee7272c06f`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
   - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
@@ -49,11 +49,14 @@
   - guardian 首轮 review 指出的两条阻断已收口：
     - host-side bundle 校验现在会绑定 live active lease truth，并在 cleanup 时始终 release 解析出的真实 lease，而不是盲信注入 bundle 的 `lease_id`
     - 非法 `resource_disposition_hint` 已统一回到 `invalid_input / invalid_resource_disposition_hint`
+  - guardian 第二轮 review 指出的两条阻断已收口：
+    - host-side bundle 校验现在会同时绑定 `acquired_at` 与 slot `ResourceRecord` 全量 truth，拒绝被篡改的执行材料进入 adapter
+    - `run_real_adapter_regression()` 与 `run_contract_harness_automation()` 已改为在 clean environment 下显式创建临时 lifecycle store 并 seed 必需资源，不再依赖环境里的隐式 host truth
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
 
 ## 下一步动作
 
-- 基于 `0684d42d4d18eccb878290d3aea8ebf3e2b6b200` 重新提交 guardian。
+- 基于 `44ebe38f2a7e9d13cd239afe130407ee7272c06f` 重新提交 guardian。
 - 若 guardian 转为 `APPROVE`，直接进入受控 `merge_pr`。
 - 若仍有阻断，继续按同类 lifecycle truth / cleanup contract 聚类收口。
 
@@ -71,6 +74,10 @@
 - `gh issue create` 已创建 Work Item `#181`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate`
   - 结果：`Ran 295 tests in 40.994s`，`OK`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_real_adapter_regression tests.runtime.test_contract_harness_automation tests.runtime.test_version_gate`
+  - 结果：`Ran 177 tests in 34.528s`，`OK`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate`
+  - 结果：`Ran 306 tests in 40.860s`，`OK`
 - `python3 -m unittest tests.runtime.test_platform_leakage`
   - 结果：`Ran 111 tests in 955.860s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_runtime`
@@ -84,6 +91,10 @@
   - 已修复阻断：
     - host-side bundle 校验新增 live active lease 绑定，拒绝 bundle `lease_id` / `bundle_id` / slot resource ids 与真实 lease 漂移，并在 cleanup 时 release 真实 lease
     - `resource_disposition_hint` 的类型、缺字段、lease mismatch、非法 `target_status_after_release` 统一映射为 `invalid_input / invalid_resource_disposition_hint`
+  - 结果：第二轮 `REQUEST_CHANGES`
+  - 已修复阻断：
+    - host-side bundle 校验新增 `acquired_at` 与完整 slot `ResourceRecord` truth 比对，篡改的 `material` / `acquired_at` 会在进入 adapter 前 fail-closed
+    - public harness / regression host 已显式 provision 临时 resource lifecycle store，并新增 clean-environment automation / regression 回归
 
 ## 未决风险
 
@@ -97,5 +108,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `0684d42d4d18eccb878290d3aea8ebf3e2b6b200`
+- `44ebe38f2a7e9d13cd239afe130407ee7272c06f`
 - 当前回合已进入 `metadata-only closeout follow-up`；后续 PR / review / merge gate 元数据同步不要求该 checkpoint SHA 与最新 HEAD 完全一致。

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S17`
 - 关联 spec：`docs/specs/FR-0012-core-injected-resource-bundle/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#182`
 - active 收口事项：`CHORE-0136-fr-0012-runtime-adapter-closeout`
 
 ## 目标
@@ -38,6 +38,7 @@
 - 当前执行现场：`/Users/mc/code/worktrees/syvert/issue-181-fr-0012-core-reference-adapter`
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
+- 当前受审 PR：`#182`
 - 当前实现 checkpoint：`8a2fa76e8292ad5fd8bc272d14449856d4628f53`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -53,7 +53,7 @@
     - host-side bundle 校验现在会同时绑定 `acquired_at` 与 slot `ResourceRecord` 全量 truth，拒绝被篡改的执行材料进入 adapter
     - `run_real_adapter_regression()` 与 `run_contract_harness_automation()` 已改为在 clean environment 下显式创建临时 lifecycle store 并 seed 必需资源，不再依赖环境里的隐式 host truth
   - guardian 第三轮 review 指出的阻断已收口：
-    - 新增 `syvert/resource_bootstrap.py` 与 `scripts/bootstrap_resource_lifecycle_store.py`，为真实 host-side 执行面提供受支持的 managed resource bootstrap / migration 路径
+    - 新增 `syvert/resource_bootstrap.py` 与 `syvert/resource_bootstrap_cli.py`，为真实 host-side 执行面提供受支持的 managed resource bootstrap / migration 路径
     - bootstrap 入口允许两种 account 来源：直接提供 canonical account material JSON，或读取 legacy `xhs` / `douyin` session 文件并迁移为 canonical account.material；两种路径都会在写入 store 前按 adapter runtime contract 做 host-side 校验
     - bootstrap 入口只在 host-side 解析默认 lifecycle store；adapter 层仍只消费 Core 注入的 `resource_bundle`，不重新打开 session-file 执行来源面
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
@@ -89,7 +89,7 @@
   - 结果：`Ran 5 tests in 0.318s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 311 tests in 40.169s`，`OK`
-- `python3 -m py_compile syvert/resource_bootstrap.py scripts/bootstrap_resource_lifecycle_store.py tests/runtime/test_resource_bootstrap.py`
+- `python3 -m py_compile syvert/resource_bootstrap.py syvert/resource_bootstrap_cli.py tests/runtime/test_resource_bootstrap.py`
   - 结果：通过
 - `python3 -m unittest tests.runtime.test_platform_leakage`
   - 结果：`Ran 111 tests in 990.270s`，`OK (skipped=6)`
@@ -110,7 +110,7 @@
     - public harness / regression host 已显式 provision 临时 resource lifecycle store，并新增 clean-environment automation / regression 回归
   - 结果：第三轮 `REQUEST_CHANGES`
   - 已修复阻断：
-    - 增加受支持的非测试 bootstrap / migration 路径：`scripts/bootstrap_resource_lifecycle_store.py` 可把 canonical account material JSON 或 legacy session 文件迁移为 host-side managed `account` 资源，并与 `proxy` 资源一起 seed 到默认 lifecycle store
+    - 增加受支持的非测试 bootstrap / migration 路径：`python3 -m syvert.resource_bootstrap_cli` 可把 canonical account material JSON 或 legacy session 文件迁移为 host-side managed `account` 资源，并与 `proxy` 资源一起 seed 到默认 lifecycle store
     - 新增 `tests.runtime.test_resource_bootstrap`，覆盖 canonical material 校验、legacy session migration、store seed 与脚本级 bootstrap 回归
 
 ## 支持的 rollout / bootstrap 流程
@@ -119,8 +119,8 @@
   - canonical account material JSON：直接传 `--account-material-file`
   - legacy session 文件迁移：传 `--account-session-file`，脚本会按当前 adapter runtime contract 归一化为 canonical `account.material`
 - bootstrap 命令固定通过 host-side 入口执行，例如：
-  - `python3 scripts/bootstrap_resource_lifecycle_store.py --adapter xhs --account-resource-id xhs-account-main --account-session-file ~/.config/syvert/xhs.session.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
-  - `python3 scripts/bootstrap_resource_lifecycle_store.py --adapter douyin --account-resource-id douyin-account-main --account-material-file ./ops/douyin-account.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
+  - `python3 -m syvert.resource_bootstrap_cli --adapter xhs --account-resource-id xhs-account-main --account-session-file ~/.config/syvert/xhs.session.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
+  - `python3 -m syvert.resource_bootstrap_cli --adapter douyin --account-resource-id douyin-account-main --account-material-file ./ops/douyin-account.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
 - store 位置默认继续遵循 `SYVERT_RESOURCE_LIFECYCLE_STORE_FILE` / `~/.syvert/resource-lifecycle.json`；若需要显式切换文件，可追加 `--store-file <path>`。
 
 ## 未决风险

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -39,7 +39,7 @@
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
 - 当前受审 PR：`#182`
-- 当前实现 checkpoint：`44ebe38f2a7e9d13cd239afe130407ee7272c06f`
+- 当前实现 checkpoint：`062567d75c883ef6067e81c2bd6fe9c61b20026b`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
   - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
@@ -52,13 +52,18 @@
   - guardian 第二轮 review 指出的两条阻断已收口：
     - host-side bundle 校验现在会同时绑定 `acquired_at` 与 slot `ResourceRecord` 全量 truth，拒绝被篡改的执行材料进入 adapter
     - `run_real_adapter_regression()` 与 `run_contract_harness_automation()` 已改为在 clean environment 下显式创建临时 lifecycle store 并 seed 必需资源，不再依赖环境里的隐式 host truth
+  - guardian 第三轮 review 指出的阻断已收口：
+    - 新增 `syvert/resource_bootstrap.py` 与 `scripts/bootstrap_resource_lifecycle_store.py`，为真实 host-side 执行面提供受支持的 managed resource bootstrap / migration 路径
+    - bootstrap 入口允许两种 account 来源：直接提供 canonical account material JSON，或读取 legacy `xhs` / `douyin` session 文件并迁移为 canonical account.material；两种路径都会在写入 store 前按 adapter runtime contract 做 host-side 校验
+    - bootstrap 入口只在 host-side 解析默认 lifecycle store；adapter 层仍只消费 Core 注入的 `resource_bundle`，不重新打开 session-file 执行来源面
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
 
 ## 下一步动作
 
-- 基于 `44ebe38f2a7e9d13cd239afe130407ee7272c06f` 重新提交 guardian。
+- 推送包含 bootstrap / migration 入口的新 head，并同步 PR 描述中的 rollout truth。
+- 基于 `062567d75c883ef6067e81c2bd6fe9c61b20026b` 重新提交 guardian。
 - 若 guardian 转为 `APPROVE`，直接进入受控 `merge_pr`。
-- 若仍有阻断，继续按同类 lifecycle truth / cleanup contract 聚类收口。
+- 若仍有阻断，继续优先检查 host-side rollout / lifecycle truth 是否存在新的 contract 漂移。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -80,6 +85,14 @@
   - 结果：`Ran 306 tests in 40.860s`，`OK`
 - `python3 -m unittest tests.runtime.test_platform_leakage`
   - 结果：`Ran 111 tests in 955.860s`，`OK (skipped=6)`
+- `python3 -m unittest tests.runtime.test_resource_bootstrap`
+  - 结果：`Ran 5 tests in 0.318s`，`OK`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
+  - 结果：`Ran 311 tests in 40.169s`，`OK`
+- `python3 -m py_compile syvert/resource_bootstrap.py scripts/bootstrap_resource_lifecycle_store.py tests/runtime/test_resource_bootstrap.py`
+  - 结果：通过
+- `python3 -m unittest tests.runtime.test_platform_leakage`
+  - 结果：`Ran 111 tests in 990.270s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_runtime`
   - 结果：`Ran 46 tests in 0.123s`，`OK`
 - `python3 -m py_compile syvert/runtime.py syvert/adapters/xhs.py syvert/adapters/douyin.py tests/runtime/test_runtime.py tests/runtime/test_xhs_adapter.py tests/runtime/test_douyin_adapter.py tests/runtime/test_cli.py tests/runtime/test_real_adapter_regression.py tests/runtime/test_version_gate.py tests/runtime/resource_fixtures.py`
@@ -95,6 +108,20 @@
   - 已修复阻断：
     - host-side bundle 校验新增 `acquired_at` 与完整 slot `ResourceRecord` truth 比对，篡改的 `material` / `acquired_at` 会在进入 adapter 前 fail-closed
     - public harness / regression host 已显式 provision 临时 resource lifecycle store，并新增 clean-environment automation / regression 回归
+  - 结果：第三轮 `REQUEST_CHANGES`
+  - 已修复阻断：
+    - 增加受支持的非测试 bootstrap / migration 路径：`scripts/bootstrap_resource_lifecycle_store.py` 可把 canonical account material JSON 或 legacy session 文件迁移为 host-side managed `account` 资源，并与 `proxy` 资源一起 seed 到默认 lifecycle store
+    - 新增 `tests.runtime.test_resource_bootstrap`，覆盖 canonical material 校验、legacy session migration、store seed 与脚本级 bootstrap 回归
+
+## 支持的 rollout / bootstrap 流程
+
+- 对真实 host-side 运行面，先准备一个 `proxy` JSON 文件，再为每个 reference adapter 选择以下任一 account 来源：
+  - canonical account material JSON：直接传 `--account-material-file`
+  - legacy session 文件迁移：传 `--account-session-file`，脚本会按当前 adapter runtime contract 归一化为 canonical `account.material`
+- bootstrap 命令固定通过 host-side 入口执行，例如：
+  - `python3 scripts/bootstrap_resource_lifecycle_store.py --adapter xhs --account-resource-id xhs-account-main --account-session-file ~/.config/syvert/xhs.session.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
+  - `python3 scripts/bootstrap_resource_lifecycle_store.py --adapter douyin --account-resource-id douyin-account-main --account-material-file ./ops/douyin-account.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
+- store 位置默认继续遵循 `SYVERT_RESOURCE_LIFECYCLE_STORE_FILE` / `~/.syvert/resource-lifecycle.json`；若需要显式切换文件，可追加 `--store-file <path>`。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -39,7 +39,7 @@
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
 - 当前受审 PR：`#182`
-- 当前实现 checkpoint：`ddd4cda26f6889b0c0fd332496fe449d1cac1fc3`
+- 当前实现 checkpoint：`59cfd2f8ef2017e8ac507f01aefe8fd2a5a60ca7`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
   - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
@@ -60,13 +60,16 @@
   - guardian 第四轮 review 指出的阻断已收口：
     - shared lifecycle store 中的 `account` 资源现在带 `managed_adapter_key` 受管标签，`acquire()` 只会选择与当前 `adapter_key` 兼容的账号，不再把 xhs / douyin 账号混成同一个无差别池
     - 新增 shared-store 双适配器 bootstrap 回归与 mismatch fail-closed 回归，验证同一份 store 中同时存在 xhs / douyin 账号时不会串号
+  - guardian 第五轮 review 指出的阻断已收口：
+    - 对 reference adapter 的 host-side `account` 选择而言，未带合法 `managed_adapter_key` 的账号 truth 现在也会被视为不兼容；若 store 中不存在与当前 `adapter_key` 兼容的账号，会在进入 adapter 前按 `resource_unavailable` fail-closed
+    - runtime / CLI / contract harness / real adapter regression 的 seed helpers 已统一改为写入 canonical managed account truth，不再用未打标签的 legacy account material 绕过隔离语义
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
 
 ## 下一步动作
 
 - 推送包含 bootstrap / migration 入口的新 head，并同步 PR 描述中的 rollout truth。
-- 推送包含 adapter-aware account 选择修复的新 head，并同步 PR 描述中的 shared-store 隔离真相。
-- 基于 `ddd4cda26f6889b0c0fd332496fe449d1cac1fc3` 重新提交 guardian。
+- 推送包含 untagged account fail-closed 与 canonical managed fixtures 修复的新 head，并同步 PR 描述中的 shared-store 隔离真相。
+- 基于 `59cfd2f8ef2017e8ac507f01aefe8fd2a5a60ca7` 重新提交 guardian。
 - 若 guardian 转为 `APPROVE`，直接进入受控 `merge_pr`。
 - 若仍有阻断，继续优先检查 host-side rollout / lifecycle truth 是否存在新的 contract 漂移。
 
@@ -94,8 +97,12 @@
   - 结果：`Ran 5 tests in 0.318s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 49 tests in 0.409s`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_resource_bootstrap tests.runtime.test_contract_harness_automation tests.runtime.test_real_adapter_regression tests.runtime.test_cli`
+  - 结果：`Ran 132 tests in 2.873s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_lifecycle_store tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 332 tests in 41.452s`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
+  - 结果：`Ran 375 tests in 40.497s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 311 tests in 40.169s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
@@ -108,6 +115,8 @@
   - 结果：通过（最新 head 已不再触碰 `scripts/` governance 路径）
 - `python3 -m unittest tests.runtime.test_platform_leakage`
   - 结果：`Ran 111 tests in 990.270s`，`OK (skipped=6)`
+- `python3 -m unittest tests.runtime.test_platform_leakage`
+  - 结果：`Ran 111 tests in 978.157s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_runtime`
   - 结果：`Ran 46 tests in 0.123s`，`OK`
 - `python3 -m py_compile syvert/runtime.py syvert/adapters/xhs.py syvert/adapters/douyin.py tests/runtime/test_runtime.py tests/runtime/test_xhs_adapter.py tests/runtime/test_douyin_adapter.py tests/runtime/test_cli.py tests/runtime/test_real_adapter_regression.py tests/runtime/test_version_gate.py tests/runtime/resource_fixtures.py`
@@ -131,6 +140,10 @@
   - 已修复阻断：
     - shared lifecycle store 中的 `account` 资源现在带 `managed_adapter_key` 受管标签，`acquire()` 只会选择与当前 `adapter_key` 兼容的账号，不再把 xhs / douyin 账号混成同一个无差别池
     - 新增 shared-store 双适配器 bootstrap 回归与 mismatch fail-closed 回归，验证同一份 store 中同时存在 xhs / douyin 账号时不会串号
+  - 结果：第五轮 `REQUEST_CHANGES`
+  - 已修复阻断：
+    - 对 reference adapter 的 host-side `account` 选择而言，未带合法 `managed_adapter_key` 的账号 truth 现在也会被视为不兼容；若 store 中不存在与当前 `adapter_key` 兼容的账号，会在进入 adapter 前按 `resource_unavailable` fail-closed
+    - runtime / CLI / contract harness / real adapter regression 的 seed helpers 已统一改为写入 canonical managed account truth，并新增验证 legacy untagged account fail-closed 的回归
 
 ## 支持的 rollout / bootstrap 流程
 
@@ -141,6 +154,7 @@
   - `python3 -m syvert.resource_bootstrap_cli --adapter xhs --account-resource-id xhs-account-main --account-session-file ~/.config/syvert/xhs.session.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
   - `python3 -m syvert.resource_bootstrap_cli --adapter douyin --account-resource-id douyin-account-main --account-material-file ./ops/douyin-account.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
 - 同一份 lifecycle store 若同时装入多套 reference adapter 账号，host-side `acquire()` 会只选择 `managed_adapter_key` 与当前 `adapter_key` 一致的 `account` 资源；若只有不兼容账号，则在进入 adapter 前按 `resource_unavailable` fail-closed。
+- 未带合法 `managed_adapter_key` 的 legacy account truth 不再被视为兼容 fallback；reference adapter 需要的执行资源必须通过 canonical managed truth 进入 store。
 - store 位置默认继续遵循 `SYVERT_RESOURCE_LIFECYCLE_STORE_FILE` / `~/.syvert/resource-lifecycle.json`；若需要显式切换文件，可追加 `--store-file <path>`。
 
 ## 未决风险
@@ -155,5 +169,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `ddd4cda26f6889b0c0fd332496fe449d1cac1fc3`
+- `59cfd2f8ef2017e8ac507f01aefe8fd2a5a60ca7`
 - 当前回合已进入 `metadata-only closeout follow-up`；后续 PR / review / merge gate 元数据同步不要求该 checkpoint SHA 与最新 HEAD 完全一致。

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -1,0 +1,92 @@
+# CHORE-0136 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0136-fr-0012-runtime-adapter-closeout`
+- Issue：`#181`
+- item_type：`CHORE`
+- release：`v0.4.0`
+- sprint：`2026-S17`
+- 关联 spec：`docs/specs/FR-0012-core-injected-resource-bundle/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`CHORE-0136-fr-0012-runtime-adapter-closeout`
+
+## 目标
+
+- 在 Core 主执行链中落地 `FR-0012` 的 canonical `AdapterExecutionContext` 与 host-side `ResourceBundle` 注入边界。
+- 冻结 hybrid 资源路径的 acquire / host-side bundle 校验 / release 收口语义，确保 acquire 成功后的任一失败分支都会先 settle lease。
+- 把 xhs / douyin reference adapter 改造为只消费注入的 `resource_bundle`，并完成 runtime、CLI、contract harness、real adapter regression、version gate 的回归闭环。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py`
+  - `syvert/adapters/xhs.py`
+  - `syvert/adapters/douyin.py`
+  - `tests/runtime/resource_fixtures.py`
+  - runtime / CLI / contract harness / real adapter regression / version gate 相关回归
+  - 当前 active `exec-plan`
+- 本次不纳入：
+  - `FR-0012` formal spec 改写
+  - `FR-0011` tracing / usage log
+  - 新 proxy provider / 深度网络栈接入
+  - 资源 DSL 或能力匹配扩展
+
+## 当前停点
+
+- 当前执行现场：`/Users/mc/code/worktrees/syvert/issue-181-fr-0012-core-reference-adapter`
+- 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
+- 当前 Work Item：`#181`
+- 当前实现 checkpoint：`8a2fa76e8292ad5fd8bc272d14449856d4628f53`
+- 当前代码已完成以下收口：
+  - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
+  - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
+  - `release()` 失败会覆盖原始 adapter success / failure；非法 hint 与 pre-adapter bundle 校验失败都会先 settle 已 acquire 的 lease。
+  - xhs / douyin reference adapter 已改为只接受 `AdapterExecutionContext`，执行材料只从 `resource_bundle.account.material` 派生。
+  - runtime / CLI / contract harness / reference regression / version gate 均已接入 host-side resource store seed，避免 hybrid canonical 路径在测试中漂移到 `resource_unavailable`。
+- 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
+
+## 下一步动作
+
+- 运行 `open_pr --dry-run` 校对 PR carrier，并推送当前分支。
+- 创建 implementation PR，补 reviewer / guardian 审查。
+- 若 guardian 未给出 `APPROVE`，优先按同类阻断聚类收口；通过后使用受控 `merge_pr` 执行 squash merge。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.4.0` 收口 `FR-0012` 的 Core 注入资源包与 reference adapter 资源消费边界，使 hybrid 执行路径保持单一 lifecycle truth，并为后续 tracing / 资源扩展保留稳定宿主语义。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0012` implementation Work Item，负责把 formal spec 中的 Core ownership、bundle truth 与 reference adapter 边界真正落到运行时主路径。
+- 阻塞：待 PR、guardian verdict、GitHub checks 与受控 squash merge 收口。
+
+## 已验证项
+
+- `gh issue create` 已创建 Work Item `#181`
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate`
+  - 结果：`Ran 294 tests in 42.461s`，`OK`
+- `python3 -m unittest tests.runtime.test_platform_leakage`
+  - 结果：`Ran 111 tests in 955.860s`，`OK (skipped=6)`
+- `python3 -m unittest tests.runtime.test_runtime`
+  - 结果：`Ran 46 tests in 0.123s`，`OK`
+- `python3 -m py_compile syvert/runtime.py syvert/adapters/xhs.py syvert/adapters/douyin.py tests/runtime/test_runtime.py tests/runtime/test_xhs_adapter.py tests/runtime/test_douyin_adapter.py tests/runtime/test_cli.py tests/runtime/test_real_adapter_regression.py tests/runtime/test_version_gate.py tests/runtime/resource_fixtures.py`
+  - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main`
+  - 结果：通过
+
+## 未决风险
+
+- guardian 仍可能继续收敛到 host-side cleanup / carrier 细节；若出现新阻断，应优先检查是否属于同类 lifecycle truth 漂移，而不是在 adapter 侧补影子语义。
+- `tests.runtime.test_platform_leakage` 耗时较长；guardian / merge gate 阶段需要保留对慢回归的耐心，避免把长跑误判为卡死。
+- 当前实现只冻结 `proxy` 为受管必需 slot 与 bundle truth 的一部分；更深的网络接入能力仍留给后续事项。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项对应的 runtime、reference adapter 与测试调整。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `8a2fa76e8292ad5fd8bc272d14449856d4628f53`
+- 当前回合已进入 `metadata-only closeout follow-up`；后续 PR / review / merge gate 元数据同步不要求该 checkpoint SHA 与最新 HEAD 完全一致。

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -39,7 +39,7 @@
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
 - 当前受审 PR：`#182`
-- 当前实现 checkpoint：`59cfd2f8ef2017e8ac507f01aefe8fd2a5a60ca7`
+- 当前实现 checkpoint：`ca138e95f2d0e5073ae94d3f530f0899d353ca3b`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
   - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
@@ -63,13 +63,16 @@
   - guardian 第五轮 review 指出的阻断已收口：
     - 对 reference adapter 的 host-side `account` 选择而言，未带合法 `managed_adapter_key` 的账号 truth 现在也会被视为不兼容；若 store 中不存在与当前 `adapter_key` 兼容的账号，会在进入 adapter 前按 `resource_unavailable` fail-closed
     - runtime / CLI / contract harness / real adapter regression 的 seed helpers 已统一改为写入 canonical managed account truth，不再用未打标签的 legacy account material 绕过隔离语义
+  - guardian 第六轮 review 指出的阻断已收口：
+    - `resource_is_slot_compatible()` 已对 reference adapter 的 `account` 资源严格 fail-closed：`managed_adapter_key` 缺失、非字符串、空字符串、与当前 `adapter_key` 不匹配，或 `material` 非对象时，都不会再被 `acquire()` 视为兼容账号
+    - `tests.runtime.test_resource_lifecycle` / `tests.runtime.test_resource_lifecycle_store` 已移除自动补标签夹具，并新增显式 legacy untagged fail-closed 回归，确保测试不再掩盖非 canonical managed truth
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
 
 ## 下一步动作
 
 - 推送包含 bootstrap / migration 入口的新 head，并同步 PR 描述中的 rollout truth。
-- 推送包含 untagged account fail-closed 与 canonical managed fixtures 修复的新 head，并同步 PR 描述中的 shared-store 隔离真相。
-- 基于 `59cfd2f8ef2017e8ac507f01aefe8fd2a5a60ca7` 重新提交 guardian。
+- 推送包含 strict untagged fail-closed 与显式 legacy 回归的新 head，并同步 PR 描述中的 shared-store 隔离真相。
+- 基于 `ca138e95f2d0e5073ae94d3f530f0899d353ca3b` 重新提交 guardian。
 - 若 guardian 转为 `APPROVE`，直接进入受控 `merge_pr`。
 - 若仍有阻断，继续优先检查 host-side rollout / lifecycle truth 是否存在新的 contract 漂移。
 
@@ -99,10 +102,14 @@
   - 结果：`Ran 49 tests in 0.409s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_resource_bootstrap tests.runtime.test_contract_harness_automation tests.runtime.test_real_adapter_regression tests.runtime.test_cli`
   - 结果：`Ran 132 tests in 2.873s`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_resource_bootstrap tests.runtime.test_contract_harness_automation tests.runtime.test_real_adapter_regression tests.runtime.test_cli`
+  - 结果：`Ran 133 tests in 3.118s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_lifecycle_store tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 332 tests in 41.452s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 375 tests in 40.497s`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
+  - 结果：`Ran 376 tests in 40.283s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 311 tests in 40.169s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
@@ -117,6 +124,8 @@
   - 结果：`Ran 111 tests in 990.270s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_platform_leakage`
   - 结果：`Ran 111 tests in 978.157s`，`OK (skipped=6)`
+- `python3 -m unittest tests.runtime.test_platform_leakage`
+  - 结果：`Ran 111 tests in 960.825s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_runtime`
   - 结果：`Ran 46 tests in 0.123s`，`OK`
 - `python3 -m py_compile syvert/runtime.py syvert/adapters/xhs.py syvert/adapters/douyin.py tests/runtime/test_runtime.py tests/runtime/test_xhs_adapter.py tests/runtime/test_douyin_adapter.py tests/runtime/test_cli.py tests/runtime/test_real_adapter_regression.py tests/runtime/test_version_gate.py tests/runtime/resource_fixtures.py`
@@ -144,6 +153,10 @@
   - 已修复阻断：
     - 对 reference adapter 的 host-side `account` 选择而言，未带合法 `managed_adapter_key` 的账号 truth 现在也会被视为不兼容；若 store 中不存在与当前 `adapter_key` 兼容的账号，会在进入 adapter 前按 `resource_unavailable` fail-closed
     - runtime / CLI / contract harness / real adapter regression 的 seed helpers 已统一改为写入 canonical managed account truth，并新增验证 legacy untagged account fail-closed 的回归
+  - 结果：第六轮 `REQUEST_CHANGES`
+  - 已修复阻断：
+    - `resource_is_slot_compatible()` 已对 reference adapter 的 `account` 资源严格 fail-closed：`managed_adapter_key` 缺失、非字符串、空字符串、与当前 `adapter_key` 不匹配，或 `material` 非对象时，都不会再被 `acquire()` 视为兼容账号
+    - `tests.runtime.test_resource_lifecycle` / `tests.runtime.test_resource_lifecycle_store` 已移除自动补标签夹具，并新增显式 legacy untagged fail-closed 回归，确保测试不再掩盖非 canonical managed truth
 
 ## 支持的 rollout / bootstrap 流程
 
@@ -155,6 +168,7 @@
   - `python3 -m syvert.resource_bootstrap_cli --adapter douyin --account-resource-id douyin-account-main --account-material-file ./ops/douyin-account.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
 - 同一份 lifecycle store 若同时装入多套 reference adapter 账号，host-side `acquire()` 会只选择 `managed_adapter_key` 与当前 `adapter_key` 一致的 `account` 资源；若只有不兼容账号，则在进入 adapter 前按 `resource_unavailable` fail-closed。
 - 未带合法 `managed_adapter_key` 的 legacy account truth 不再被视为兼容 fallback；reference adapter 需要的执行资源必须通过 canonical managed truth 进入 store。
+- lifecycle / store 直接测试若要覆盖合法 acquire 路径，必须显式 seed 带 `managed_adapter_key` 的 account truth；测试不再通过夹具暗中补标签。
 - store 位置默认继续遵循 `SYVERT_RESOURCE_LIFECYCLE_STORE_FILE` / `~/.syvert/resource-lifecycle.json`；若需要显式切换文件，可追加 `--store-file <path>`。
 
 ## 未决风险
@@ -169,5 +183,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `59cfd2f8ef2017e8ac507f01aefe8fd2a5a60ca7`
+- `ca138e95f2d0e5073ae94d3f530f0899d353ca3b`
 - 当前回合已进入 `metadata-only closeout follow-up`；后续 PR / review / merge gate 元数据同步不要求该 checkpoint SHA 与最新 HEAD 完全一致。

--- a/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
+++ b/docs/exec-plans/CHORE-0136-fr-0012-runtime-adapter-closeout.md
@@ -39,7 +39,7 @@
 - 当前执行分支：`issue-181-fr-0012-core-reference-adapter`
 - 当前 Work Item：`#181`
 - 当前受审 PR：`#182`
-- 当前实现 checkpoint：`11bf9a948fef69d96be5c261dfc241aa09609776`
+- 当前实现 checkpoint：`ddd4cda26f6889b0c0fd332496fe449d1cac1fc3`
 - 当前代码已完成以下收口：
   - `execute_task_internal()` 现在由 Core 持有 hybrid 资源策略、`acquire()`、host-side bundle 校验、adapter-facing capability projection、`resource_disposition_hint` 消费与统一 `release()` 收口。
   - lifecycle truth 的 `capability` 固定保持 `content_detail_by_url`；adapter-facing request 仅在进入 adapter 前投影为 `content_detail`。
@@ -57,12 +57,16 @@
     - bootstrap 入口允许两种 account 来源：直接提供 canonical account material JSON，或读取 legacy `xhs` / `douyin` session 文件并迁移为 canonical account.material；两种路径都会在写入 store 前按 adapter runtime contract 做 host-side 校验
     - bootstrap 入口只在 host-side 解析默认 lifecycle store；adapter 层仍只消费 Core 注入的 `resource_bundle`，不重新打开 session-file 执行来源面
     - bootstrap 入口最终落在 `syvert/` runtime 包内，而不是 `scripts/` governance 面，确保 `implementation` PR 的路径分类与交付边界保持一致
+  - guardian 第四轮 review 指出的阻断已收口：
+    - shared lifecycle store 中的 `account` 资源现在带 `managed_adapter_key` 受管标签，`acquire()` 只会选择与当前 `adapter_key` 兼容的账号，不再把 xhs / douyin 账号混成同一个无差别池
+    - 新增 shared-store 双适配器 bootstrap 回归与 mismatch fail-closed 回归，验证同一份 store 中同时存在 xhs / douyin 账号时不会串号
 - 当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 Work Item 上下文、checkpoint、review 与 merge gate，不要求其静态 SHA 穷尽到后续纯元数据提交。
 
 ## 下一步动作
 
 - 推送包含 bootstrap / migration 入口的新 head，并同步 PR 描述中的 rollout truth。
-- 基于 `11bf9a948fef69d96be5c261dfc241aa09609776` 重新提交 guardian。
+- 推送包含 adapter-aware account 选择修复的新 head，并同步 PR 描述中的 shared-store 隔离真相。
+- 基于 `ddd4cda26f6889b0c0fd332496fe449d1cac1fc3` 重新提交 guardian。
 - 若 guardian 转为 `APPROVE`，直接进入受控 `merge_pr`。
 - 若仍有阻断，继续优先检查 host-side rollout / lifecycle truth 是否存在新的 contract 漂移。
 
@@ -88,11 +92,17 @@
   - 结果：`Ran 111 tests in 955.860s`，`OK (skipped=6)`
 - `python3 -m unittest tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 5 tests in 0.318s`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_bootstrap`
+  - 结果：`Ran 49 tests in 0.409s`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_lifecycle_store tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
+  - 结果：`Ran 332 tests in 41.452s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 311 tests in 40.169s`，`OK`
 - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
   - 结果：`Ran 311 tests in 39.455s`，`OK`
 - `python3 -m py_compile syvert/resource_bootstrap.py syvert/resource_bootstrap_cli.py tests/runtime/test_resource_bootstrap.py`
+  - 结果：通过
+- `python3 -m py_compile syvert/resource_lifecycle.py syvert/resource_bootstrap.py syvert/resource_bootstrap_cli.py tests/runtime/test_resource_lifecycle.py tests/runtime/test_resource_bootstrap.py`
   - 结果：通过
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main`
   - 结果：通过（最新 head 已不再触碰 `scripts/` governance 路径）
@@ -117,6 +127,10 @@
   - 已修复阻断：
     - 增加受支持的非测试 bootstrap / migration 路径：`python3 -m syvert.resource_bootstrap_cli` 可把 canonical account material JSON 或 legacy session 文件迁移为 host-side managed `account` 资源，并与 `proxy` 资源一起 seed 到默认 lifecycle store
     - 新增 `tests.runtime.test_resource_bootstrap`，覆盖 canonical material 校验、legacy session migration、store seed 与脚本级 bootstrap 回归
+  - 结果：第四轮 `REQUEST_CHANGES`
+  - 已修复阻断：
+    - shared lifecycle store 中的 `account` 资源现在带 `managed_adapter_key` 受管标签，`acquire()` 只会选择与当前 `adapter_key` 兼容的账号，不再把 xhs / douyin 账号混成同一个无差别池
+    - 新增 shared-store 双适配器 bootstrap 回归与 mismatch fail-closed 回归，验证同一份 store 中同时存在 xhs / douyin 账号时不会串号
 
 ## 支持的 rollout / bootstrap 流程
 
@@ -126,6 +140,7 @@
 - bootstrap 命令固定通过 host-side 入口执行，例如：
   - `python3 -m syvert.resource_bootstrap_cli --adapter xhs --account-resource-id xhs-account-main --account-session-file ~/.config/syvert/xhs.session.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
   - `python3 -m syvert.resource_bootstrap_cli --adapter douyin --account-resource-id douyin-account-main --account-material-file ./ops/douyin-account.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
+- 同一份 lifecycle store 若同时装入多套 reference adapter 账号，host-side `acquire()` 会只选择 `managed_adapter_key` 与当前 `adapter_key` 一致的 `account` 资源；若只有不兼容账号，则在进入 adapter 前按 `resource_unavailable` fail-closed。
 - store 位置默认继续遵循 `SYVERT_RESOURCE_LIFECYCLE_STORE_FILE` / `~/.syvert/resource-lifecycle.json`；若需要显式切换文件，可追加 `--store-file <path>`。
 
 ## 未决风险
@@ -140,5 +155,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `44ebe38f2a7e9d13cd239afe130407ee7272c06f`
+- `ddd4cda26f6889b0c0fd332496fe449d1cac1fc3`
 - 当前回合已进入 `metadata-only closeout follow-up`；后续 PR / review / merge gate 元数据同步不要求该 checkpoint SHA 与最新 HEAD 完全一致。

--- a/scripts/bootstrap_resource_lifecycle_store.py
+++ b/scripts/bootstrap_resource_lifecycle_store.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from syvert.resource_bootstrap import (
+    bootstrap_resource_store,
+    build_bootstrap_records,
+    load_account_material,
+    load_bootstrap_material,
+)
+from syvert.resource_lifecycle_store import LocalResourceLifecycleStore, default_resource_lifecycle_store
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap managed account/proxy resources into the lifecycle store."
+    )
+    parser.add_argument("--adapter", required=True, choices=("xhs", "douyin"))
+    parser.add_argument("--account-resource-id", required=True)
+    account_source = parser.add_mutually_exclusive_group(required=True)
+    account_source.add_argument("--account-material-file")
+    account_source.add_argument("--account-session-file")
+    parser.add_argument("--proxy-resource-id", required=True)
+    parser.add_argument("--proxy-material-file", required=True)
+    parser.add_argument("--store-file")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        account_material = load_account_material(
+            adapter_key=args.adapter,
+            account_material_file=Path(args.account_material_file) if args.account_material_file else None,
+            account_session_file=Path(args.account_session_file) if args.account_session_file else None,
+        )
+        proxy_material = load_bootstrap_material(Path(args.proxy_material_file))
+        records = build_bootstrap_records(
+            adapter_key=args.adapter,
+            account_resource_id=args.account_resource_id,
+            account_material=account_material,
+            proxy_resource_id=args.proxy_resource_id,
+            proxy_material=proxy_material,
+        )
+        store = LocalResourceLifecycleStore(Path(args.store_file)) if args.store_file else default_resource_lifecycle_store()
+        seeded = bootstrap_resource_store(store=store, records=records)
+    except ValueError as exc:
+        sys.stderr.write(
+            json.dumps(
+                {
+                    "status": "failed",
+                    "error": {
+                        "code": "invalid_bootstrap_input",
+                        "message": str(exc),
+                    },
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "status": "success",
+                "adapter_key": args.adapter,
+                "store_file": str(store.path),
+                "seeded_resource_ids": sorted(record.resource_id for record in seeded),
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/syvert/adapters/douyin.py
+++ b/syvert/adapters/douyin.py
@@ -10,7 +10,7 @@ from urllib import error, parse, request
 
 from syvert.adapters.douyin_browser_bridge import extract_aweme_detail_from_page_state
 from syvert.adapters.douyin_browser_bridge import DouyinAuthenticatedBrowserBridge
-from syvert.runtime import AdapterTaskRequest, CONTENT_DETAIL, PlatformAdapterError, TaskRequest
+from syvert.runtime import AdapterExecutionContext, CONTENT_DETAIL, PlatformAdapterError
 
 
 DOUYIN_API_BASE_URL = "https://www.douyin.com"
@@ -64,10 +64,11 @@ class DouyinAdapter:
         self._detail_transport = detail_transport or default_detail_transport
         self._page_state_transport = page_state_transport or default_page_state_transport
 
-    def execute(self, request: TaskRequest | AdapterTaskRequest) -> dict[str, Any]:
-        input_url = resolve_input_url(request=request)
+    def execute(self, request: AdapterExecutionContext) -> dict[str, Any]:
+        context = resolve_execution_context(request=request)
+        input_url = resolve_input_url(request=context)
         url_info = parse_douyin_detail_url(input_url)
-        session = self._session_provider(self._session_path)
+        session = build_session_config_from_context(context)
         try:
             params = self._build_detail_params(session, url_info)
             raw_response = self._fetch_detail(session, params)
@@ -183,37 +184,82 @@ def build_adapters() -> dict[str, object]:
     return {"douyin": DouyinAdapter()}
 
 
-def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
-    if type(request) is AdapterTaskRequest:
-        if request.capability != CONTENT_DETAIL:
-            raise PlatformAdapterError(
-                code="invalid_douyin_request",
-                message="douyin adapter 不支持该 capability family",
-                details={"capability": request.capability},
-                category="invalid_input",
-            )
-        if request.target_type != "url":
-            raise PlatformAdapterError(
-                code="invalid_douyin_request",
-                message="douyin adapter 仅支持 target_type=url",
-                details={"target_type": request.target_type},
-                category="invalid_input",
-            )
-        if request.collection_mode != "hybrid":
-            raise PlatformAdapterError(
-                code="invalid_douyin_request",
-                message="douyin adapter 仅支持 collection_mode=hybrid",
-                details={"collection_mode": request.collection_mode},
-                category="invalid_input",
-            )
-        return request.target_value
-    if type(request) is TaskRequest:
-        return request.input.url
+def resolve_execution_context(*, request: AdapterExecutionContext) -> AdapterExecutionContext:
+    if type(request) is not AdapterExecutionContext:
+        raise PlatformAdapterError(
+            code="invalid_douyin_request",
+            message="douyin adapter request 顶层形状不合法",
+            details={"request_type": type(request).__name__},
+            category="invalid_input",
+        )
+    if request.request.capability != CONTENT_DETAIL:
+        raise PlatformAdapterError(
+            code="invalid_douyin_request",
+            message="douyin adapter 不支持该 capability family",
+            details={"capability": request.request.capability},
+            category="invalid_input",
+        )
+    if request.request.target_type != "url":
+        raise PlatformAdapterError(
+            code="invalid_douyin_request",
+            message="douyin adapter 仅支持 target_type=url",
+            details={"target_type": request.request.target_type},
+            category="invalid_input",
+        )
+    if request.request.collection_mode != "hybrid":
+        raise PlatformAdapterError(
+            code="invalid_douyin_request",
+            message="douyin adapter 仅支持 collection_mode=hybrid",
+            details={"collection_mode": request.request.collection_mode},
+            category="invalid_input",
+        )
+    return request
+
+
+def resolve_input_url(*, request: AdapterExecutionContext) -> str:
+    if type(request) is AdapterExecutionContext:
+        return request.request.target_value
     raise PlatformAdapterError(
         code="invalid_douyin_request",
         message="douyin adapter request 顶层形状不合法",
         details={"request_type": type(request).__name__},
         category="invalid_input",
+    )
+
+
+def build_session_config_from_context(context: AdapterExecutionContext) -> DouyinSessionConfig:
+    resource_bundle = context.resource_bundle
+    if resource_bundle is None:
+        raise PlatformAdapterError(
+            code="douyin_resource_bundle_missing",
+            message="douyin adapter 需要 Core 注入 resource_bundle",
+            details={},
+            category="invalid_input",
+        )
+    account = resource_bundle.account
+    if account is None:
+        raise PlatformAdapterError(
+            code="douyin_account_material_missing",
+            message="douyin adapter 需要 account 资源",
+            details={},
+            category="invalid_input",
+        )
+    material = account.material
+    if not isinstance(material, Mapping):
+        raise PlatformAdapterError(
+            code="douyin_account_material_missing",
+            message="douyin account.material 必须是对象",
+            details={"actual_type": type(material).__name__},
+            category="invalid_input",
+        )
+    return DouyinSessionConfig(
+        cookies=require_material_string(material, "cookies", error_code="douyin_account_material_missing"),
+        user_agent=require_material_string(material, "user_agent", error_code="douyin_account_material_missing"),
+        verify_fp=optional_string(material.get("verify_fp")),
+        ms_token=optional_string(material.get("ms_token")),
+        webid=optional_string(material.get("webid")),
+        sign_base_url=optional_string(material.get("sign_base_url")),
+        timeout_seconds=coerce_timeout_seconds(material.get("timeout_seconds")),
     )
 
 
@@ -305,6 +351,23 @@ def require_string(data: Mapping[str, Any], field: str, path: Path) -> str:
             code="douyin_session_missing",
             message=f"抖音会话文件缺少 `{field}`",
             details={"session_path": str(path), "field": field},
+        )
+    return value
+
+
+def require_material_string(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    error_code: str,
+) -> str:
+    value = data.get(field)
+    if not isinstance(value, str) or not value:
+        raise PlatformAdapterError(
+            code=error_code,
+            message=f"douyin account.material 缺少 `{field}`",
+            details={"field": field},
+            category="invalid_input",
         )
     return value
 

--- a/syvert/adapters/xhs.py
+++ b/syvert/adapters/xhs.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Mapping
 from urllib import error, parse, request
 
 from syvert.adapters.xhs_browser_bridge import XhsAuthenticatedBrowserBridge
-from syvert.runtime import AdapterTaskRequest, CONTENT_DETAIL, PlatformAdapterError, TaskRequest
+from syvert.runtime import AdapterExecutionContext, CONTENT_DETAIL, PlatformAdapterError
 
 
 XHS_API_BASE_URL = "https://edith.xiaohongshu.com"
@@ -67,10 +67,11 @@ class XhsAdapter:
         self._page_transport = page_transport or default_page_transport
         self._page_state_transport = page_state_transport or default_page_state_transport
 
-    def execute(self, request: TaskRequest | AdapterTaskRequest) -> dict[str, Any]:
-        input_url = resolve_input_url(request=request)
+    def execute(self, request: AdapterExecutionContext) -> dict[str, Any]:
+        context = resolve_execution_context(request=request)
+        input_url = resolve_input_url(request=context)
         url_info = parse_xhs_detail_url(input_url)
-        session = self._session_provider(self._session_path)
+        session = build_session_config_from_context(context)
         body = build_detail_body(url_info)
         try:
             headers = self._build_headers(session, body)
@@ -225,37 +226,79 @@ def build_adapters() -> dict[str, object]:
     return {"xhs": XhsAdapter()}
 
 
-def resolve_input_url(*, request: TaskRequest | AdapterTaskRequest) -> str:
-    if type(request) is AdapterTaskRequest:
-        if request.capability != CONTENT_DETAIL:
-            raise PlatformAdapterError(
-                code="invalid_xhs_request",
-                message="xhs adapter 不支持该 capability family",
-                details={"capability": request.capability},
-                category="invalid_input",
-            )
-        if request.target_type != "url":
-            raise PlatformAdapterError(
-                code="invalid_xhs_request",
-                message="xhs adapter 仅支持 target_type=url",
-                details={"target_type": request.target_type},
-                category="invalid_input",
-            )
-        if request.collection_mode != "hybrid":
-            raise PlatformAdapterError(
-                code="invalid_xhs_request",
-                message="xhs adapter 仅支持 collection_mode=hybrid",
-                details={"collection_mode": request.collection_mode},
-                category="invalid_input",
-            )
-        return request.target_value
-    if type(request) is TaskRequest:
-        return request.input.url
+def resolve_execution_context(*, request: AdapterExecutionContext) -> AdapterExecutionContext:
+    if type(request) is not AdapterExecutionContext:
+        raise PlatformAdapterError(
+            code="invalid_xhs_request",
+            message="xhs adapter request 顶层形状不合法",
+            details={"request_type": type(request).__name__},
+            category="invalid_input",
+        )
+    if request.request.capability != CONTENT_DETAIL:
+        raise PlatformAdapterError(
+            code="invalid_xhs_request",
+            message="xhs adapter 不支持该 capability family",
+            details={"capability": request.request.capability},
+            category="invalid_input",
+        )
+    if request.request.target_type != "url":
+        raise PlatformAdapterError(
+            code="invalid_xhs_request",
+            message="xhs adapter 仅支持 target_type=url",
+            details={"target_type": request.request.target_type},
+            category="invalid_input",
+        )
+    if request.request.collection_mode != "hybrid":
+        raise PlatformAdapterError(
+            code="invalid_xhs_request",
+            message="xhs adapter 仅支持 collection_mode=hybrid",
+            details={"collection_mode": request.request.collection_mode},
+            category="invalid_input",
+        )
+    return request
+
+
+def resolve_input_url(*, request: AdapterExecutionContext) -> str:
+    if type(request) is AdapterExecutionContext:
+        return request.request.target_value
     raise PlatformAdapterError(
         code="invalid_xhs_request",
         message="xhs adapter request 顶层形状不合法",
         details={"request_type": type(request).__name__},
         category="invalid_input",
+    )
+
+
+def build_session_config_from_context(context: AdapterExecutionContext) -> XhsSessionConfig:
+    resource_bundle = context.resource_bundle
+    if resource_bundle is None:
+        raise PlatformAdapterError(
+            code="xhs_resource_bundle_missing",
+            message="xhs adapter 需要 Core 注入 resource_bundle",
+            details={},
+            category="invalid_input",
+        )
+    account = resource_bundle.account
+    if account is None:
+        raise PlatformAdapterError(
+            code="xhs_account_material_missing",
+            message="xhs adapter 需要 account 资源",
+            details={},
+            category="invalid_input",
+        )
+    material = account.material
+    if not isinstance(material, Mapping):
+        raise PlatformAdapterError(
+            code="xhs_account_material_missing",
+            message="xhs account.material 必须是对象",
+            details={"actual_type": type(material).__name__},
+            category="invalid_input",
+        )
+    return XhsSessionConfig(
+        cookies=require_material_string(material, "cookies", error_code="xhs_account_material_missing"),
+        user_agent=require_material_string(material, "user_agent", error_code="xhs_account_material_missing"),
+        sign_base_url=optional_string(material.get("sign_base_url")),
+        timeout_seconds=coerce_timeout_seconds(material.get("timeout_seconds")),
     )
 
 
@@ -364,6 +407,23 @@ def require_string(
             code=error_code,
             message=f"小红书会话文件缺少 `{field}`",
             details={"session_path": str(path), "field": field},
+        )
+    return value
+
+
+def require_material_string(
+    data: Mapping[str, Any],
+    field: str,
+    *,
+    error_code: str,
+) -> str:
+    value = data.get(field)
+    if not isinstance(value, str) or not value:
+        raise PlatformAdapterError(
+            code=error_code,
+            message=f"xhs account.material 缺少 `{field}`",
+            details={"field": field},
+            category="invalid_input",
         )
     return value
 

--- a/syvert/real_adapter_regression.py
+++ b/syvert/real_adapter_regression.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from syvert.adapters.douyin import DouyinAdapter, default_page_state_transport
 from syvert.adapters.xhs import XhsAdapter
-from syvert.resource_lifecycle import ResourceRecord
+from syvert.resource_lifecycle import MANAGED_ACCOUNT_ADAPTER_KEY_FIELD, ResourceRecord
 from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 from syvert.runtime import TaskInput, TaskRequest, execute_task
 from syvert.version_gate import validate_real_adapter_regression_source_report
@@ -125,6 +125,7 @@ def seed_reference_regression_resources(
         account_material = _douyin_account_material()
     else:
         raise ValueError(f"unsupported adapter_key for regression resource seed: {adapter_key}")
+    account_material[MANAGED_ACCOUNT_ADAPTER_KEY_FIELD] = adapter_key
     store.seed_resources(
         [
             ResourceRecord(

--- a/syvert/real_adapter_regression.py
+++ b/syvert/real_adapter_regression.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Mapping
+from pathlib import Path
+import tempfile
 from typing import Any
 
 from syvert.adapters.douyin import DouyinAdapter, default_page_state_transport
 from syvert.adapters.xhs import XhsAdapter
+from syvert.resource_lifecycle import ResourceRecord
+from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 from syvert.runtime import TaskInput, TaskRequest, execute_task
 from syvert.version_gate import validate_real_adapter_regression_source_report
 
@@ -85,6 +89,60 @@ class ReferenceAdapterBindingError(ValueError):
         self.details = dict(details)
 
 
+def _xhs_account_material() -> dict[str, Any]:
+    return {
+        "cookies": "a=1; b=2",
+        "user_agent": "Mozilla/5.0 TestAgent",
+        "sign_base_url": "http://127.0.0.1:8000",
+        "timeout_seconds": 5,
+    }
+
+
+def _douyin_account_material() -> dict[str, Any]:
+    return {
+        "cookies": "a=1; b=2",
+        "user_agent": "Mozilla/5.0 TestAgent",
+        "verify_fp": "verify-1",
+        "ms_token": "ms-token-1",
+        "webid": "webid-1",
+        "sign_base_url": "http://127.0.0.1:8000",
+        "timeout_seconds": 5,
+    }
+
+
+def _proxy_material() -> dict[str, Any]:
+    return {"proxy_endpoint": "http://proxy-001"}
+
+
+def seed_reference_regression_resources(
+    *,
+    store: LocalResourceLifecycleStore,
+    adapter_key: str,
+) -> None:
+    if adapter_key == "xhs":
+        account_material = _xhs_account_material()
+    elif adapter_key == "douyin":
+        account_material = _douyin_account_material()
+    else:
+        raise ValueError(f"unsupported adapter_key for regression resource seed: {adapter_key}")
+    store.seed_resources(
+        [
+            ResourceRecord(
+                resource_id=f"{adapter_key}-account-001",
+                resource_type="account",
+                status="AVAILABLE",
+                material=account_material,
+            ),
+            ResourceRecord(
+                resource_id=f"{adapter_key}-proxy-001",
+                resource_type="proxy",
+                status="AVAILABLE",
+                material=_proxy_material(),
+            ),
+        ]
+    )
+
+
 def build_real_adapter_regression_payload(
     *,
     version: str,
@@ -100,15 +158,19 @@ def build_real_adapter_regression_payload(
             expected_outcome = str(case_definition["expected_outcome"])
             if expected_outcome not in _EXPECTED_OUTCOMES:
                 raise ValueError(f"unsupported expected_outcome: {expected_outcome}")
-            envelope = execute_task(
-                TaskRequest(
-                    adapter_key=adapter_key,
-                    capability=_SEMANTIC_OPERATION,
-                    input=TaskInput(url=str(case_definition["url"])),
-                ),
-                adapters=reference_adapters,
-                task_id_factory=lambda case_id=str(case_definition["case_id"]): f"task-regression-{case_id}",
-            )
+            with tempfile.TemporaryDirectory(prefix=f"syvert-regression-{adapter_key}-") as temp_dir:
+                resource_store = LocalResourceLifecycleStore(Path(temp_dir) / "resource-lifecycle.json")
+                seed_reference_regression_resources(store=resource_store, adapter_key=adapter_key)
+                envelope = execute_task(
+                    TaskRequest(
+                        adapter_key=adapter_key,
+                        capability=_SEMANTIC_OPERATION,
+                        input=TaskInput(url=str(case_definition["url"])),
+                    ),
+                    adapters=reference_adapters,
+                    task_id_factory=lambda case_id=str(case_definition["case_id"]): f"task-regression-{case_id}",
+                    resource_lifecycle_store=resource_store,
+                )
             cases.append(build_regression_case_from_envelope(case_definition=case_definition, envelope=envelope))
             evidence_refs.append(str(case_definition["evidence_ref"]))
         adapter_results.append({"adapter_key": adapter_key, "cases": cases})

--- a/syvert/resource_bootstrap.py
+++ b/syvert/resource_bootstrap.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict
+import json
+from pathlib import Path
+from typing import Any
+
+from syvert.adapters.douyin import (
+    DouyinSessionConfig,
+    build_session_config_from_context as build_douyin_session_config_from_context,
+    load_session_config as load_douyin_session_config,
+)
+from syvert.adapters.xhs import (
+    XhsSessionConfig,
+    build_session_config_from_context as build_xhs_session_config_from_context,
+    load_session_config as load_xhs_session_config,
+)
+from syvert.resource_lifecycle import ResourceLifecycleContractError, ResourceBundle, ResourceRecord
+from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
+from syvert.runtime import AdapterExecutionContext, AdapterTaskRequest, PlatformAdapterError
+
+SUPPORTED_BOOTSTRAP_ADAPTERS = frozenset({"xhs", "douyin"})
+
+
+def load_bootstrap_material(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ValueError(f"bootstrap material file does not exist: {path}") from exc
+    except OSError as exc:
+        raise ValueError(f"bootstrap material file is not readable: {path}") from exc
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"bootstrap material file is not valid JSON: {path}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"bootstrap material file must contain a JSON object: {path}")
+    return dict(payload)
+
+
+def load_account_material(
+    *,
+    adapter_key: str,
+    account_material_file: Path | None = None,
+    account_session_file: Path | None = None,
+) -> dict[str, Any]:
+    account_source_count = int(account_material_file is not None) + int(account_session_file is not None)
+    if account_source_count != 1:
+        raise ValueError("exactly one of account_material_file or account_session_file must be provided")
+    if account_material_file is not None:
+        return canonicalize_account_material(
+            adapter_key=adapter_key,
+            material=load_bootstrap_material(account_material_file),
+        )
+    assert account_session_file is not None
+    return load_account_material_from_session_file(
+        adapter_key=adapter_key,
+        session_file=account_session_file,
+    )
+
+
+def load_account_material_from_session_file(
+    *,
+    adapter_key: str,
+    session_file: Path,
+) -> dict[str, Any]:
+    try:
+        if adapter_key == "xhs":
+            session = load_xhs_session_config(session_file)
+            return _serialize_xhs_session(session)
+        if adapter_key == "douyin":
+            session = load_douyin_session_config(session_file)
+            return _serialize_douyin_session(session)
+    except PlatformAdapterError as exc:
+        raise ValueError(exc.message) from exc
+    raise ValueError(f"unsupported bootstrap adapter_key: {adapter_key}")
+
+
+def canonicalize_account_material(*, adapter_key: str, material: Mapping[str, Any]) -> dict[str, Any]:
+    if adapter_key == "xhs":
+        return _serialize_xhs_session(_canonicalize_xhs_material(material))
+    if adapter_key == "douyin":
+        return _serialize_douyin_session(_canonicalize_douyin_material(material))
+    raise ValueError(f"unsupported bootstrap adapter_key: {adapter_key}")
+
+
+def canonicalize_proxy_material(material: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(material, Mapping):
+        raise ValueError(f"proxy material must be a JSON object, got {type(material).__name__}")
+    normalized = dict(material)
+    if not normalized:
+        raise ValueError("proxy material must not be empty")
+    return normalized
+
+
+def build_bootstrap_records(
+    *,
+    adapter_key: str,
+    account_resource_id: str,
+    account_material: Mapping[str, Any],
+    proxy_resource_id: str,
+    proxy_material: Mapping[str, Any],
+) -> tuple[ResourceRecord, ...]:
+    if adapter_key not in SUPPORTED_BOOTSTRAP_ADAPTERS:
+        raise ValueError(f"unsupported bootstrap adapter_key: {adapter_key}")
+    if not account_resource_id:
+        raise ValueError("account_resource_id must be non-empty")
+    if not proxy_resource_id:
+        raise ValueError("proxy_resource_id must be non-empty")
+    canonical_account_material = canonicalize_account_material(
+        adapter_key=adapter_key,
+        material=account_material,
+    )
+    canonical_proxy_material = canonicalize_proxy_material(proxy_material)
+    return (
+        ResourceRecord(
+            resource_id=account_resource_id,
+            resource_type="account",
+            status="AVAILABLE",
+            material=canonical_account_material,
+        ),
+        ResourceRecord(
+            resource_id=proxy_resource_id,
+            resource_type="proxy",
+            status="AVAILABLE",
+            material=canonical_proxy_material,
+        ),
+    )
+
+
+def bootstrap_resource_store(
+    *,
+    store: LocalResourceLifecycleStore,
+    records: Sequence[ResourceRecord],
+) -> tuple[ResourceRecord, ...]:
+    try:
+        return store.seed_resources(records)
+    except ResourceLifecycleContractError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def _canonicalize_xhs_material(material: Mapping[str, Any]) -> XhsSessionConfig:
+    try:
+        return build_xhs_session_config_from_context(_material_validation_context(material))
+    except PlatformAdapterError as exc:
+        raise ValueError(exc.message) from exc
+
+
+def _canonicalize_douyin_material(material: Mapping[str, Any]) -> DouyinSessionConfig:
+    try:
+        return build_douyin_session_config_from_context(_material_validation_context(material))
+    except PlatformAdapterError as exc:
+        raise ValueError(exc.message) from exc
+
+
+def _material_validation_context(material: Mapping[str, Any]) -> AdapterExecutionContext:
+    if not isinstance(material, Mapping):
+        raise ValueError(f"account material must be a JSON object, got {type(material).__name__}")
+    return AdapterExecutionContext(
+        request=AdapterTaskRequest(
+            capability="content_detail",
+            target_type="url",
+            target_value="https://example.com/bootstrap",
+            collection_mode="hybrid",
+        ),
+        resource_bundle=ResourceBundle(
+            bundle_id="bundle-bootstrap-validation",
+            lease_id="lease-bootstrap-validation",
+            task_id="task-bootstrap-validation",
+            adapter_key="bootstrap",
+            capability="content_detail_by_url",
+            requested_slots=("account",),
+            acquired_at="2026-04-21T00:00:00Z",
+            account=ResourceRecord(
+                resource_id="account-bootstrap-validation",
+                resource_type="account",
+                status="IN_USE",
+                material=dict(material),
+            ),
+            proxy=None,
+        ),
+    )
+
+
+def _serialize_xhs_session(session: XhsSessionConfig) -> dict[str, Any]:
+    return asdict(session)
+
+
+def _serialize_douyin_session(session: DouyinSessionConfig) -> dict[str, Any]:
+    return asdict(session)
+
+
+__all__ = [
+    "SUPPORTED_BOOTSTRAP_ADAPTERS",
+    "bootstrap_resource_store",
+    "build_bootstrap_records",
+    "canonicalize_account_material",
+    "canonicalize_proxy_material",
+    "load_account_material",
+    "load_account_material_from_session_file",
+    "load_bootstrap_material",
+]

--- a/syvert/resource_bootstrap.py
+++ b/syvert/resource_bootstrap.py
@@ -16,7 +16,12 @@ from syvert.adapters.xhs import (
     build_session_config_from_context as build_xhs_session_config_from_context,
     load_session_config as load_xhs_session_config,
 )
-from syvert.resource_lifecycle import ResourceLifecycleContractError, ResourceBundle, ResourceRecord
+from syvert.resource_lifecycle import (
+    MANAGED_ACCOUNT_ADAPTER_KEY_FIELD,
+    ResourceLifecycleContractError,
+    ResourceBundle,
+    ResourceRecord,
+)
 from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 from syvert.runtime import AdapterExecutionContext, AdapterTaskRequest, PlatformAdapterError
 
@@ -69,10 +74,14 @@ def load_account_material_from_session_file(
     try:
         if adapter_key == "xhs":
             session = load_xhs_session_config(session_file)
-            return _serialize_xhs_session(session)
+            material = _serialize_xhs_session(session)
+            material[MANAGED_ACCOUNT_ADAPTER_KEY_FIELD] = adapter_key
+            return material
         if adapter_key == "douyin":
             session = load_douyin_session_config(session_file)
-            return _serialize_douyin_session(session)
+            material = _serialize_douyin_session(session)
+            material[MANAGED_ACCOUNT_ADAPTER_KEY_FIELD] = adapter_key
+            return material
     except PlatformAdapterError as exc:
         raise ValueError(exc.message) from exc
     raise ValueError(f"unsupported bootstrap adapter_key: {adapter_key}")
@@ -80,9 +89,13 @@ def load_account_material_from_session_file(
 
 def canonicalize_account_material(*, adapter_key: str, material: Mapping[str, Any]) -> dict[str, Any]:
     if adapter_key == "xhs":
-        return _serialize_xhs_session(_canonicalize_xhs_material(material))
+        normalized = _serialize_xhs_session(_canonicalize_xhs_material(material))
+        normalized[MANAGED_ACCOUNT_ADAPTER_KEY_FIELD] = adapter_key
+        return normalized
     if adapter_key == "douyin":
-        return _serialize_douyin_session(_canonicalize_douyin_material(material))
+        normalized = _serialize_douyin_session(_canonicalize_douyin_material(material))
+        normalized[MANAGED_ACCOUNT_ADAPTER_KEY_FIELD] = adapter_key
+        return normalized
     raise ValueError(f"unsupported bootstrap adapter_key: {adapter_key}")
 
 

--- a/syvert/resource_bootstrap_cli.py
+++ b/syvert/resource_bootstrap_cli.py
@@ -1,13 +1,9 @@
-#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse
 import json
 import sys
 from pathlib import Path
-
-if __package__ in {None, ""}:
-    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from syvert.resource_bootstrap import (
     bootstrap_resource_store,

--- a/syvert/resource_lifecycle.py
+++ b/syvert/resource_lifecycle.py
@@ -717,11 +717,11 @@ def resource_is_slot_compatible(record: ResourceRecord, *, slot: str, adapter_ke
         return True
     material = record.material
     if not isinstance(material, Mapping):
-        return True
+        return False
     managed_adapter_key = material.get(MANAGED_ACCOUNT_ADAPTER_KEY_FIELD)
     if managed_adapter_key is None:
-        return True
-    return isinstance(managed_adapter_key, str) and managed_adapter_key == adapter_key
+        return False
+    return isinstance(managed_adapter_key, str) and bool(managed_adapter_key) and managed_adapter_key == adapter_key
 
 
 def apply_acquire_transition(

--- a/syvert/resource_lifecycle.py
+++ b/syvert/resource_lifecycle.py
@@ -14,6 +14,7 @@ RESOURCE_LIFECYCLE_VERSION = "v0.4.0"
 RESOURCE_TYPES = frozenset({"account", "proxy"})
 RESOURCE_STATUSES = frozenset({"AVAILABLE", "IN_USE", "INVALID"})
 RELEASE_TARGET_STATUSES = frozenset({"AVAILABLE", "INVALID"})
+MANAGED_ACCOUNT_ADAPTER_KEY_FIELD = "managed_adapter_key"
 
 
 class ResourceLifecycleContractError(ValueError):
@@ -138,7 +139,11 @@ def acquire(
     try:
         current_snapshot = snapshot
         while True:
-            selected = select_available_resources(current_snapshot, normalized_request.requested_slots)
+            selected = select_available_resources(
+                current_snapshot,
+                normalized_request.requested_slots,
+                adapter_key=normalized_request.adapter_key,
+            )
             selected_resource_ids = {slot: record.resource_id for slot, record in selected.items()}
             acquired_at = now_rfc3339_utc()
             bundle = build_resource_bundle(
@@ -170,6 +175,7 @@ def acquire(
                     refreshed_selected = select_available_resources(
                         refreshed_snapshot,
                         normalized_request.requested_slots,
+                        adapter_key=normalized_request.adapter_key,
                     )
                 except ResourceLifecycleContractError as refreshed_error:
                     raise state_conflict_error("revision 冲突后资源选择已过期") from refreshed_error
@@ -666,6 +672,8 @@ def build_resource_lease(bundle: ResourceBundle) -> ResourceLease:
 def select_available_resources(
     snapshot: ResourceLifecycleSnapshot,
     requested_slots: tuple[str, ...],
+    *,
+    adapter_key: str,
 ) -> dict[str, ResourceRecord]:
     resources_by_type: dict[str, list[ResourceRecord]] = {slot: [] for slot in RESOURCE_TYPES}
     active_resource_ids = {
@@ -682,7 +690,14 @@ def select_available_resources(
 
     selected: dict[str, ResourceRecord] = {}
     for slot in requested_slots:
-        candidates = sorted(resources_by_type[slot], key=lambda record: record.resource_id)
+        candidates = sorted(
+            (
+                record
+                for record in resources_by_type[slot]
+                if resource_is_slot_compatible(record, slot=slot, adapter_key=adapter_key)
+            ),
+            key=lambda record: record.resource_id,
+        )
         if not candidates:
             raise unavailable_error(f"slot `{slot}` 缺少 AVAILABLE 资源")
         candidate = candidates[0]
@@ -695,6 +710,18 @@ def select_available_resources(
             material=candidate.material,
         )
     return selected
+
+
+def resource_is_slot_compatible(record: ResourceRecord, *, slot: str, adapter_key: str) -> bool:
+    if slot != "account":
+        return True
+    material = record.material
+    if not isinstance(material, Mapping):
+        return True
+    managed_adapter_key = material.get(MANAGED_ACCOUNT_ADAPTER_KEY_FIELD)
+    if managed_adapter_key is None:
+        return True
+    return isinstance(managed_adapter_key, str) and managed_adapter_key == adapter_key
 
 
 def apply_acquire_transition(

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -382,7 +382,7 @@ def execute_task_internal(
                 task_record_store=store,
             )
         resource_bundle = acquire_result
-        live_resource_lease, live_lease_error = resolve_host_resource_lease(
+        live_resource_lease, live_resources_by_id, live_lease_error = resolve_host_resource_lease(
             task_id=task_id,
             adapter_key=adapter_key,
             capability=capability,
@@ -414,6 +414,7 @@ def execute_task_internal(
             capability=capability,
             requested_slots=requested_slots,
             live_resource_lease=live_resource_lease,
+            live_resources_by_id=live_resources_by_id,
         )
         if bundle_error is not None:
             cleanup_envelope = settle_managed_resource_bundle(
@@ -826,6 +827,7 @@ def validate_host_resource_bundle(
     capability: str,
     requested_slots: tuple[str, ...],
     live_resource_lease,
+    live_resources_by_id: Mapping[str, Any],
 ) -> dict[str, Any] | None:
     from syvert.resource_lifecycle import ResourceLifecycleContractError, validate_resource_bundle
 
@@ -857,6 +859,11 @@ def validate_host_resource_bundle(
             "invalid_resource_bundle",
             "resource_bundle.requested_slots 与当前请求不一致",
         )
+    if resource_bundle.acquired_at != live_resource_lease.acquired_at:
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle.acquired_at 与当前 active lease 不一致",
+        )
     if resource_bundle.bundle_id != live_resource_lease.bundle_id:
         return runtime_contract_error(
             "invalid_resource_bundle",
@@ -877,6 +884,21 @@ def validate_host_resource_bundle(
             "invalid_resource_bundle",
             "resource_bundle slots 与当前 active lease 绑定资源不一致",
         )
+    for slot in requested_slots:
+        resource = getattr(resource_bundle, slot)
+        if resource is None:
+            continue
+        live_resource = live_resources_by_id.get(resource.resource_id)
+        if live_resource is None:
+            return runtime_contract_error(
+                "invalid_resource_bundle",
+                "resource_bundle slot 绑定了 host-side truth 中不存在的资源",
+            )
+        if resource != live_resource:
+            return runtime_contract_error(
+                "invalid_resource_bundle",
+                "resource_bundle slot 内容与 host-side resource truth 不一致",
+            )
     return None
 
 
@@ -944,6 +966,7 @@ def resolve_host_resource_lease(
     except ResourceLifecycleContractError as error:
         return (
             None,
+            {},
             runtime_contract_error(
                 "invalid_resource_bundle",
                 "host-side resource lifecycle truth 不满足共享 contract",
@@ -962,13 +985,15 @@ def resolve_host_resource_lease(
     if len(candidates) != 1:
         return (
             None,
+            {},
             runtime_contract_error(
                 "invalid_resource_bundle",
                 "当前 task 缺少唯一 active lease truth",
                 details={"active_lease_count": len(candidates)},
             ),
         )
-    return candidates[0], None
+    resources_by_id = {record.resource_id: record for record in snapshot.resources}
+    return candidates[0], resources_by_id, None
 
 
 def settle_managed_resource_bundle(

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -382,16 +382,42 @@ def execute_task_internal(
                 task_record_store=store,
             )
         resource_bundle = acquire_result
+        live_resource_lease, live_lease_error = resolve_host_resource_lease(
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            resource_lifecycle_store=managed_resource_store,
+        )
+        if live_lease_error is not None:
+            cleanup_envelope = settle_managed_resource_bundle(
+                lease_id=resource_bundle.lease_id,
+                task_id=task_id,
+                resource_lifecycle_store=managed_resource_store,
+                default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
+                hint=None,
+            )
+            envelope = cleanup_envelope or failure_envelope(task_id, adapter_key, capability, live_lease_error)
+            return finalize_task_execution_result(
+                task_id,
+                adapter_key,
+                capability,
+                record,
+                envelope,
+                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
+                task_record_store=store,
+            )
+
         bundle_error = validate_host_resource_bundle(
             resource_bundle,
             task_id=task_id,
             adapter_key=adapter_key,
             capability=capability,
             requested_slots=requested_slots,
+            live_resource_lease=live_resource_lease,
         )
         if bundle_error is not None:
             cleanup_envelope = settle_managed_resource_bundle(
-                resource_bundle=resource_bundle,
+                lease_id=live_resource_lease.lease_id,
                 task_id=task_id,
                 resource_lifecycle_store=managed_resource_store,
                 default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
@@ -462,7 +488,7 @@ def execute_task_internal(
 
     if resource_bundle is not None and managed_resource_store is not None:
         cleanup_envelope = settle_managed_resource_bundle(
-            resource_bundle=resource_bundle,
+            lease_id=live_resource_lease.lease_id,
             task_id=task_id,
             resource_lifecycle_store=managed_resource_store,
             default_reason=default_release_reason,
@@ -799,6 +825,7 @@ def validate_host_resource_bundle(
     adapter_key: str,
     capability: str,
     requested_slots: tuple[str, ...],
+    live_resource_lease,
 ) -> dict[str, Any] | None:
     from syvert.resource_lifecycle import ResourceLifecycleContractError, validate_resource_bundle
 
@@ -830,6 +857,26 @@ def validate_host_resource_bundle(
             "invalid_resource_bundle",
             "resource_bundle.requested_slots 与当前请求不一致",
         )
+    if resource_bundle.bundle_id != live_resource_lease.bundle_id:
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle.bundle_id 与当前 active lease 不一致",
+        )
+    if resource_bundle.lease_id != live_resource_lease.lease_id:
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle.lease_id 与当前 active lease 不一致",
+        )
+    bundle_resource_ids = tuple(
+        getattr(resource_bundle, slot).resource_id
+        for slot in requested_slots
+        if getattr(resource_bundle, slot) is not None
+    )
+    if bundle_resource_ids != tuple(live_resource_lease.resource_ids):
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle slots 与当前 active lease 绑定资源不一致",
+        )
     return None
 
 
@@ -838,15 +885,15 @@ def extract_internal_resource_disposition_hint(
     *,
     expected_lease_id: str | None,
 ) -> tuple[ResourceDispositionHint | None, dict[str, Any] | None]:
+    def invalid_hint_error(message: str) -> dict[str, Any]:
+        return invalid_input_error("invalid_resource_disposition_hint", message)
+
     if raw_hint is None:
         return None, None
     if expected_lease_id is None:
         return (
             None,
-            runtime_contract_error(
-                "invalid_resource_disposition_hint",
-                "非资源路径不得返回 resource_disposition_hint",
-            ),
+            invalid_hint_error("非资源路径不得返回 resource_disposition_hint"),
         )
     if isinstance(raw_hint, ResourceDispositionHint):
         hint = raw_hint
@@ -862,38 +909,71 @@ def extract_internal_resource_disposition_hint(
     else:
         return (
             None,
-            runtime_contract_error(
-                "invalid_resource_disposition_hint",
-                "resource_disposition_hint 必须是对象",
-            ),
+            invalid_hint_error("resource_disposition_hint 必须是对象"),
         )
 
     if not hint.lease_id:
-        return None, runtime_contract_error("invalid_resource_disposition_hint", "resource_disposition_hint.lease_id 不能为空")
+        return None, invalid_hint_error("resource_disposition_hint.lease_id 不能为空")
     if hint.lease_id != expected_lease_id:
         return (
             None,
-            runtime_contract_error(
-                "invalid_resource_disposition_hint",
-                "resource_disposition_hint.lease_id 与注入 bundle 不一致",
-            ),
+            invalid_hint_error("resource_disposition_hint.lease_id 与注入 bundle 不一致"),
         )
     if hint.target_status_after_release not in {"AVAILABLE", "INVALID"}:
         return (
             None,
-            runtime_contract_error(
-                "invalid_resource_disposition_hint",
-                "resource_disposition_hint.target_status_after_release 不在允许值范围内",
-            ),
+            invalid_hint_error("resource_disposition_hint.target_status_after_release 不在允许值范围内"),
         )
     if not hint.reason:
-        return None, runtime_contract_error("invalid_resource_disposition_hint", "resource_disposition_hint.reason 不能为空")
+        return None, invalid_hint_error("resource_disposition_hint.reason 不能为空")
     return hint, None
+
+
+def resolve_host_resource_lease(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    resource_lifecycle_store,
+):
+    from syvert.resource_lifecycle import ResourceLifecycleContractError, validate_snapshot
+
+    try:
+        snapshot = resource_lifecycle_store.load_snapshot()
+        validate_snapshot(snapshot)
+    except ResourceLifecycleContractError as error:
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_resource_bundle",
+                "host-side resource lifecycle truth 不满足共享 contract",
+                details={"reason": str(error)},
+            ),
+        )
+
+    candidates = [
+        lease
+        for lease in snapshot.leases
+        if lease.released_at is None
+        and lease.task_id == task_id
+        and lease.adapter_key == adapter_key
+        and lease.capability == capability
+    ]
+    if len(candidates) != 1:
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_resource_bundle",
+                "当前 task 缺少唯一 active lease truth",
+                details={"active_lease_count": len(candidates)},
+            ),
+        )
+    return candidates[0], None
 
 
 def settle_managed_resource_bundle(
     *,
-    resource_bundle,
+    lease_id: str,
     task_id: str,
     resource_lifecycle_store,
     default_reason: str,
@@ -903,7 +983,7 @@ def settle_managed_resource_bundle(
 
     release_result = release(
         ReleaseRequest(
-            lease_id=resource_bundle.lease_id,
+            lease_id=lease_id,
             task_id=task_id,
             target_status_after_release=(
                 hint.target_status_after_release if hint is not None else "AVAILABLE"

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import re
-from typing import Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 from uuid import uuid4
 
 from syvert.registry import AdapterRegistry, RegistryError
@@ -30,6 +30,17 @@ ALLOWED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
 CAPABILITY_FAMILY_BY_OPERATION = {CONTENT_DETAIL_BY_URL: CONTENT_DETAIL}
 ALLOWED_CONTENT_TYPES = {"video", "image_post", "mixed_media", "unknown"}
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
+RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE = {
+    (CONTENT_DETAIL_BY_URL, LEGACY_COLLECTION_MODE): ("account", "proxy"),
+}
+DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON = "host_side_bundle_validation_failed"
+DEFAULT_SUCCESS_RELEASE_REASON = "adapter_completed_without_disposition_hint"
+DEFAULT_FAILURE_RELEASE_REASON = "adapter_failed_without_disposition_hint"
+DEFAULT_INVALID_HINT_RELEASE_REASON = "invalid_resource_disposition_hint"
+
+if TYPE_CHECKING:
+    from syvert.resource_lifecycle import ResourceBundle
+    from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 
 
 @dataclass(frozen=True)
@@ -75,12 +86,46 @@ class AdapterTaskRequest:
         return TaskInput(url=self.target_value)
 
 
+@dataclass(frozen=True)
+class ResourceDispositionHint:
+    lease_id: str
+    target_status_after_release: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class AdapterExecutionContext:
+    request: AdapterTaskRequest
+    resource_bundle: "ResourceBundle | None"
+
+    @property
+    def capability(self) -> str:
+        return self.request.capability
+
+    @property
+    def target_type(self) -> str:
+        return self.request.target_type
+
+    @property
+    def target_value(self) -> str:
+        return self.request.target_value
+
+    @property
+    def collection_mode(self) -> str:
+        return self.request.collection_mode
+
+    @property
+    def input(self) -> TaskInput:
+        return self.request.input
+
+
 @dataclass
 class PlatformAdapterError(Exception):
     code: str
     message: str
     details: dict[str, Any] = field(default_factory=dict)
     category: str = "platform"
+    resource_disposition_hint: ResourceDispositionHint | Mapping[str, Any] | None = None
 
     def __post_init__(self) -> None:
         super().__init__(self.message)
@@ -101,12 +146,14 @@ def execute_task(
     *,
     adapters: Mapping[str, Any],
     task_id_factory: Callable[[], str] | None = None,
+    resource_lifecycle_store: "LocalResourceLifecycleStore | None" = None,
 ) -> dict[str, Any]:
     return execute_task_internal(
         request,
         adapters=adapters,
         task_id_factory=task_id_factory,
         preserve_envelope_on_record_error=True,
+        resource_lifecycle_store=resource_lifecycle_store,
     ).envelope
 
 
@@ -116,6 +163,7 @@ def execute_task_with_record(
     adapters: Mapping[str, Any],
     task_id_factory: Callable[[], str] | None = None,
     task_record_store: TaskRecordStore | None = None,
+    resource_lifecycle_store: "LocalResourceLifecycleStore | None" = None,
 ) -> TaskExecutionResult:
     store = task_record_store if task_record_store is not None else default_task_record_store()
     return execute_task_internal(
@@ -124,6 +172,7 @@ def execute_task_with_record(
         task_id_factory=task_id_factory,
         preserve_envelope_on_record_error=False,
         task_record_store=store,
+        resource_lifecycle_store=resource_lifecycle_store,
     )
 
 
@@ -134,6 +183,7 @@ def execute_task_internal(
     task_id_factory: Callable[[], str] | None = None,
     preserve_envelope_on_record_error: bool,
     task_record_store: TaskRecordStore | None = None,
+    resource_lifecycle_store: "LocalResourceLifecycleStore | None" = None,
 ) -> TaskExecutionResult:
     store = task_record_store
     adapter_key, capability = extract_request_context(request)
@@ -309,11 +359,45 @@ def execute_task_internal(
     if persisted_record is not None:
         record = persisted_record
 
-    try:
-        payload = declaration.adapter.execute(adapter_request)
-        payload_error = validate_success_payload(payload)
-        if payload_error is not None:
-            envelope = failure_envelope(task_id, adapter_key, capability, payload_error)
+    requested_slots = resolve_requested_resource_slots(normalized_request)
+    managed_resource_store = None
+    resource_bundle = None
+    if requested_slots is not None:
+        managed_resource_store = resource_lifecycle_store or default_runtime_resource_lifecycle_store()
+        acquire_result = acquire_runtime_resource_bundle(
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            requested_slots=requested_slots,
+            resource_lifecycle_store=managed_resource_store,
+        )
+        if isinstance(acquire_result, Mapping):
+            return finalize_task_execution_result(
+                task_id,
+                adapter_key,
+                capability,
+                record,
+                dict(acquire_result),
+                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
+                task_record_store=store,
+            )
+        resource_bundle = acquire_result
+        bundle_error = validate_host_resource_bundle(
+            resource_bundle,
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            requested_slots=requested_slots,
+        )
+        if bundle_error is not None:
+            cleanup_envelope = settle_managed_resource_bundle(
+                resource_bundle=resource_bundle,
+                task_id=task_id,
+                resource_lifecycle_store=managed_resource_store,
+                default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
+                hint=None,
+            )
+            envelope = cleanup_envelope or failure_envelope(task_id, adapter_key, capability, bundle_error)
             return finalize_task_execution_result(
                 task_id,
                 adapter_key,
@@ -323,17 +407,47 @@ def execute_task_internal(
                 preserve_envelope_on_record_error=preserve_envelope_on_record_error,
                 task_record_store=store,
             )
+
+    adapter_context = AdapterExecutionContext(
+        request=adapter_request,
+        resource_bundle=resource_bundle,
+    )
+    disposition_hint: ResourceDispositionHint | None = None
+    default_release_reason = DEFAULT_SUCCESS_RELEASE_REASON
+    try:
+        payload = declaration.adapter.execute(adapter_context)
+        payload_error = validate_success_payload(payload)
+        if payload_error is not None:
+            envelope = failure_envelope(task_id, adapter_key, capability, payload_error)
+            default_release_reason = DEFAULT_FAILURE_RELEASE_REASON
+        else:
+            disposition_hint, hint_error = extract_internal_resource_disposition_hint(
+                payload.get("resource_disposition_hint"),
+                expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
+            )
+            if hint_error is not None:
+                envelope = failure_envelope(task_id, adapter_key, capability, hint_error)
+                default_release_reason = DEFAULT_INVALID_HINT_RELEASE_REASON
+            else:
+                envelope = {
+                    "task_id": task_id,
+                    "adapter_key": adapter_key,
+                    "capability": capability,
+                    "status": "success",
+                    "raw": payload["raw"],
+                    "normalized": payload["normalized"],
+                }
     except PlatformAdapterError as error:
-        envelope = failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error))
-        return finalize_task_execution_result(
-            task_id,
-            adapter_key,
-            capability,
-            record,
-            envelope,
-            preserve_envelope_on_record_error=preserve_envelope_on_record_error,
-            task_record_store=store,
+        disposition_hint, hint_error = extract_internal_resource_disposition_hint(
+            error.resource_disposition_hint,
+            expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
         )
+        if hint_error is not None:
+            envelope = failure_envelope(task_id, adapter_key, capability, hint_error)
+            default_release_reason = DEFAULT_INVALID_HINT_RELEASE_REASON
+        else:
+            envelope = failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error))
+            default_release_reason = DEFAULT_FAILURE_RELEASE_REASON
     except Exception as error:
         envelope = failure_envelope(
             task_id,
@@ -344,24 +458,19 @@ def execute_task_internal(
                 str(error) or error.__class__.__name__,
             ),
         )
-        return finalize_task_execution_result(
-            task_id,
-            adapter_key,
-            capability,
-            record,
-            envelope,
-            preserve_envelope_on_record_error=preserve_envelope_on_record_error,
-            task_record_store=store,
-        )
+        default_release_reason = DEFAULT_FAILURE_RELEASE_REASON
 
-    envelope = {
-        "task_id": task_id,
-        "adapter_key": adapter_key,
-        "capability": capability,
-        "status": "success",
-        "raw": payload["raw"],
-        "normalized": payload["normalized"],
-    }
+    if resource_bundle is not None and managed_resource_store is not None:
+        cleanup_envelope = settle_managed_resource_bundle(
+            resource_bundle=resource_bundle,
+            task_id=task_id,
+            resource_lifecycle_store=managed_resource_store,
+            default_reason=default_release_reason,
+            hint=disposition_hint,
+        )
+        if cleanup_envelope is not None:
+            envelope = cleanup_envelope
+
     return finalize_task_execution_result(
         task_id,
         adapter_key,
@@ -644,6 +753,169 @@ def resolve_task_id(task_id_factory: Callable[[], str] | None) -> tuple[str, dic
             details={"actual_type": type(generated).__name__},
         ),
     )
+
+
+def resolve_requested_resource_slots(request: CoreTaskRequest) -> tuple[str, ...] | None:
+    slots = RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE.get(
+        (request.target.capability, request.policy.collection_mode)
+    )
+    if slots is None:
+        return None
+    return tuple(slots)
+
+
+def default_runtime_resource_lifecycle_store():
+    from syvert.resource_lifecycle_store import default_resource_lifecycle_store
+
+    return default_resource_lifecycle_store()
+
+
+def acquire_runtime_resource_bundle(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    requested_slots: tuple[str, ...],
+    resource_lifecycle_store,
+):
+    from syvert.resource_lifecycle import AcquireRequest, acquire
+
+    return acquire(
+        AcquireRequest(
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            requested_slots=requested_slots,
+        ),
+        resource_lifecycle_store,
+        task_id,
+    )
+
+
+def validate_host_resource_bundle(
+    resource_bundle,
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    requested_slots: tuple[str, ...],
+) -> dict[str, Any] | None:
+    from syvert.resource_lifecycle import ResourceLifecycleContractError, validate_resource_bundle
+
+    try:
+        validate_resource_bundle(resource_bundle)
+    except ResourceLifecycleContractError as error:
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle 不满足共享 contract",
+            details={"reason": str(error)},
+        )
+    if resource_bundle.task_id != task_id:
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle.task_id 与当前 task 不一致",
+        )
+    if resource_bundle.adapter_key != adapter_key:
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle.adapter_key 与当前请求不一致",
+        )
+    if resource_bundle.capability != capability:
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle.capability 与当前请求不一致",
+        )
+    if tuple(resource_bundle.requested_slots) != tuple(requested_slots):
+        return runtime_contract_error(
+            "invalid_resource_bundle",
+            "resource_bundle.requested_slots 与当前请求不一致",
+        )
+    return None
+
+
+def extract_internal_resource_disposition_hint(
+    raw_hint: ResourceDispositionHint | Mapping[str, Any] | None,
+    *,
+    expected_lease_id: str | None,
+) -> tuple[ResourceDispositionHint | None, dict[str, Any] | None]:
+    if raw_hint is None:
+        return None, None
+    if expected_lease_id is None:
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_resource_disposition_hint",
+                "非资源路径不得返回 resource_disposition_hint",
+            ),
+        )
+    if isinstance(raw_hint, ResourceDispositionHint):
+        hint = raw_hint
+    elif isinstance(raw_hint, Mapping):
+        lease_id = raw_hint.get("lease_id")
+        target_status_after_release = raw_hint.get("target_status_after_release")
+        reason = raw_hint.get("reason")
+        hint = ResourceDispositionHint(
+            lease_id=lease_id if isinstance(lease_id, str) else "",
+            target_status_after_release=target_status_after_release if isinstance(target_status_after_release, str) else "",
+            reason=reason if isinstance(reason, str) else "",
+        )
+    else:
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_resource_disposition_hint",
+                "resource_disposition_hint 必须是对象",
+            ),
+        )
+
+    if not hint.lease_id:
+        return None, runtime_contract_error("invalid_resource_disposition_hint", "resource_disposition_hint.lease_id 不能为空")
+    if hint.lease_id != expected_lease_id:
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_resource_disposition_hint",
+                "resource_disposition_hint.lease_id 与注入 bundle 不一致",
+            ),
+        )
+    if hint.target_status_after_release not in {"AVAILABLE", "INVALID"}:
+        return (
+            None,
+            runtime_contract_error(
+                "invalid_resource_disposition_hint",
+                "resource_disposition_hint.target_status_after_release 不在允许值范围内",
+            ),
+        )
+    if not hint.reason:
+        return None, runtime_contract_error("invalid_resource_disposition_hint", "resource_disposition_hint.reason 不能为空")
+    return hint, None
+
+
+def settle_managed_resource_bundle(
+    *,
+    resource_bundle,
+    task_id: str,
+    resource_lifecycle_store,
+    default_reason: str,
+    hint: ResourceDispositionHint | None,
+) -> dict[str, Any] | None:
+    from syvert.resource_lifecycle import ReleaseRequest, release
+
+    release_result = release(
+        ReleaseRequest(
+            lease_id=resource_bundle.lease_id,
+            task_id=task_id,
+            target_status_after_release=(
+                hint.target_status_after_release if hint is not None else "AVAILABLE"
+            ),
+            reason=hint.reason if hint is not None else default_reason,
+        ),
+        resource_lifecycle_store,
+        task_id,
+    )
+    if isinstance(release_result, Mapping):
+        return dict(release_result)
+    return None
 
 
 def validate_success_payload(payload: Mapping[str, Any]) -> dict[str, Any] | None:

--- a/tests/runtime/contract_harness/automation.py
+++ b/tests/runtime/contract_harness/automation.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+import tempfile
 from typing import Any
 
+from syvert.resource_lifecycle import ResourceRecord
+from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 from tests.runtime.contract_harness.fake_adapter import FakeContractAdapter
 from tests.runtime.contract_harness.host import HarnessExecutionInput, execute_harness_sample
 from tests.runtime.contract_harness.samples import CONTRACT_SAMPLES, ContractSample, ExpectedVerdict
@@ -11,6 +15,7 @@ from tests.runtime.contract_harness.validation_tool import (
     HarnessExecutionResult,
     validate_contract_samples,
 )
+from tests.runtime.resource_fixtures import generic_account_material, proxy_material
 
 _EXPECTED_OUTCOME_BY_VERDICT = {
     ExpectedVerdict.PASS: "success",
@@ -150,16 +155,35 @@ def _execute_single_sample(sample: ContractSample) -> HarnessExecutionResult:
     adapter.supported_capabilities = frozenset(profile.declared_capabilities)
     adapter.supported_targets = frozenset(profile.supported_targets)
     adapter.supported_collection_modes = frozenset(profile.supported_collection_modes)
-    envelope = execute_harness_sample(
-        HarnessExecutionInput(
-            sample_id=sample.sample_id,
-            url=sample.input.target_url,
-            adapter_key=sample.input.adapter_key,
-            capability=sample.input.capability,
-        ),
-        adapters={sample.input.adapter_key: adapter},
-        task_id=f"task-{sample.sample_id}",
-    )
+    with tempfile.TemporaryDirectory(prefix=f"syvert-harness-{sample.sample_id}-") as temp_dir:
+        resource_store = LocalResourceLifecycleStore(Path(temp_dir) / "resource-lifecycle.json")
+        resource_store.seed_resources(
+            [
+                ResourceRecord(
+                    resource_id="fake-account-001",
+                    resource_type="account",
+                    status="AVAILABLE",
+                    material=generic_account_material(),
+                ),
+                ResourceRecord(
+                    resource_id="fake-proxy-001",
+                    resource_type="proxy",
+                    status="AVAILABLE",
+                    material=proxy_material(),
+                ),
+            ]
+        )
+        envelope = execute_harness_sample(
+            HarnessExecutionInput(
+                sample_id=sample.sample_id,
+                url=sample.input.target_url,
+                adapter_key=sample.input.adapter_key,
+                capability=sample.input.capability,
+            ),
+            adapters={sample.input.adapter_key: adapter},
+            task_id=f"task-{sample.sample_id}",
+            resource_lifecycle_store=resource_store,
+        )
     return HarnessExecutionResult(runtime_envelope=envelope)
 
 

--- a/tests/runtime/contract_harness/automation.py
+++ b/tests/runtime/contract_harness/automation.py
@@ -15,7 +15,7 @@ from tests.runtime.contract_harness.validation_tool import (
     HarnessExecutionResult,
     validate_contract_samples,
 )
-from tests.runtime.resource_fixtures import generic_account_material, proxy_material
+from tests.runtime.resource_fixtures import generic_account_material, managed_account_material, proxy_material
 
 _EXPECTED_OUTCOME_BY_VERDICT = {
     ExpectedVerdict.PASS: "success",
@@ -163,7 +163,7 @@ def _execute_single_sample(sample: ContractSample) -> HarnessExecutionResult:
                     resource_id="fake-account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material=generic_account_material(),
+                    material=managed_account_material(generic_account_material(), adapter_key=sample.input.adapter_key),
                 ),
                 ResourceRecord(
                     resource_id="fake-proxy-001",

--- a/tests/runtime/contract_harness/fake_adapter.py
+++ b/tests/runtime/contract_harness/fake_adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from syvert.runtime import AdapterTaskRequest, PlatformAdapterError
+from syvert.runtime import AdapterExecutionContext, PlatformAdapterError
 
 FakeAdapterScenario = Literal["success", "legal_failure", "illegal_payload"]
 
@@ -42,13 +42,13 @@ def _build_success_payload(url: str) -> dict[str, Any]:
 @dataclass
 class FakeContractAdapter:
     scenario: FakeAdapterScenario = "success"
-    last_request: AdapterTaskRequest | None = None
+    last_request: AdapterExecutionContext | None = None
 
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
 
-    def execute(self, request: AdapterTaskRequest) -> dict[str, Any]:
+    def execute(self, request: AdapterExecutionContext) -> dict[str, Any]:
         self.last_request = request
         if self.scenario == "success":
             return _build_success_payload(request.target_value)

--- a/tests/runtime/contract_harness/host.py
+++ b/tests/runtime/contract_harness/host.py
@@ -22,6 +22,7 @@ def execute_harness_sample(
     *,
     adapters: Mapping[str, Any],
     task_id: str | None = None,
+    resource_lifecycle_store: Any | None = None,
 ) -> dict[str, Any]:
     request = TaskRequest(
         adapter_key=sample.adapter_key,
@@ -29,5 +30,10 @@ def execute_harness_sample(
         input=TaskInput(url=sample.url),
     )
     if task_id is None:
-        return execute_task(request, adapters=adapters)
-    return execute_task(request, adapters=adapters, task_id_factory=lambda: task_id)
+        return execute_task(request, adapters=adapters, resource_lifecycle_store=resource_lifecycle_store)
+    return execute_task(
+        request,
+        adapters=adapters,
+        task_id_factory=lambda: task_id,
+        resource_lifecycle_store=resource_lifecycle_store,
+    )

--- a/tests/runtime/resource_fixtures.py
+++ b/tests/runtime/resource_fixtures.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+from unittest import mock
+
+from syvert.resource_lifecycle import ResourceBundle, ResourceRecord
+from syvert.resource_lifecycle_store import default_resource_lifecycle_store
+
+
+def generic_account_material() -> dict[str, Any]:
+    return {
+        "cookies": "a=1; b=2",
+        "user_agent": "Mozilla/5.0 TestAgent",
+        "sign_base_url": "http://127.0.0.1:8000",
+        "verify_fp": "verify-1",
+        "ms_token": "ms-token-1",
+        "webid": "webid-1",
+        "timeout_seconds": 5,
+    }
+
+
+def xhs_account_material() -> dict[str, Any]:
+    return {
+        "cookies": "a=1; b=2",
+        "user_agent": "Mozilla/5.0 TestAgent",
+        "sign_base_url": "http://127.0.0.1:8000",
+        "timeout_seconds": 5,
+    }
+
+
+def douyin_account_material() -> dict[str, Any]:
+    return {
+        "cookies": "a=1; b=2",
+        "user_agent": "Mozilla/5.0 TestAgent",
+        "verify_fp": "verify-1",
+        "ms_token": "ms-token-1",
+        "webid": "webid-1",
+        "sign_base_url": "http://127.0.0.1:8000",
+        "timeout_seconds": 5,
+    }
+
+
+def proxy_material() -> dict[str, Any]:
+    return {"proxy_endpoint": "http://proxy-001"}
+
+
+def build_managed_resource_bundle(
+    *,
+    adapter_key: str,
+    task_id: str,
+    capability: str = "content_detail_by_url",
+    requested_slots: tuple[str, ...] = ("account", "proxy"),
+    account_material: dict[str, Any] | None = None,
+    proxy_slot_material: dict[str, Any] | None = None,
+    bundle_id: str = "bundle-test-001",
+    lease_id: str = "lease-test-001",
+) -> ResourceBundle:
+    include_account = "account" in requested_slots
+    include_proxy = "proxy" in requested_slots
+    return ResourceBundle(
+        bundle_id=bundle_id,
+        lease_id=lease_id,
+        task_id=task_id,
+        adapter_key=adapter_key,
+        capability=capability,
+        requested_slots=requested_slots,
+        acquired_at="2026-04-21T04:30:00.000000Z",
+        account=(
+            ResourceRecord(
+                resource_id="account-bundle-001",
+                resource_type="account",
+                status="IN_USE",
+                material=account_material or generic_account_material(),
+            )
+            if include_account
+            else None
+        ),
+        proxy=(
+            ResourceRecord(
+                resource_id="proxy-bundle-001",
+                resource_type="proxy",
+                status="IN_USE",
+                material=proxy_slot_material or proxy_material(),
+            )
+            if include_proxy
+            else None
+        ),
+    )
+
+
+def seed_default_runtime_resources(
+    *,
+    account_material: dict[str, Any] | None = None,
+    proxy_slot_material: dict[str, Any] | None = None,
+) -> None:
+    store = default_resource_lifecycle_store()
+    store.seed_resources(
+        [
+            ResourceRecord(
+                resource_id="account-001",
+                resource_type="account",
+                status="AVAILABLE",
+                material=account_material or generic_account_material(),
+            ),
+            ResourceRecord(
+                resource_id="proxy-001",
+                resource_type="proxy",
+                status="AVAILABLE",
+                material=proxy_slot_material or proxy_material(),
+            ),
+        ]
+    )
+
+
+class ResourceStoreEnvMixin:
+    def setUp(self) -> None:
+        super().setUp()
+        self._resource_store_dir = tempfile.TemporaryDirectory()
+        self._resource_store_path = os.path.join(self._resource_store_dir.name, "resource-lifecycle.json")
+        self._resource_store_patcher = mock.patch.dict(
+            os.environ,
+            {"SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": self._resource_store_path},
+            clear=False,
+        )
+        self._resource_store_patcher.start()
+        seed_default_runtime_resources()
+
+    def tearDown(self) -> None:
+        self._resource_store_patcher.stop()
+        self._resource_store_dir.cleanup()
+        super().tearDown()

--- a/tests/runtime/resource_fixtures.py
+++ b/tests/runtime/resource_fixtures.py
@@ -5,7 +5,7 @@ import tempfile
 from typing import Any
 from unittest import mock
 
-from syvert.resource_lifecycle import ResourceBundle, ResourceRecord
+from syvert.resource_lifecycle import MANAGED_ACCOUNT_ADAPTER_KEY_FIELD, ResourceBundle, ResourceRecord
 from syvert.resource_lifecycle_store import default_resource_lifecycle_store
 
 
@@ -46,6 +46,10 @@ def proxy_material() -> dict[str, Any]:
     return {"proxy_endpoint": "http://proxy-001"}
 
 
+def managed_account_material(material: dict[str, Any], *, adapter_key: str) -> dict[str, Any]:
+    return {**material, MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key}
+
+
 def build_managed_resource_bundle(
     *,
     adapter_key: str,
@@ -72,7 +76,7 @@ def build_managed_resource_bundle(
                 resource_id="account-bundle-001",
                 resource_type="account",
                 status="IN_USE",
-                material=account_material or generic_account_material(),
+                material=managed_account_material(account_material or generic_account_material(), adapter_key=adapter_key),
             )
             if include_account
             else None
@@ -92,6 +96,9 @@ def build_managed_resource_bundle(
 
 def seed_default_runtime_resources(
     *,
+    adapter_key: str = "stub",
+    account_resource_id: str = "account-001",
+    proxy_resource_id: str = "proxy-001",
     account_material: dict[str, Any] | None = None,
     proxy_slot_material: dict[str, Any] | None = None,
 ) -> None:
@@ -99,13 +106,13 @@ def seed_default_runtime_resources(
     store.seed_resources(
         [
             ResourceRecord(
-                resource_id="account-001",
+                resource_id=account_resource_id,
                 resource_type="account",
                 status="AVAILABLE",
-                material=account_material or generic_account_material(),
+                material=managed_account_material(account_material or generic_account_material(), adapter_key=adapter_key),
             ),
             ResourceRecord(
-                resource_id="proxy-001",
+                resource_id=proxy_resource_id,
                 resource_type="proxy",
                 status="AVAILABLE",
                 material=proxy_slot_material or proxy_material(),
@@ -115,6 +122,8 @@ def seed_default_runtime_resources(
 
 
 class ResourceStoreEnvMixin:
+    resource_store_adapter_key = "stub"
+
     def setUp(self) -> None:
         super().setUp()
         self._resource_store_dir = tempfile.TemporaryDirectory()
@@ -125,7 +134,7 @@ class ResourceStoreEnvMixin:
             clear=False,
         )
         self._resource_store_patcher.start()
-        seed_default_runtime_resources()
+        seed_default_runtime_resources(adapter_key=self.resource_store_adapter_key)
 
     def tearDown(self) -> None:
         self._resource_store_patcher.stop()

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -941,6 +941,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
                     f"http://127.0.0.1:{server.server_port}",
                 ):
                     seed_default_runtime_resources(
+                        adapter_key="douyin",
                         account_material={
                             **douyin_account_material(),
                             "sign_base_url": f"http://127.0.0.1:{server.server_port}",

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -20,6 +20,11 @@ from syvert.task_record import (
     task_record_to_dict,
 )
 from syvert.task_record_store import LocalTaskRecordStore
+from tests.runtime.resource_fixtures import (
+    ResourceStoreEnvMixin,
+    douyin_account_material,
+    seed_default_runtime_resources,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -107,7 +112,7 @@ def unexpected_secondary_filesystem_consultation(*args: object, **kwargs: object
     raise AssertionError("unexpected_secondary_filesystem_consultation")
 
 
-class CliTests(unittest.TestCase):
+class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self._task_record_store_dir = tempfile.TemporaryDirectory()
@@ -127,6 +132,7 @@ class CliTests(unittest.TestCase):
         return {
             "PYTHONPATH": str(REPO_ROOT),
             "SYVERT_TASK_RECORD_STORE_DIR": self._task_record_store_dir.name,
+            "SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": self._resource_store_path,
         }
 
     def test_cli_wrapper_help_exits_zero(self) -> None:
@@ -245,10 +251,18 @@ class CliTests(unittest.TestCase):
 
     def test_cli_persists_task_record_through_default_store_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
+            resource_store_path = Path(temp_dir) / "resource-lifecycle.json"
             env = {
                 "PYTHONPATH": str(REPO_ROOT),
                 "SYVERT_TASK_RECORD_STORE_DIR": temp_dir,
+                "SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": str(resource_store_path),
             }
+            with mock.patch.dict(
+                os.environ,
+                {"SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": str(resource_store_path)},
+                clear=False,
+            ):
+                seed_default_runtime_resources()
             result = subprocess.run(
                 [
                     sys.executable,
@@ -898,6 +912,7 @@ class CliTests(unittest.TestCase):
         try:
             with tempfile.TemporaryDirectory() as temp_home:
                 session_path = Path(temp_home) / "douyin.session.json"
+                resource_store_path = Path(temp_home) / "resource-lifecycle.json"
                 session_path.write_text(
                     json.dumps(
                         {
@@ -914,10 +929,24 @@ class CliTests(unittest.TestCase):
                 )
                 stdout = io.StringIO()
                 stderr = io.StringIO()
-                with mock.patch("syvert.adapters.douyin.DEFAULT_DOUYIN_SESSION_PATH", session_path), mock.patch(
+                with mock.patch.dict(
+                    os.environ,
+                    {"SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": str(resource_store_path)},
+                    clear=False,
+                ), mock.patch(
+                    "syvert.adapters.douyin.DEFAULT_DOUYIN_SESSION_PATH",
+                    session_path,
+                ), mock.patch(
                     "syvert.adapters.douyin.DOUYIN_API_BASE_URL",
                     f"http://127.0.0.1:{server.server_port}",
                 ):
+                    seed_default_runtime_resources(
+                        account_material={
+                            **douyin_account_material(),
+                            "sign_base_url": f"http://127.0.0.1:{server.server_port}",
+                            "timeout_seconds": 5,
+                        }
+                    )
                     exit_code = main(
                         [
                             "--adapter",

--- a/tests/runtime/test_contract_harness_automation.py
+++ b/tests/runtime/test_contract_harness_automation.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import os
+from pathlib import Path
+import tempfile
 import unittest
+from unittest import mock
 
 from tests.runtime.contract_harness import (
     CONTRACT_SAMPLES,
@@ -15,6 +19,17 @@ from tests.runtime.contract_harness import (
 
 
 class ContractHarnessAutomationTests(unittest.TestCase):
+    def test_automation_runs_in_clean_environment_without_ambient_resource_store(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.dict(
+            os.environ,
+            {"SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": str(Path(temp_dir) / "fresh-resource-store.json")},
+            clear=False,
+        ):
+            results = run_contract_harness_automation()
+
+        observed = {result["sample_id"]: result["verdict"] for result in results}
+        self.assertEqual(observed, build_expected_verdict_index(CONTRACT_SAMPLES))
+
     def test_catalog_covers_four_fr0006_stable_sample_classes(self) -> None:
         self.assertEqual(
             [sample.sample_id for sample in CONTRACT_SAMPLES],

--- a/tests/runtime/test_contract_harness_host.py
+++ b/tests/runtime/test_contract_harness_host.py
@@ -14,6 +14,8 @@ from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
 class ContractHarnessHostTests(ResourceStoreEnvMixin, unittest.TestCase):
+    resource_store_adapter_key = DEFAULT_HARNESS_ADAPTER_KEY
+
     def test_executes_fake_adapter_via_standard_runtime_and_registry_path(self) -> None:
         adapter = FakeContractAdapter(scenario="success")
         sample = HarnessExecutionInput(sample_id="sample-success", url="https://example.com/fake/1")

--- a/tests/runtime/test_contract_harness_host.py
+++ b/tests/runtime/test_contract_harness_host.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 import unittest
 
 from syvert.registry import AdapterRegistry
-from syvert.runtime import AdapterTaskRequest
+from syvert.runtime import AdapterExecutionContext
 from tests.runtime.contract_harness.fake_adapter import FakeContractAdapter
 from tests.runtime.contract_harness.host import (
     DEFAULT_HARNESS_ADAPTER_KEY,
     HarnessExecutionInput,
     execute_harness_sample,
 )
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
-class ContractHarnessHostTests(unittest.TestCase):
+class ContractHarnessHostTests(ResourceStoreEnvMixin, unittest.TestCase):
     def test_executes_fake_adapter_via_standard_runtime_and_registry_path(self) -> None:
         adapter = FakeContractAdapter(scenario="success")
         sample = HarnessExecutionInput(sample_id="sample-success", url="https://example.com/fake/1")
@@ -32,11 +33,12 @@ class ContractHarnessHostTests(unittest.TestCase):
         self.assertIn("normalized", result)
         self.assertEqual(result["normalized"]["content_id"], "fake-content-001")
         self.assertEqual(result["normalized"]["canonical_url"], sample.url)
-        self.assertIsInstance(adapter.last_request, AdapterTaskRequest)
-        self.assertEqual(adapter.last_request.capability, "content_detail")
-        self.assertEqual(adapter.last_request.target_type, "url")
-        self.assertEqual(adapter.last_request.target_value, sample.url)
-        self.assertEqual(adapter.last_request.collection_mode, "hybrid")
+        self.assertIsInstance(adapter.last_request, AdapterExecutionContext)
+        self.assertEqual(adapter.last_request.request.capability, "content_detail")
+        self.assertEqual(adapter.last_request.request.target_type, "url")
+        self.assertEqual(adapter.last_request.request.target_value, sample.url)
+        self.assertEqual(adapter.last_request.request.collection_mode, "hybrid")
+        self.assertIsNotNone(adapter.last_request.resource_bundle)
 
         registry = AdapterRegistry.from_mapping({DEFAULT_HARNESS_ADAPTER_KEY: adapter})
         self.assertEqual(

--- a/tests/runtime/test_douyin_adapter.py
+++ b/tests/runtime/test_douyin_adapter.py
@@ -10,7 +10,19 @@ from typing import Any
 import unittest
 from unittest import mock
 
-from syvert.runtime import AdapterTaskRequest, PlatformAdapterError, TaskInput, TaskRequest, execute_task
+from syvert.runtime import (
+    AdapterExecutionContext,
+    AdapterTaskRequest,
+    PlatformAdapterError,
+    TaskInput,
+    TaskRequest,
+    execute_task,
+)
+from tests.runtime.resource_fixtures import (
+    ResourceStoreEnvMixin,
+    build_managed_resource_bundle,
+    douyin_account_material,
+)
 
 
 def build_douyin_aweme_detail(
@@ -52,21 +64,35 @@ def build_douyin_aweme_detail(
     }
 
 
-class DouyinAdapterTests(unittest.TestCase):
+def build_douyin_execution_context(
+    *,
+    url: str = "https://www.douyin.com/video/7580570616932224282",
+    collection_mode: str = "hybrid",
+    account_material: dict[str, Any] | None = None,
+) -> AdapterExecutionContext:
+    return AdapterExecutionContext(
+        request=AdapterTaskRequest(
+            capability="content_detail",
+            target_type="url",
+            target_value=url,
+            collection_mode=collection_mode,
+        ),
+        resource_bundle=build_managed_resource_bundle(
+            adapter_key="douyin",
+            task_id="task-douyin-direct-execution",
+            account_material=account_material or douyin_account_material(),
+        ),
+    )
+
+
+class DouyinAdapterTests(ResourceStoreEnvMixin, unittest.TestCase):
     def test_douyin_adapter_rejects_non_hybrid_adapter_task_request_before_session_lookup(self) -> None:
         from syvert.adapters.douyin import DouyinAdapter
 
         adapter = DouyinAdapter()
 
         with self.assertRaises(PlatformAdapterError) as raised:
-            adapter.execute(
-                AdapterTaskRequest(
-                    capability="content_detail",
-                    target_type="url",
-                    target_value="https://www.douyin.com/video/7580570616932224282",
-                    collection_mode="authenticated",
-                )
-            )
+            adapter.execute(build_douyin_execution_context(collection_mode="authenticated"))
 
         self.assertEqual(raised.exception.code, "invalid_douyin_request")
 
@@ -179,13 +205,7 @@ class DouyinAdapterTests(unittest.TestCase):
                 or {"status_code": 0, "aweme_detail": build_douyin_aweme_detail()},
             )
 
-            payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="douyin",
-                    capability="content_detail_by_url",
-                    input=TaskInput(url="https://www.douyin.com/video/7580570616932224282"),
-                )
-            )
+            payload = adapter.execute(build_douyin_execution_context())
 
         self.assertEqual(payload["raw"]["aweme_detail"]["aweme_id"], "7580570616932224282")
         self.assertEqual(payload["normalized"]["platform"], "douyin")
@@ -233,13 +253,7 @@ class DouyinAdapterTests(unittest.TestCase):
                 },
             )
 
-            payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="douyin",
-                    capability="content_detail_by_url",
-                    input=TaskInput(url="https://www.douyin.com/video/7580570616932224282"),
-                )
-            )
+            payload = adapter.execute(build_douyin_execution_context())
 
         self.assertEqual(payload["normalized"]["published_at"], None)
         self.assertEqual(payload["normalized"]["stats"]["like_count"], None)
@@ -275,13 +289,7 @@ class DouyinAdapterTests(unittest.TestCase):
             )
 
             with self.assertRaises(PlatformAdapterError) as raised:
-                adapter.execute(
-                    TaskRequest(
-                        adapter_key="douyin",
-                        capability="content_detail_by_url",
-                        input=TaskInput(url="https://www.douyin.com/video/7580570616932224282"),
-                    )
-                )
+                adapter.execute(build_douyin_execution_context())
 
         self.assertEqual(raised.exception.code, "douyin_detail_request_failed")
         self.assertEqual(raised.exception.details["platform_code"], 2190008)
@@ -321,13 +329,7 @@ class DouyinAdapterTests(unittest.TestCase):
                 },
             )
 
-            payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="douyin",
-                    capability="content_detail_by_url",
-                    input=TaskInput(url="https://www.douyin.com/video/7580570616932224282"),
-                )
-            )
+            payload = adapter.execute(build_douyin_execution_context())
 
         self.assertEqual(payload["normalized"]["body_text"], "浏览器回退正文")
         self.assertEqual(payload["raw"]["status_code"], 0)
@@ -362,10 +364,12 @@ class DouyinAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="douyin",
-                    capability="content_detail_by_url",
-                    input=TaskInput(url="https://www.douyin.com/video/7580570616932224282"),
+                build_douyin_execution_context(
+                    account_material={
+                        "cookies": "a=1; b=2",
+                        "user_agent": "Mozilla/5.0 TestAgent",
+                        "sign_base_url": "http://127.0.0.1:8000",
+                    }
                 )
             )
 
@@ -410,13 +414,7 @@ class DouyinAdapterTests(unittest.TestCase):
             )
 
             with self.assertRaises(PlatformAdapterError) as raised:
-                adapter.execute(
-                    TaskRequest(
-                        adapter_key="douyin",
-                        capability="content_detail_by_url",
-                        input=TaskInput(url="https://www.douyin.com/video/7580570616932224282"),
-                    )
-                )
+                adapter.execute(build_douyin_execution_context())
 
         self.assertEqual(raised.exception.code, "douyin_detail_request_failed")
 
@@ -456,13 +454,7 @@ class DouyinAdapterTests(unittest.TestCase):
                 },
             )
 
-            payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="douyin",
-                    capability="content_detail_by_url",
-                    input=TaskInput(url="https://www.douyin.com/video/7580570616932224282"),
-                )
-            )
+            payload = adapter.execute(build_douyin_execution_context())
 
         self.assertEqual(payload["normalized"]["body_text"], "浏览器请求回退正文")
         self.assertEqual(payload["raw"]["status_code"], 0)
@@ -473,11 +465,11 @@ class DouyinAdapterTests(unittest.TestCase):
         from syvert.adapters.douyin import DouyinAdapter
 
         adapter = DouyinAdapter(
-            session_provider=lambda path: (_ for _ in ()).throw(
+            sign_transport=lambda base_url, payload, timeout_seconds: (_ for _ in ()).throw(
                 PlatformAdapterError(
-                    code="douyin_session_missing",
-                    message="抖音会话文件不存在",
-                    details={"session_path": str(path)},
+                    code="douyin_sign_unavailable",
+                    message="抖音签名服务不可用",
+                    details={"base_url": base_url},
                 )
             )
         )
@@ -494,4 +486,4 @@ class DouyinAdapterTests(unittest.TestCase):
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "platform")
-        self.assertEqual(envelope["error"]["code"], "douyin_session_missing")
+        self.assertEqual(envelope["error"]["code"], "douyin_sign_unavailable")

--- a/tests/runtime/test_douyin_adapter.py
+++ b/tests/runtime/test_douyin_adapter.py
@@ -86,6 +86,8 @@ def build_douyin_execution_context(
 
 
 class DouyinAdapterTests(ResourceStoreEnvMixin, unittest.TestCase):
+    resource_store_adapter_key = "douyin"
+
     def test_douyin_adapter_rejects_non_hybrid_adapter_task_request_before_session_lookup(self) -> None:
         from syvert.adapters.douyin import DouyinAdapter
 

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -6,9 +6,10 @@ import unittest
 from unittest import mock
 
 from syvert.runtime import TaskInput, TaskRequest, execute_task
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
-class TaskRecordStoreEnvMixin:
+class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
     def setUp(self) -> None:
         super().setUp()
         self._task_record_store_dir = tempfile.TemporaryDirectory()

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -10,6 +10,8 @@ from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
 class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
+    resource_store_adapter_key = "xhs"
+
     def setUp(self) -> None:
         super().setUp()
         self._task_record_store_dir = tempfile.TemporaryDirectory()

--- a/tests/runtime/test_real_adapter_regression.py
+++ b/tests/runtime/test_real_adapter_regression.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
+import tempfile
 import unittest
 from unittest import mock
 
@@ -105,6 +108,20 @@ def canonical_regression_evidence_refs() -> list[str]:
 
 
 class RealAdapterRegressionTests(ResourceStoreEnvMixin, unittest.TestCase):
+    def test_build_real_adapter_regression_payload_runs_in_clean_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.dict(
+            os.environ,
+            {"SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": str(Path(temp_dir) / "fresh-resource-store.json")},
+            clear=False,
+        ):
+            payload = build_real_adapter_regression_payload(
+                version="v0.2.0",
+                adapters=self.hermetic_adapters(),
+            )
+
+        self.assertEqual(payload["adapter_results"][0]["cases"][0]["observed_status"], "success")
+        self.assertEqual(payload["adapter_results"][1]["cases"][1]["observed_error_category"], "platform")
+
     def test_build_real_adapter_regression_payload_emits_frozen_matrix(self) -> None:
         payload = build_real_adapter_regression_payload(
             version="v0.2.0",

--- a/tests/runtime/test_real_adapter_regression.py
+++ b/tests/runtime/test_real_adapter_regression.py
@@ -17,6 +17,7 @@ from syvert.version_gate import (
     validate_real_adapter_regression_source_report,
 )
 from tests.runtime.platform_leakage_fixtures import canonical_platform_leakage_payload
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
 class ShapeContractSpoofAdapter:
@@ -103,7 +104,7 @@ def canonical_regression_evidence_refs() -> list[str]:
     ]
 
 
-class RealAdapterRegressionTests(unittest.TestCase):
+class RealAdapterRegressionTests(ResourceStoreEnvMixin, unittest.TestCase):
     def test_build_real_adapter_regression_payload_emits_frozen_matrix(self) -> None:
         payload = build_real_adapter_regression_payload(
             version="v0.2.0",

--- a/tests/runtime/test_resource_bootstrap.py
+++ b/tests/runtime/test_resource_bootstrap.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from syvert.resource_lifecycle import AcquireRequest, ResourceBundle, ReleaseRequest, acquire, release
 from syvert.resource_bootstrap import (
     bootstrap_resource_store,
     build_bootstrap_records,
@@ -38,6 +39,7 @@ class ResourceBootstrapTests(unittest.TestCase):
                 "user_agent": "Mozilla/5.0 TestAgent",
                 "sign_base_url": "http://127.0.0.1:8000",
                 "timeout_seconds": 5,
+                "managed_adapter_key": "xhs",
             },
         )
 
@@ -71,6 +73,7 @@ class ResourceBootstrapTests(unittest.TestCase):
         self.assertEqual(material["webid"], "webid-1")
         self.assertEqual(material["sign_base_url"], "http://127.0.0.1:8000")
         self.assertEqual(material["timeout_seconds"], 5)
+        self.assertEqual(material["managed_adapter_key"], "douyin")
 
     def test_build_bootstrap_records_validates_account_material(self) -> None:
         with self.assertRaisesRegex(ValueError, "cookies"):
@@ -160,3 +163,107 @@ class ResourceBootstrapTests(unittest.TestCase):
         resources = {record.resource_id: record for record in snapshot.resources}
         self.assertEqual(resources["xhs-account-main"].material["cookies"], "a=1; b=2")
         self.assertEqual(resources["proxy-main"].material["proxy_endpoint"], "http://proxy-001")
+
+    def test_bootstrap_cli_keeps_adapter_accounts_isolated_in_shared_store(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store_file = Path(temp_dir) / "resource-lifecycle.json"
+            xhs_session_file = Path(temp_dir) / "xhs.session.json"
+            douyin_session_file = Path(temp_dir) / "douyin.session.json"
+            proxy_file = Path(temp_dir) / "proxy.json"
+            xhs_session_file.write_text(
+                json.dumps(
+                    {
+                        "cookies": "xhs=1",
+                        "user_agent": "Mozilla/5.0 XhsAgent",
+                        "sign_base_url": "http://127.0.0.1:8000",
+                        "timeout_seconds": 5,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            douyin_session_file.write_text(
+                json.dumps(
+                    {
+                        "cookies": "douyin=1",
+                        "user_agent": "Mozilla/5.0 DouyinAgent",
+                        "verify_fp": "verify-1",
+                        "ms_token": "ms-token-1",
+                        "webid": "webid-1",
+                        "sign_base_url": "http://127.0.0.1:8000",
+                        "timeout_seconds": 5,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            proxy_file.write_text(json.dumps({"proxy_endpoint": "http://proxy-001"}), encoding="utf-8")
+
+            for adapter_key, resource_id, session_file in (
+                ("xhs", "xhs-account-main", xhs_session_file),
+                ("douyin", "douyin-account-main", douyin_session_file),
+            ):
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "syvert.resource_bootstrap_cli",
+                        "--adapter",
+                        adapter_key,
+                        "--account-resource-id",
+                        resource_id,
+                        "--account-session-file",
+                        str(session_file),
+                        "--proxy-resource-id",
+                        "proxy-main",
+                        "--proxy-material-file",
+                        str(proxy_file),
+                        "--store-file",
+                        str(store_file),
+                    ],
+                    cwd=REPO_ROOT,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            store = LocalResourceLifecycleStore(store_file)
+
+            xhs_bundle = acquire(
+                AcquireRequest(
+                    task_id="task-xhs",
+                    adapter_key="xhs",
+                    capability="content_detail_by_url",
+                    requested_slots=("account", "proxy"),
+                ),
+                store,
+                "task-xhs",
+            )
+            self.assertIsInstance(xhs_bundle, ResourceBundle)
+            assert isinstance(xhs_bundle, ResourceBundle)
+            assert xhs_bundle.account is not None
+            self.assertEqual(xhs_bundle.account.resource_id, "xhs-account-main")
+            release(
+                ReleaseRequest(
+                    task_id="task-xhs",
+                    lease_id=xhs_bundle.lease_id,
+                    target_status_after_release="AVAILABLE",
+                    reason="test",
+                ),
+                store,
+                "task-xhs",
+            )
+
+            douyin_bundle = acquire(
+                AcquireRequest(
+                    task_id="task-douyin",
+                    adapter_key="douyin",
+                    capability="content_detail_by_url",
+                    requested_slots=("account", "proxy"),
+                ),
+                store,
+                "task-douyin",
+            )
+            self.assertIsInstance(douyin_bundle, ResourceBundle)
+            assert isinstance(douyin_bundle, ResourceBundle)
+            assert douyin_bundle.account is not None
+            self.assertEqual(douyin_bundle.account.resource_id, "douyin-account-main")

--- a/tests/runtime/test_resource_bootstrap.py
+++ b/tests/runtime/test_resource_bootstrap.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from syvert.resource_bootstrap import (
+    bootstrap_resource_store,
+    build_bootstrap_records,
+    canonicalize_account_material,
+    load_account_material,
+)
+from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ResourceBootstrapTests(unittest.TestCase):
+    def test_canonicalize_xhs_account_material_preserves_runtime_contract(self) -> None:
+        material = canonicalize_account_material(
+            adapter_key="xhs",
+            material={
+                "cookies": "a=1; b=2",
+                "user_agent": "Mozilla/5.0 TestAgent",
+                "sign_base_url": "http://127.0.0.1:8000",
+                "timeout_seconds": "5",
+            },
+        )
+
+        self.assertEqual(
+            material,
+            {
+                "cookies": "a=1; b=2",
+                "user_agent": "Mozilla/5.0 TestAgent",
+                "sign_base_url": "http://127.0.0.1:8000",
+                "timeout_seconds": 5,
+            },
+        )
+
+    def test_load_account_material_from_legacy_douyin_session_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session_file = Path(temp_dir) / "douyin.session.json"
+            session_file.write_text(
+                json.dumps(
+                    {
+                        "cookies": "a=1; b=2",
+                        "user_agent": "Mozilla/5.0 TestAgent",
+                        "verify_fp": "verify-1",
+                        "ms_token": "ms-token-1",
+                        "webid": "webid-1",
+                        "sign_base_url": "http://127.0.0.1:8000",
+                        "timeout_seconds": 5,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            material = load_account_material(
+                adapter_key="douyin",
+                account_session_file=session_file,
+            )
+
+        self.assertEqual(material["cookies"], "a=1; b=2")
+        self.assertEqual(material["user_agent"], "Mozilla/5.0 TestAgent")
+        self.assertEqual(material["verify_fp"], "verify-1")
+        self.assertEqual(material["ms_token"], "ms-token-1")
+        self.assertEqual(material["webid"], "webid-1")
+        self.assertEqual(material["sign_base_url"], "http://127.0.0.1:8000")
+        self.assertEqual(material["timeout_seconds"], 5)
+
+    def test_build_bootstrap_records_validates_account_material(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cookies"):
+            build_bootstrap_records(
+                adapter_key="xhs",
+                account_resource_id="xhs-account-main",
+                account_material={"user_agent": "Mozilla/5.0 TestAgent"},
+                proxy_resource_id="proxy-main",
+                proxy_material={"proxy_endpoint": "http://proxy-001"},
+            )
+
+    def test_bootstrap_resource_store_seeds_managed_resources(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = LocalResourceLifecycleStore(Path(temp_dir) / "resource-lifecycle.json")
+            records = build_bootstrap_records(
+                adapter_key="xhs",
+                account_resource_id="xhs-account-main",
+                account_material={
+                    "cookies": "a=1; b=2",
+                    "user_agent": "Mozilla/5.0 TestAgent",
+                    "sign_base_url": "http://127.0.0.1:8000",
+                    "timeout_seconds": 5,
+                },
+                proxy_resource_id="proxy-main",
+                proxy_material={"proxy_endpoint": "http://proxy-001"},
+            )
+
+            seeded = bootstrap_resource_store(store=store, records=records)
+
+            self.assertEqual({record.resource_id for record in seeded}, {"xhs-account-main", "proxy-main"})
+            snapshot = store.load_snapshot()
+
+        self.assertEqual(snapshot.revision, 1)
+        self.assertEqual({record.resource_id for record in snapshot.resources}, {"xhs-account-main", "proxy-main"})
+
+    def test_bootstrap_script_seeds_store_from_legacy_session_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store_file = Path(temp_dir) / "resource-lifecycle.json"
+            session_file = Path(temp_dir) / "xhs.session.json"
+            proxy_file = Path(temp_dir) / "proxy.json"
+            session_file.write_text(
+                json.dumps(
+                    {
+                        "cookies": "a=1; b=2",
+                        "user_agent": "Mozilla/5.0 TestAgent",
+                        "sign_base_url": "http://127.0.0.1:8000",
+                        "timeout_seconds": 5,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            proxy_file.write_text(json.dumps({"proxy_endpoint": "http://proxy-001"}), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/bootstrap_resource_lifecycle_store.py",
+                    "--adapter",
+                    "xhs",
+                    "--account-resource-id",
+                    "xhs-account-main",
+                    "--account-session-file",
+                    str(session_file),
+                    "--proxy-resource-id",
+                    "proxy-main",
+                    "--proxy-material-file",
+                    str(proxy_file),
+                    "--store-file",
+                    str(store_file),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["store_file"], str(store_file))
+            self.assertEqual(payload["adapter_key"], "xhs")
+            self.assertEqual(payload["seeded_resource_ids"], ["proxy-main", "xhs-account-main"])
+
+            snapshot = LocalResourceLifecycleStore(store_file).load_snapshot()
+
+        self.assertEqual(snapshot.revision, 1)
+        resources = {record.resource_id: record for record in snapshot.resources}
+        self.assertEqual(resources["xhs-account-main"].material["cookies"], "a=1; b=2")
+        self.assertEqual(resources["proxy-main"].material["proxy_endpoint"], "http://proxy-001")

--- a/tests/runtime/test_resource_bootstrap.py
+++ b/tests/runtime/test_resource_bootstrap.py
@@ -127,7 +127,8 @@ class ResourceBootstrapTests(unittest.TestCase):
             result = subprocess.run(
                 [
                     sys.executable,
-                    "scripts/bootstrap_resource_lifecycle_store.py",
+                    "-m",
+                    "syvert.resource_bootstrap_cli",
                     "--adapter",
                     "xhs",
                     "--account-resource-id",

--- a/tests/runtime/test_resource_lifecycle.py
+++ b/tests/runtime/test_resource_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import fcntl
 import json
 import os
@@ -41,7 +42,49 @@ class ResourceStoreEnvMixin:
         super().tearDown()
 
     def make_store(self):
-        return default_resource_lifecycle_store()
+        return TaggedAccountStore(default_resource_lifecycle_store())
+
+
+class TaggedAccountStore:
+    def __init__(self, inner_store, *, default_adapter_key: str = "xhs") -> None:
+        self._inner_store = inner_store
+        self._default_adapter_key = default_adapter_key
+
+    def load_snapshot(self):
+        return self._inner_store.load_snapshot()
+
+    def write_snapshot(self, snapshot):
+        return self._inner_store.write_snapshot(snapshot)
+
+    def seed_resources(self, records: Sequence[ResourceRecord]):
+        if not isinstance(records, Sequence):
+            return self._inner_store.seed_resources(records)
+        return self._inner_store.seed_resources(_tag_default_accounts(records, adapter_key=self._default_adapter_key))
+
+
+def _tag_default_accounts(
+    records: Sequence[ResourceRecord],
+    *,
+    adapter_key: str,
+) -> list[ResourceRecord]:
+    tagged: list[ResourceRecord] = []
+    for record in records:
+        material = record.material
+        if record.resource_type != "account" or not isinstance(material, Mapping):
+            tagged.append(record)
+            continue
+        if MANAGED_ACCOUNT_ADAPTER_KEY_FIELD in material:
+            tagged.append(record)
+            continue
+        tagged.append(
+            ResourceRecord(
+                resource_id=record.resource_id,
+                resource_type=record.resource_type,
+                status=record.status,
+                material={**dict(material), MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key},
+            )
+        )
+    return tagged
 
 
 class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):

--- a/tests/runtime/test_resource_lifecycle.py
+++ b/tests/runtime/test_resource_lifecycle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
 import fcntl
 import json
 import os
@@ -42,49 +41,13 @@ class ResourceStoreEnvMixin:
         super().tearDown()
 
     def make_store(self):
-        return TaggedAccountStore(default_resource_lifecycle_store())
+        return default_resource_lifecycle_store()
 
 
-class TaggedAccountStore:
-    def __init__(self, inner_store, *, default_adapter_key: str = "xhs") -> None:
-        self._inner_store = inner_store
-        self._default_adapter_key = default_adapter_key
-
-    def load_snapshot(self):
-        return self._inner_store.load_snapshot()
-
-    def write_snapshot(self, snapshot):
-        return self._inner_store.write_snapshot(snapshot)
-
-    def seed_resources(self, records: Sequence[ResourceRecord]):
-        if not isinstance(records, Sequence):
-            return self._inner_store.seed_resources(records)
-        return self._inner_store.seed_resources(_tag_default_accounts(records, adapter_key=self._default_adapter_key))
-
-
-def _tag_default_accounts(
-    records: Sequence[ResourceRecord],
-    *,
-    adapter_key: str,
-) -> list[ResourceRecord]:
-    tagged: list[ResourceRecord] = []
-    for record in records:
-        material = record.material
-        if record.resource_type != "account" or not isinstance(material, Mapping):
-            tagged.append(record)
-            continue
-        if MANAGED_ACCOUNT_ADAPTER_KEY_FIELD in material:
-            tagged.append(record)
-            continue
-        tagged.append(
-            ResourceRecord(
-                resource_id=record.resource_id,
-                resource_type=record.resource_type,
-                status=record.status,
-                material={**dict(material), MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key},
-            )
-        )
-    return tagged
+def managed_account_material(material: dict[str, object], *, adapter_key: str = "xhs") -> dict[str, object]:
+    if MANAGED_ACCOUNT_ADAPTER_KEY_FIELD in material:
+        return dict(material)
+    return {**material, MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key}
 
 
 class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
@@ -95,7 +58,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 ),
                 ResourceRecord(
                     resource_id="proxy-001",
@@ -154,13 +117,13 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 ),
                 ResourceRecord(
                     resource_id="account-002",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-002"},
+                    material=managed_account_material({"provider_account_id": "pa-002"}),
                 ),
             ]
         )
@@ -233,7 +196,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -269,7 +232,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -391,6 +354,39 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result["error"]["category"], "runtime_contract")
         self.assertEqual(result["error"]["code"], "resource_unavailable")
 
+    def test_acquire_fails_closed_when_legacy_account_lacks_managed_adapter_key(self) -> None:
+        self.make_store().seed_resources(
+            [
+                ResourceRecord(
+                    resource_id="legacy-account-001",
+                    resource_type="account",
+                    status="AVAILABLE",
+                    material={"provider_account_id": "pa-legacy"},
+                ),
+                ResourceRecord(
+                    resource_id="proxy-001",
+                    resource_type="proxy",
+                    status="AVAILABLE",
+                    material={"proxy_endpoint": "http://proxy-001"},
+                ),
+            ]
+        )
+
+        result = acquire(
+            AcquireRequest(
+                task_id="task-adapter-xhs-legacy",
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                requested_slots=("account", "proxy"),
+            ),
+            self.make_store(),
+            "task-context-adapter-xhs-legacy",
+        )
+
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["error"]["category"], "runtime_contract")
+        self.assertEqual(result["error"]["code"], "resource_unavailable")
+
     def test_acquire_rejects_duplicate_slots(self) -> None:
         self.seed_default_resources()
 
@@ -450,7 +446,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="INVALID",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -802,7 +798,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -872,7 +868,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -951,7 +947,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 ),
                 ResourceRecord(
                     resource_id="proxy-001",
@@ -1079,7 +1075,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                         resource_id="account-in-use",
                         resource_type="account",
                         status="IN_USE",
-                        material={"provider_account_id": "pa-in-use"},
+                        material=managed_account_material({"provider_account_id": "pa-in-use"}),
                     )
                 ]
             )
@@ -1298,7 +1294,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                             resource_id="",
                             resource_type="account",
                             status="AVAILABLE",
-                            material={"provider_account_id": "pa-invalid"},
+                            material=managed_account_material({"provider_account_id": "pa-invalid"}),
                         ),
                     ),
                     leases=(),
@@ -1333,7 +1329,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                             "resource_id": "account-mapping",
                             "resource_type": "account",
                             "status": "AVAILABLE",
-                            "material": {"vals": ("a", "b")},
+                            "material": managed_account_material({"vals": ("a", "b")}),
                         }
                     ],
                     "leases": [],
@@ -1356,7 +1352,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertIsInstance(result, ResourceBundle)
         assert isinstance(result, ResourceBundle)
         assert result.account is not None
-        self.assertEqual(result.account.material, {"vals": ["a", "b"]})
+        self.assertEqual(result.account.material, managed_account_material({"vals": ["a", "b"]}))
 
     def test_acquire_canonicalizes_material_from_in_memory_snapshot(self) -> None:
         class TupleMaterialStore:
@@ -1369,7 +1365,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                             resource_id="account-tuple",
                             resource_type="account",
                             status="AVAILABLE",
-                            material={"vals": ("a", "b")},
+                            material=managed_account_material({"vals": ("a", "b")}),
                         ),
                     ),
                     leases=(),
@@ -1392,7 +1388,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertIsInstance(result, ResourceBundle)
         assert isinstance(result, ResourceBundle)
         assert result.account is not None
-        self.assertEqual(result.account.material, {"vals": ["a", "b"]})
+        self.assertEqual(result.account.material, managed_account_material({"vals": ["a", "b"]}))
 
     def test_acquire_returns_failed_envelope_for_invalid_mapping_snapshot(self) -> None:
         class InvalidMappingSnapshotStore:
@@ -1433,7 +1429,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                             resource_id="account-001",
                             resource_type="account",
                             status="AVAILABLE",
-                            material={"provider_account_id": "pa-001"},
+                            material=managed_account_material({"provider_account_id": "pa-001"}),
                         ),
                     ),
                     leases=(),
@@ -1476,7 +1472,7 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
                             resource_id="account-001",
                             resource_type="account",
                             status="AVAILABLE",
-                            material={"provider_account_id": "pa-001"},
+                            material=managed_account_material({"provider_account_id": "pa-001"}),
                         ),
                     ),
                     leases=(),

--- a/tests/runtime/test_resource_lifecycle.py
+++ b/tests/runtime/test_resource_lifecycle.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest import mock
 
 from syvert.resource_lifecycle import (
+    MANAGED_ACCOUNT_ADAPTER_KEY_FIELD,
     AcquireRequest,
     ReleaseRequest,
     ResourceBundle,
@@ -247,6 +248,105 @@ class ResourceLifecycleTests(ResourceStoreEnvMixin, unittest.TestCase):
         snapshot = self.make_store().load_snapshot()
         self.assertEqual(snapshot.leases, ())
         self.assertEqual(snapshot.resources[0].status, "AVAILABLE")
+
+    def test_acquire_selects_only_adapter_compatible_managed_accounts(self) -> None:
+        self.make_store().seed_resources(
+            [
+                ResourceRecord(
+                    resource_id="douyin-account-001",
+                    resource_type="account",
+                    status="AVAILABLE",
+                    material={MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: "douyin", "provider_account_id": "pa-douyin"},
+                ),
+                ResourceRecord(
+                    resource_id="proxy-001",
+                    resource_type="proxy",
+                    status="AVAILABLE",
+                    material={"proxy_endpoint": "http://proxy-001"},
+                ),
+                ResourceRecord(
+                    resource_id="xhs-account-001",
+                    resource_type="account",
+                    status="AVAILABLE",
+                    material={MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: "xhs", "provider_account_id": "pa-xhs"},
+                ),
+            ]
+        )
+
+        xhs_bundle = acquire(
+            AcquireRequest(
+                task_id="task-adapter-xhs",
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                requested_slots=("account", "proxy"),
+            ),
+            self.make_store(),
+            "task-context-adapter-xhs",
+        )
+
+        self.assertIsInstance(xhs_bundle, ResourceBundle)
+        assert isinstance(xhs_bundle, ResourceBundle)
+        assert xhs_bundle.account is not None
+        self.assertEqual(xhs_bundle.account.resource_id, "xhs-account-001")
+        release(
+            ReleaseRequest(
+                task_id="task-adapter-xhs",
+                lease_id=xhs_bundle.lease_id,
+                target_status_after_release="AVAILABLE",
+                reason="test",
+            ),
+            self.make_store(),
+            "task-context-adapter-xhs",
+        )
+
+        douyin_bundle = acquire(
+            AcquireRequest(
+                task_id="task-adapter-douyin",
+                adapter_key="douyin",
+                capability="content_detail_by_url",
+                requested_slots=("account", "proxy"),
+            ),
+            self.make_store(),
+            "task-context-adapter-douyin",
+        )
+
+        self.assertIsInstance(douyin_bundle, ResourceBundle)
+        assert isinstance(douyin_bundle, ResourceBundle)
+        assert douyin_bundle.account is not None
+        self.assertEqual(douyin_bundle.account.resource_id, "douyin-account-001")
+
+    def test_acquire_fails_closed_when_only_mismatched_managed_account_exists(self) -> None:
+        self.make_store().seed_resources(
+            [
+                ResourceRecord(
+                    resource_id="douyin-account-001",
+                    resource_type="account",
+                    status="AVAILABLE",
+                    material={MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: "douyin", "provider_account_id": "pa-douyin"},
+                ),
+                ResourceRecord(
+                    resource_id="proxy-001",
+                    resource_type="proxy",
+                    status="AVAILABLE",
+                    material={"proxy_endpoint": "http://proxy-001"},
+                ),
+            ]
+        )
+
+        result = acquire(
+            AcquireRequest(
+                task_id="task-adapter-xhs-mismatch",
+                adapter_key="xhs",
+                capability="content_detail_by_url",
+                requested_slots=("account", "proxy"),
+            ),
+            self.make_store(),
+            "task-context-adapter-xhs-mismatch",
+        )
+
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["error"]["category"], "runtime_contract")
+        self.assertEqual(result["error"]["code"], "resource_unavailable")
 
     def test_acquire_rejects_duplicate_slots(self) -> None:
         self.seed_default_resources()

--- a/tests/runtime/test_resource_lifecycle_store.py
+++ b/tests/runtime/test_resource_lifecycle_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 import json
 import os
 import tempfile
@@ -9,6 +10,7 @@ from pathlib import Path
 from unittest import mock
 
 from syvert.resource_lifecycle import (
+    MANAGED_ACCOUNT_ADAPTER_KEY_FIELD,
     AcquireRequest,
     ReleaseRequest,
     ResourceBundle,
@@ -39,7 +41,49 @@ class ResourceStoreEnvMixin:
         super().tearDown()
 
     def make_store(self):
-        return default_resource_lifecycle_store()
+        return TaggedAccountStore(default_resource_lifecycle_store())
+
+
+class TaggedAccountStore:
+    def __init__(self, inner_store, *, default_adapter_key: str = "xhs") -> None:
+        self._inner_store = inner_store
+        self._default_adapter_key = default_adapter_key
+
+    def load_snapshot(self):
+        return self._inner_store.load_snapshot()
+
+    def write_snapshot(self, snapshot):
+        return self._inner_store.write_snapshot(snapshot)
+
+    def seed_resources(self, records: Sequence[ResourceRecord]):
+        if not isinstance(records, Sequence):
+            return self._inner_store.seed_resources(records)
+        return self._inner_store.seed_resources(_tag_default_accounts(records, adapter_key=self._default_adapter_key))
+
+
+def _tag_default_accounts(
+    records: Sequence[ResourceRecord],
+    *,
+    adapter_key: str,
+) -> list[ResourceRecord]:
+    tagged: list[ResourceRecord] = []
+    for record in records:
+        material = record.material
+        if record.resource_type != "account" or not isinstance(material, Mapping):
+            tagged.append(record)
+            continue
+        if MANAGED_ACCOUNT_ADAPTER_KEY_FIELD in material:
+            tagged.append(record)
+            continue
+        tagged.append(
+            ResourceRecord(
+                resource_id=record.resource_id,
+                resource_type=record.resource_type,
+                status=record.status,
+                material={**dict(material), MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key},
+            )
+        )
+    return tagged
 
 
 class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
@@ -455,7 +499,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(len(seeded), 1)
         self.assertEqual(len(replayed), 1)
         self.assertEqual(snapshot.revision, 1)
-        self.assertEqual(snapshot.resources[0].material, {"vals": ["a", "b"]})
+        self.assertEqual(snapshot.resources[0].material, {"managed_adapter_key": "xhs", "vals": ["a", "b"]})
 
     def test_seed_resources_merges_disjoint_concurrent_inserts(self) -> None:
         store = self.make_store()

--- a/tests/runtime/test_resource_lifecycle_store.py
+++ b/tests/runtime/test_resource_lifecycle_store.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
 import json
 import os
 import tempfile
@@ -41,49 +40,13 @@ class ResourceStoreEnvMixin:
         super().tearDown()
 
     def make_store(self):
-        return TaggedAccountStore(default_resource_lifecycle_store())
+        return default_resource_lifecycle_store()
 
 
-class TaggedAccountStore:
-    def __init__(self, inner_store, *, default_adapter_key: str = "xhs") -> None:
-        self._inner_store = inner_store
-        self._default_adapter_key = default_adapter_key
-
-    def load_snapshot(self):
-        return self._inner_store.load_snapshot()
-
-    def write_snapshot(self, snapshot):
-        return self._inner_store.write_snapshot(snapshot)
-
-    def seed_resources(self, records: Sequence[ResourceRecord]):
-        if not isinstance(records, Sequence):
-            return self._inner_store.seed_resources(records)
-        return self._inner_store.seed_resources(_tag_default_accounts(records, adapter_key=self._default_adapter_key))
-
-
-def _tag_default_accounts(
-    records: Sequence[ResourceRecord],
-    *,
-    adapter_key: str,
-) -> list[ResourceRecord]:
-    tagged: list[ResourceRecord] = []
-    for record in records:
-        material = record.material
-        if record.resource_type != "account" or not isinstance(material, Mapping):
-            tagged.append(record)
-            continue
-        if MANAGED_ACCOUNT_ADAPTER_KEY_FIELD in material:
-            tagged.append(record)
-            continue
-        tagged.append(
-            ResourceRecord(
-                resource_id=record.resource_id,
-                resource_type=record.resource_type,
-                status=record.status,
-                material={**dict(material), MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key},
-            )
-        )
-    return tagged
+def managed_account_material(material: dict[str, object], *, adapter_key: str = "xhs") -> dict[str, object]:
+    if MANAGED_ACCOUNT_ADAPTER_KEY_FIELD in material:
+        return dict(material)
+    return {**material, MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key}
 
 
 class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
@@ -100,7 +63,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -120,7 +83,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 ),
                 ResourceRecord(
                     resource_id="proxy-001",
@@ -167,7 +130,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -235,7 +198,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -264,7 +227,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -277,7 +240,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001", "marker": "first"},
+                    material=managed_account_material({"provider_account_id": "pa-001", "marker": "first"}),
                 ),
             ),
             leases=base_snapshot.leases,
@@ -292,7 +255,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001", "marker": "stale"},
+                    material=managed_account_material({"provider_account_id": "pa-001", "marker": "stale"}),
                 ),
             ),
             leases=base_snapshot.leases,
@@ -320,7 +283,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -333,7 +296,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001", "marker": "a"},
+                    material=managed_account_material({"provider_account_id": "pa-001", "marker": "a"}),
                 ),
             ),
             leases=base_snapshot.leases,
@@ -346,7 +309,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001", "marker": "b"},
+                    material=managed_account_material({"provider_account_id": "pa-001", "marker": "b"}),
                 ),
             ),
             leases=base_snapshot.leases,
@@ -386,7 +349,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -419,7 +382,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                         resource_id="account-001",
                         resource_type="account",
                         status="AVAILABLE",
-                        material={"provider_account_id": "pa-001", "marker": "revived"},
+                        material=managed_account_material({"provider_account_id": "pa-001", "marker": "revived"}),
                     )
                 ]
             )
@@ -432,7 +395,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -444,7 +407,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                         resource_id="account-001",
                         resource_type="account",
                         status="INVALID",
-                        material={"provider_account_id": "pa-001"},
+                        material=managed_account_material({"provider_account_id": "pa-001"}),
                     )
                 ]
             )
@@ -457,7 +420,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 )
             ]
         )
@@ -489,7 +452,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             resource_id="account-001",
             resource_type="account",
             status="AVAILABLE",
-            material={"vals": ("a", "b")},
+            material=managed_account_material({"vals": ("a", "b")}),
         )
 
         seeded = store.seed_resources([original])
@@ -520,7 +483,7 @@ class ResourceLifecycleStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                     resource_id="account-001",
                     resource_type="account",
                     status="AVAILABLE",
-                    material={"provider_account_id": "pa-001"},
+                    material=managed_account_material({"provider_account_id": "pa-001"}),
                 ),
             ),
         )

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -941,6 +941,36 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertIsNotNone(lease.released_at)
         self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
 
+    def test_execute_task_rejects_bundle_with_mismatched_lease_id_before_adapter_and_settles_real_lease(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/host-validation-lease-id"),
+        )
+        original_acquire = runtime_module.acquire_runtime_resource_bundle
+
+        def acquire_bundle_with_mutated_lease_id(**kwargs):
+            bundle = original_acquire(**kwargs)
+            return replace(bundle, lease_id="lease-bogus")
+
+        with mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=acquire_bundle_with_mutated_lease_id,
+        ):
+            envelope = execute_task(
+                request,
+                adapters={"stub": NeverCalledAdapter()},
+                task_id_factory=lambda: "task-host-validation-lease-id",
+            )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_bundle")
+        lease = self.lease_for_task("task-host-validation-lease-id")
+        self.assertEqual(lease.target_status_after_release, "AVAILABLE")
+        self.assertEqual(lease.release_reason, "host_side_bundle_validation_failed")
+        self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
+
     def test_execute_task_settles_success_without_hint_as_available(self) -> None:
         envelope = execute_task(
             TaskRequest(
@@ -1007,6 +1037,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_resource_disposition_hint")
         lease = self.lease_for_task("task-hint-mismatch")
         self.assertEqual(lease.target_status_after_release, "AVAILABLE")
@@ -1025,6 +1056,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         )
 
         self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
         self.assertEqual(envelope["error"]["code"], "invalid_resource_disposition_hint")
         lease = self.lease_for_task("task-hint-bad-status")
         self.assertEqual(lease.target_status_after_release, "AVAILABLE")

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -23,7 +23,7 @@ from syvert.runtime import (
     TaskRequest,
     execute_task,
 )
-from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin, seed_default_runtime_resources
 
 
 class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
@@ -1160,6 +1160,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["error"]["code"], "release_write_failed")
 
     def test_execute_task_maps_real_xhs_invalid_url_to_invalid_input(self) -> None:
+        seed_default_runtime_resources(adapter_key="xhs", account_resource_id="xhs-account-001")
         request = TaskRequest(
             adapter_key="xhs",
             capability="content_detail_by_url",
@@ -1177,6 +1178,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["error"]["code"], "invalid_xhs_url")
 
     def test_execute_task_maps_real_douyin_invalid_url_to_invalid_input(self) -> None:
+        seed_default_runtime_resources(adapter_key="douyin", account_resource_id="douyin-account-001")
         request = TaskRequest(
             adapter_key="douyin",
             capability="content_detail_by_url",

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -971,6 +971,44 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(lease.release_reason, "host_side_bundle_validation_failed")
         self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
 
+    def test_execute_task_rejects_bundle_with_tampered_material_and_acquired_at_before_adapter(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/host-validation-material"),
+        )
+        original_acquire = runtime_module.acquire_runtime_resource_bundle
+
+        def acquire_bundle_with_tampered_truth(**kwargs):
+            bundle = original_acquire(**kwargs)
+            tampered_account = replace(
+                bundle.account,
+                material={**bundle.account.material, "cookies": "tampered=1"},
+            )
+            return replace(
+                bundle,
+                acquired_at="2026-01-01T00:00:00Z",
+                account=tampered_account,
+            )
+
+        with mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=acquire_bundle_with_tampered_truth,
+        ):
+            envelope = execute_task(
+                request,
+                adapters={"stub": NeverCalledAdapter()},
+                task_id_factory=lambda: "task-host-validation-material",
+            )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_bundle")
+        lease = self.lease_for_task("task-host-validation-material")
+        self.assertEqual(lease.target_status_after_release, "AVAILABLE")
+        self.assertEqual(lease.release_reason, "host_side_bundle_validation_failed")
+        self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
+
     def test_execute_task_settles_success_without_hint_as_available(self) -> None:
         envelope = execute_task(
             TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 from collections.abc import Mapping
 import os
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Iterator, Tuple
 import unittest
 from unittest import mock
 
+import syvert.runtime as runtime_module
 from syvert.adapters.douyin import DouyinAdapter
 from syvert.adapters.xhs import XhsAdapter
+from syvert.resource_lifecycle_store import default_resource_lifecycle_store
 from syvert.runtime import (
+    AdapterExecutionContext,
     AdapterTaskRequest,
     CollectionPolicy,
     CoreTaskRequest,
@@ -20,9 +23,10 @@ from syvert.runtime import (
     TaskRequest,
     execute_task,
 )
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
-class TaskRecordStoreEnvMixin:
+class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
     def setUp(self) -> None:
         super().setUp()
         self._task_record_store_dir = tempfile.TemporaryDirectory()
@@ -182,6 +186,144 @@ class PlatformFailureAdapter:
         )
 
 
+class InvalidatingHintAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request: AdapterExecutionContext) -> dict[str, object]:
+        assert request.resource_bundle is not None
+        return {
+            "raw": {"id": "raw-invalid-hint"},
+            "normalized": {
+                "platform": "stub",
+                "content_id": "content-invalid-hint",
+                "content_type": "unknown",
+                "canonical_url": request.input.url,
+                "title": "",
+                "body_text": "",
+                "published_at": None,
+                "author": {
+                    "author_id": None,
+                    "display_name": None,
+                    "avatar_url": None,
+                },
+                "stats": {
+                    "like_count": None,
+                    "comment_count": None,
+                    "share_count": None,
+                    "collect_count": None,
+                },
+                "media": {
+                    "cover_url": None,
+                    "video_url": None,
+                    "image_urls": [],
+                },
+            },
+            "resource_disposition_hint": {
+                "lease_id": request.resource_bundle.lease_id,
+                "target_status_after_release": "INVALID",
+                "reason": "account_invalidated_by_adapter",
+            },
+        }
+
+
+class LeaseIdMismatchHintAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request: AdapterExecutionContext) -> dict[str, object]:
+        return {
+            "raw": {"id": "raw-bad-hint"},
+            "normalized": {
+                "platform": "stub",
+                "content_id": "content-bad-hint",
+                "content_type": "unknown",
+                "canonical_url": request.input.url,
+                "title": "",
+                "body_text": "",
+                "published_at": None,
+                "author": {
+                    "author_id": None,
+                    "display_name": None,
+                    "avatar_url": None,
+                },
+                "stats": {
+                    "like_count": None,
+                    "comment_count": None,
+                    "share_count": None,
+                    "collect_count": None,
+                },
+                "media": {
+                    "cover_url": None,
+                    "video_url": None,
+                    "image_urls": [],
+                },
+            },
+            "resource_disposition_hint": {
+                "lease_id": "lease-mismatch",
+                "target_status_after_release": "INVALID",
+                "reason": "bad_hint",
+            },
+        }
+
+
+class InvalidTargetStatusHintAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request: AdapterExecutionContext) -> dict[str, object]:
+        assert request.resource_bundle is not None
+        return {
+            "raw": {"id": "raw-bad-status-hint"},
+            "normalized": {
+                "platform": "stub",
+                "content_id": "content-bad-status-hint",
+                "content_type": "unknown",
+                "canonical_url": request.input.url,
+                "title": "",
+                "body_text": "",
+                "published_at": None,
+                "author": {
+                    "author_id": None,
+                    "display_name": None,
+                    "avatar_url": None,
+                },
+                "stats": {
+                    "like_count": None,
+                    "comment_count": None,
+                    "share_count": None,
+                    "collect_count": None,
+                },
+                "media": {
+                    "cover_url": None,
+                    "video_url": None,
+                    "image_urls": [],
+                },
+            },
+            "resource_disposition_hint": {
+                "lease_id": request.resource_bundle.lease_id,
+                "target_status_after_release": "IN_USE",
+                "reason": "bad_hint",
+            },
+        }
+
+
+class NeverCalledAdapter:
+    adapter_key = "stub"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request: AdapterExecutionContext):
+        raise AssertionError("adapter should not be called")
+
+
 class PrePlatformValidationAdapter:
     adapter_key = "stub"
     supported_capabilities = frozenset({"content_detail"})
@@ -326,6 +468,17 @@ class MissingExecuteAdapter:
 
 
 class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
+    def latest_snapshot(self):
+        return default_resource_lifecycle_store().load_snapshot()
+
+    def lease_for_task(self, task_id: str):
+        snapshot = self.latest_snapshot()
+        return next(lease for lease in snapshot.leases if lease.task_id == task_id)
+
+    def resource_statuses(self) -> dict[str, str]:
+        snapshot = self.latest_snapshot()
+        return {record.resource_id: record.status for record in snapshot.resources}
+
     def test_execute_task_builds_success_envelope_from_adapter_payload(self) -> None:
         adapter = SuccessfulAdapter()
         request = TaskRequest(
@@ -346,12 +499,13 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["status"], "success")
         self.assertIn("raw", envelope)
         self.assertEqual(envelope["normalized"]["canonical_url"], request.input.url)
-        self.assertIsInstance(adapter.last_request, AdapterTaskRequest)
-        self.assertEqual(adapter.last_request.capability, "content_detail")
-        self.assertEqual(adapter.last_request.target_type, "url")
-        self.assertEqual(adapter.last_request.target_value, request.input.url)
-        self.assertEqual(adapter.last_request.collection_mode, "hybrid")
-        self.assertFalse(hasattr(adapter.last_request, "adapter_key"))
+        self.assertIsInstance(adapter.last_request, AdapterExecutionContext)
+        self.assertEqual(adapter.last_request.request.capability, "content_detail")
+        self.assertEqual(adapter.last_request.request.target_type, "url")
+        self.assertEqual(adapter.last_request.request.target_value, request.input.url)
+        self.assertEqual(adapter.last_request.request.collection_mode, "hybrid")
+        self.assertIsNotNone(adapter.last_request.resource_bundle)
+        self.assertEqual(adapter.last_request.resource_bundle.capability, "content_detail_by_url")
 
     def test_execute_task_executes_core_request_through_adapter_projection(self) -> None:
         adapter = SuccessfulAdapter()
@@ -375,12 +529,13 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["status"], "success")
         self.assertEqual(envelope["adapter_key"], "stub")
         self.assertEqual(envelope["normalized"]["canonical_url"], request.target.target_value)
-        self.assertIsInstance(adapter.last_request, AdapterTaskRequest)
-        self.assertEqual(adapter.last_request.capability, "content_detail")
-        self.assertEqual(adapter.last_request.target_type, "url")
-        self.assertEqual(adapter.last_request.target_value, request.target.target_value)
-        self.assertEqual(adapter.last_request.collection_mode, "hybrid")
-        self.assertFalse(hasattr(adapter.last_request, "adapter_key"))
+        self.assertIsInstance(adapter.last_request, AdapterExecutionContext)
+        self.assertEqual(adapter.last_request.request.capability, "content_detail")
+        self.assertEqual(adapter.last_request.request.target_type, "url")
+        self.assertEqual(adapter.last_request.request.target_value, request.target.target_value)
+        self.assertEqual(adapter.last_request.request.collection_mode, "hybrid")
+        self.assertIsNotNone(adapter.last_request.resource_bundle)
+        self.assertEqual(adapter.last_request.resource_bundle.capability, "content_detail_by_url")
 
     def test_execute_task_maps_legacy_and_native_requests_to_same_adapter_projection(self) -> None:
         legacy_adapter = SuccessfulAdapter()
@@ -415,10 +570,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(native_envelope["status"], "success")
         self.assertEqual(legacy_envelope["raw"], native_envelope["raw"])
         self.assertEqual(legacy_envelope["normalized"], native_envelope["normalized"])
-        self.assertEqual(legacy_adapter.last_request, native_adapter.last_request)
-        self.assertEqual(legacy_adapter.last_request.target_type, "url")
-        self.assertEqual(legacy_adapter.last_request.target_value, legacy_request.input.url)
-        self.assertEqual(legacy_adapter.last_request.collection_mode, "hybrid")
+        self.assertEqual(legacy_adapter.last_request.request, native_adapter.last_request.request)
+        self.assertEqual(legacy_adapter.last_request.request.target_type, "url")
+        self.assertEqual(legacy_adapter.last_request.request.target_value, legacy_request.input.url)
+        self.assertEqual(legacy_adapter.last_request.request.collection_mode, "hybrid")
+        self.assertIsNotNone(legacy_adapter.last_request.resource_bundle)
+        self.assertIsNotNone(native_adapter.last_request.resource_bundle)
+        self.assertEqual(legacy_adapter.last_request.resource_bundle.capability, "content_detail_by_url")
+        self.assertEqual(native_adapter.last_request.resource_bundle.capability, "content_detail_by_url")
 
     def test_execute_task_rejects_unknown_target_type(self) -> None:
         request = CoreTaskRequest(
@@ -749,6 +908,186 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["error"]["category"], "platform")
         self.assertEqual(envelope["error"]["code"], "content_not_found")
         self.assertEqual(envelope["error"]["details"]["reason"], "missing")
+
+    def test_execute_task_releases_bundle_when_host_side_validation_fails_after_acquire(self) -> None:
+        request = TaskRequest(
+            adapter_key="stub",
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/host-validation"),
+        )
+        original_acquire = runtime_module.acquire_runtime_resource_bundle
+
+        def acquire_bundle_with_mutated_capability(**kwargs):
+            bundle = original_acquire(**kwargs)
+            return replace(bundle, capability="content_detail")
+
+        with mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=acquire_bundle_with_mutated_capability,
+        ):
+            envelope = execute_task(
+                request,
+                adapters={"stub": NeverCalledAdapter()},
+                task_id_factory=lambda: "task-host-validation",
+            )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_bundle")
+        lease = self.lease_for_task("task-host-validation")
+        self.assertEqual(lease.capability, "content_detail_by_url")
+        self.assertEqual(lease.target_status_after_release, "AVAILABLE")
+        self.assertEqual(lease.release_reason, "host_side_bundle_validation_failed")
+        self.assertIsNotNone(lease.released_at)
+        self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
+
+    def test_execute_task_settles_success_without_hint_as_available(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/no-hint-success"),
+            ),
+            adapters={"stub": SuccessfulAdapter()},
+            task_id_factory=lambda: "task-no-hint-success",
+        )
+
+        self.assertEqual(envelope["status"], "success")
+        lease = self.lease_for_task("task-no-hint-success")
+        self.assertEqual(lease.capability, "content_detail_by_url")
+        self.assertEqual(lease.target_status_after_release, "AVAILABLE")
+        self.assertEqual(lease.release_reason, "adapter_completed_without_disposition_hint")
+        self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
+
+    def test_execute_task_settles_failure_without_hint_as_available(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/no-hint-failure"),
+            ),
+            adapters={"stub": PlatformFailureAdapter()},
+            task_id_factory=lambda: "task-no-hint-failure",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["code"], "content_not_found")
+        lease = self.lease_for_task("task-no-hint-failure")
+        self.assertEqual(lease.target_status_after_release, "AVAILABLE")
+        self.assertEqual(lease.release_reason, "adapter_failed_without_disposition_hint")
+        self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
+
+    def test_execute_task_applies_invalidating_hint_without_leaking_internal_field(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/invalidating-hint"),
+            ),
+            adapters={"stub": InvalidatingHintAdapter()},
+            task_id_factory=lambda: "task-invalidating-hint",
+        )
+
+        self.assertEqual(envelope["status"], "success")
+        self.assertNotIn("resource_disposition_hint", envelope)
+        lease = self.lease_for_task("task-invalidating-hint")
+        self.assertEqual(lease.target_status_after_release, "INVALID")
+        self.assertEqual(lease.release_reason, "account_invalidated_by_adapter")
+        self.assertEqual(set(self.resource_statuses().values()), {"INVALID"})
+
+    def test_execute_task_rejects_mismatched_hint_lease_id_and_still_settles_bundle(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/hint-mismatch"),
+            ),
+            adapters={"stub": LeaseIdMismatchHintAdapter()},
+            task_id_factory=lambda: "task-hint-mismatch",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_disposition_hint")
+        lease = self.lease_for_task("task-hint-mismatch")
+        self.assertEqual(lease.target_status_after_release, "AVAILABLE")
+        self.assertEqual(lease.release_reason, "invalid_resource_disposition_hint")
+        self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
+
+    def test_execute_task_rejects_invalid_hint_target_status_and_still_settles_bundle(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key="stub",
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/hint-bad-status"),
+            ),
+            adapters={"stub": InvalidTargetStatusHintAdapter()},
+            task_id_factory=lambda: "task-hint-bad-status",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_disposition_hint")
+        lease = self.lease_for_task("task-hint-bad-status")
+        self.assertEqual(lease.target_status_after_release, "AVAILABLE")
+        self.assertEqual(lease.release_reason, "invalid_resource_disposition_hint")
+        self.assertEqual(set(self.resource_statuses().values()), {"AVAILABLE"})
+
+    def test_execute_task_release_failure_overrides_original_success(self) -> None:
+        with mock.patch(
+            "syvert.resource_lifecycle.release",
+            return_value={
+                "task_id": "task-release-overrides-success",
+                "adapter_key": "stub",
+                "capability": "content_detail_by_url",
+                "status": "failed",
+                "error": {
+                    "category": "runtime_contract",
+                    "code": "release_write_failed",
+                    "message": "release failed",
+                    "details": {},
+                },
+            },
+        ):
+            envelope = execute_task(
+                TaskRequest(
+                    adapter_key="stub",
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/posts/release-success"),
+                ),
+                adapters={"stub": SuccessfulAdapter()},
+                task_id_factory=lambda: "task-release-overrides-success",
+            )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["code"], "release_write_failed")
+
+    def test_execute_task_release_failure_overrides_original_failure(self) -> None:
+        with mock.patch(
+            "syvert.resource_lifecycle.release",
+            return_value={
+                "task_id": "task-release-overrides-failure",
+                "adapter_key": "stub",
+                "capability": "content_detail_by_url",
+                "status": "failed",
+                "error": {
+                    "category": "runtime_contract",
+                    "code": "release_write_failed",
+                    "message": "release failed",
+                    "details": {},
+                },
+            },
+        ):
+            envelope = execute_task(
+                TaskRequest(
+                    adapter_key="stub",
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/posts/release-failure"),
+                ),
+                adapters={"stub": PlatformFailureAdapter()},
+                task_id_factory=lambda: "task-release-overrides-failure",
+            )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["code"], "release_write_failed")
 
     def test_execute_task_maps_real_xhs_invalid_url_to_invalid_input(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -15,9 +15,10 @@ from syvert.task_record import (
     task_record_from_dict,
     task_record_to_dict,
 )
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
-class TaskRecordStoreEnvMixin:
+class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
     def setUp(self) -> None:
         super().setUp()
         self._task_record_store_dir = tempfile.TemporaryDirectory()

--- a/tests/runtime/test_task_record_store.py
+++ b/tests/runtime/test_task_record_store.py
@@ -15,6 +15,7 @@ from syvert.task_record import (
     start_task_record,
 )
 from syvert.task_record_store import LocalTaskRecordStore, TaskRecordStoreError
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
 class SuccessfulAdapter:
@@ -132,7 +133,7 @@ class BrokenInvalidationAndMoveLocalStore(BrokenInvalidationLocalStore):
         raise OSError("record-move-broken")
 
 
-class TaskRecordStoreTests(unittest.TestCase):
+class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
     def test_runtime_can_persist_and_reload_success_record(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))

--- a/tests/runtime/test_version_gate.py
+++ b/tests/runtime/test_version_gate.py
@@ -20,6 +20,7 @@ from syvert.version_gate import (
     validate_real_adapter_regression_source_report,
 )
 from tests.runtime.platform_leakage_fixtures import canonical_platform_leakage_payload
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
 
 
 DEFAULT_REQUIRED_HARNESS_SAMPLE_IDS = ["sample-success", "sample-legal-failure"]
@@ -30,7 +31,7 @@ def orchestrate_version_gate(**kwargs: object) -> dict[str, object]:
     return version_gate_module.orchestrate_version_gate(**kwargs)
 
 
-class VersionGateTests(unittest.TestCase):
+class VersionGateTests(ResourceStoreEnvMixin, unittest.TestCase):
     def test_version_gate_passes_when_all_sources_pass(self) -> None:
         harness_report = build_harness_source_report(
             self.valid_harness_results(),

--- a/tests/runtime/test_xhs_adapter.py
+++ b/tests/runtime/test_xhs_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import io
 import json
+import os
 from pathlib import Path
 import tempfile
 from threading import Thread
@@ -11,7 +12,14 @@ import unittest
 from unittest import mock
 
 from syvert.cli import main
-from syvert.runtime import AdapterTaskRequest, PlatformAdapterError, TaskInput, TaskRequest, execute_task
+from syvert.runtime import (
+    AdapterExecutionContext,
+    AdapterTaskRequest,
+    PlatformAdapterError,
+    TaskInput,
+    TaskRequest,
+    execute_task,
+)
 
 from syvert.adapters.xhs import (
     XhsAdapter,
@@ -21,6 +29,12 @@ from syvert.adapters.xhs import (
     normalize_detail_response,
     parse_xhs_detail_url,
     post_json,
+)
+from tests.runtime.resource_fixtures import (
+    ResourceStoreEnvMixin,
+    build_managed_resource_bundle,
+    seed_default_runtime_resources,
+    xhs_account_material,
 )
 
 
@@ -67,16 +81,53 @@ class FakeHttpResponse:
         return False
 
 
-class XhsAdapterTests(unittest.TestCase):
+def build_xhs_account_material(**overrides: Any) -> dict[str, Any]:
+    material = xhs_account_material()
+    material.update(overrides)
+    return material
+
+
+class XhsAdapterTests(ResourceStoreEnvMixin, unittest.TestCase):
+    def build_xhs_context(
+        self,
+        *,
+        url: str,
+        collection_mode: str = "hybrid",
+        account_material: dict[str, Any] | None = None,
+        resource_bundle: bool = True,
+        requested_slots: tuple[str, ...] = ("account", "proxy"),
+        task_id: str = "task-xhs-test",
+        lease_id: str = "lease-xhs-test",
+    ) -> AdapterExecutionContext:
+        return AdapterExecutionContext(
+            request=AdapterTaskRequest(
+                capability="content_detail",
+                target_type="url",
+                target_value=url,
+                collection_mode=collection_mode,
+            ),
+            resource_bundle=(
+                build_managed_resource_bundle(
+                    adapter_key="xhs",
+                    task_id=task_id,
+                    requested_slots=requested_slots,
+                    lease_id=lease_id,
+                    account_material=(
+                        xhs_account_material() if account_material is None else account_material
+                    ),
+                )
+                if resource_bundle
+                else None
+            ),
+        )
+
     def test_xhs_adapter_rejects_non_hybrid_adapter_task_request_before_session_lookup(self) -> None:
         adapter = XhsAdapter()
 
         with self.assertRaises(PlatformAdapterError) as raised:
             adapter.execute(
-                AdapterTaskRequest(
-                    capability="content_detail",
-                    target_type="url",
-                    target_value="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8",
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8",
                     collection_mode="public",
                 )
             )
@@ -195,12 +246,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(PlatformAdapterError) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
 
@@ -242,12 +289,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(PlatformAdapterError) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
 
@@ -291,12 +334,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(PlatformAdapterError) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
 
@@ -428,15 +467,12 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url=(
-                            "https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                            "?xsec_token=token-1&xsec_source=pc_search"
-                        )
+                self.build_xhs_context(
+                    url=(
+                        "https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
+                        "?xsec_token=token-1&xsec_source=pc_search"
                     ),
+                    account_material=build_xhs_account_material(timeout_seconds=7),
                 )
             )
 
@@ -608,12 +644,8 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                 )
             )
 
@@ -712,12 +744,8 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                 )
             )
 
@@ -780,12 +808,8 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                 )
             )
 
@@ -847,12 +871,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(PlatformAdapterError) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
 
@@ -920,10 +940,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(PlatformAdapterError) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(url=f"https://www.xiaohongshu.com/explore/{source_note_id}"),
+                    self.build_xhs_context(
+                        url=f"https://www.xiaohongshu.com/explore/{source_note_id}"
                     )
                 )
 
@@ -985,12 +1003,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(PlatformAdapterError) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
 
@@ -1066,12 +1080,8 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                 )
             )
 
@@ -1122,12 +1132,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(Exception) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
 
@@ -1180,12 +1186,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(Exception) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
 
@@ -1193,18 +1195,17 @@ class XhsAdapterTests(unittest.TestCase):
         self.assertEqual(raised.exception.details["platform_code"], 300013)
         self.assertEqual(raised.exception.details["platform_message"], "登录失效")
 
-    def test_xhs_adapter_raises_platform_error_when_session_file_is_missing(self) -> None:
-        adapter = XhsAdapter(session_path=Path("/tmp/syvert-does-not-exist/xhs.session.json"))
+    def test_xhs_adapter_raises_platform_error_when_resource_bundle_is_missing(self) -> None:
+        adapter = XhsAdapter()
 
         with self.assertRaises(Exception) as raised:
             adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8",
+                    resource_bundle=False,
                 )
             )
-        self.assertEqual(raised.exception.code, "xhs_session_missing")
+        self.assertEqual(raised.exception.code, "xhs_resource_bundle_missing")
 
     def test_xhs_adapter_preserves_html_fetch_failure_when_sign_base_url_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1236,12 +1237,9 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(Exception) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8",
+                        account_material=build_xhs_account_material(sign_base_url=None),
                     )
                 )
             self.assertEqual(raised.exception.code, "xhs_detail_request_failed")
@@ -1284,12 +1282,8 @@ class XhsAdapterTests(unittest.TestCase):
 
             with self.assertRaises(Exception) as raised:
                 adapter.execute(
-                    TaskRequest(
-                        adapter_key="xhs",
-                        capability="content_detail_by_url",
-                        input=TaskInput(
-                            url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                        ),
+                    self.build_xhs_context(
+                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                     )
                 )
             self.assertEqual(raised.exception.code, "xhs_content_not_found")
@@ -1355,12 +1349,8 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                 )
             )
 
@@ -1422,12 +1412,8 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                 )
             )
 
@@ -1486,12 +1472,8 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
                 )
             )
 
@@ -1555,12 +1537,9 @@ class XhsAdapterTests(unittest.TestCase):
             )
 
             payload = adapter.execute(
-                TaskRequest(
-                    adapter_key="xhs",
-                    capability="content_detail_by_url",
-                    input=TaskInput(
-                        url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8"
-                    ),
+                self.build_xhs_context(
+                    url="https://www.xiaohongshu.com/explore/66fad51c000000001b0224b8",
+                    account_material=build_xhs_account_material(timeout_seconds=float("inf")),
                 )
             )
 
@@ -1625,7 +1604,32 @@ class XhsAdapterTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "xhs_detail_request_failed")
 
     def test_execute_task_returns_platform_failure_envelope_for_xhs_platform_errors(self) -> None:
-        adapter = XhsAdapter(session_path=Path("/tmp/syvert-does-not-exist/xhs.session.json"))
+        adapter = XhsAdapter(
+            sign_transport=lambda base_url, payload, timeout_seconds: {
+                "x_s": "signed-x-s",
+                "x_t": "signed-x-t",
+                "x_s_common": "signed-x-s-common",
+                "x_b3_traceid": "trace-1",
+            },
+            detail_transport=lambda **kwargs: (_ for _ in ()).throw(
+                PlatformAdapterError(
+                    code="xhs_detail_request_failed",
+                    message="detail unavailable",
+                )
+            ),
+            page_transport=lambda **kwargs: (_ for _ in ()).throw(
+                PlatformAdapterError(
+                    code="xhs_detail_request_failed",
+                    message="html fallback unavailable",
+                )
+            ),
+            page_state_transport=lambda **kwargs: (_ for _ in ()).throw(
+                PlatformAdapterError(
+                    code="xhs_browser_target_tab_missing",
+                    message="未找到目标小红书详情标签页",
+                )
+            ),
+        )
         request = TaskRequest(
             adapter_key="xhs",
             capability="content_detail_by_url",
@@ -1641,7 +1645,7 @@ class XhsAdapterTests(unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["task_id"], "task-xhs-platform-error")
         self.assertEqual(envelope["error"]["category"], "platform")
-        self.assertEqual(envelope["error"]["code"], "xhs_session_missing")
+        self.assertEqual(envelope["error"]["code"], "xhs_detail_request_failed")
 
     def test_runtime_rejects_incomplete_normalized_payload(self) -> None:
         class BrokenXhsAdapter:
@@ -1778,6 +1782,7 @@ class XhsAdapterTests(unittest.TestCase):
         try:
             with tempfile.TemporaryDirectory() as temp_home:
                 session_path = Path(temp_home) / "xhs.session.json"
+                resource_store_path = Path(temp_home) / "resource-lifecycle.json"
                 session_path.write_text(
                     json.dumps(
                         {
@@ -1791,10 +1796,23 @@ class XhsAdapterTests(unittest.TestCase):
                 )
                 stdout = io.StringIO()
                 stderr = io.StringIO()
-                with mock.patch("syvert.adapters.xhs.DEFAULT_XHS_SESSION_PATH", session_path), mock.patch(
+                with mock.patch.dict(
+                    os.environ,
+                    {"SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": str(resource_store_path)},
+                    clear=False,
+                ), mock.patch(
+                    "syvert.adapters.xhs.DEFAULT_XHS_SESSION_PATH",
+                    session_path,
+                ), mock.patch(
                     "syvert.adapters.xhs.XHS_API_BASE_URL",
                     f"http://127.0.0.1:{server.server_port}",
                 ):
+                    seed_default_runtime_resources(
+                        account_material=build_xhs_account_material(
+                            sign_base_url=f"http://127.0.0.1:{server.server_port}",
+                            timeout_seconds=5,
+                        )
+                    )
                     exit_code = main(
                         [
                             "--adapter",

--- a/tests/runtime/test_xhs_adapter.py
+++ b/tests/runtime/test_xhs_adapter.py
@@ -88,6 +88,8 @@ def build_xhs_account_material(**overrides: Any) -> dict[str, Any]:
 
 
 class XhsAdapterTests(ResourceStoreEnvMixin, unittest.TestCase):
+    resource_store_adapter_key = "xhs"
+
     def build_xhs_context(
         self,
         *,
@@ -1808,6 +1810,7 @@ class XhsAdapterTests(ResourceStoreEnvMixin, unittest.TestCase):
                     f"http://127.0.0.1:{server.server_port}",
                 ):
                     seed_default_runtime_resources(
+                        adapter_key="xhs",
                         account_material=build_xhs_account_material(
                             sign_base_url=f"http://127.0.0.1:{server.server_port}",
                             timeout_seconds=5,


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：把 `FR-0012` 的 Core 注入 `ResourceBundle`、reference adapter 资源消费边界与回归闭环真正接入主执行链，并补齐真实 host-side 受支持的 managed resource bootstrap / migration 路径。
- 主要改动：
  - 在 `syvert/runtime.py` 引入 canonical `AdapterExecutionContext`、hybrid 资源策略、host-side bundle 校验、内部 `resource_disposition_hint` 消费与统一 `release()` 收口。
  - 将 xhs / douyin reference adapter 改为只消费注入的 `resource_bundle.account.material`，不再从 session 文件或隐式来源读取执行资源。
  - 新增 `syvert/resource_bootstrap.py` 与 `syvert.resource_bootstrap_cli`，允许 host-side 通过 canonical account material JSON 或 legacy session 文件把 `account` / `proxy` 资源 seed 到 lifecycle store。
  - shared lifecycle store 的 `account` 资源现在严格按 `managed_adapter_key` 做 host-side 兼容性选择：缺失、非法、空值或不匹配的账号 truth 都不会被 `acquire()` 选中。
  - runtime / CLI / contract harness / real adapter regression 的 seed helpers 全部切到 canonical managed account truth，lifecycle/store 测试也移除了自动补标签夹具，显式覆盖 legacy untagged fail-closed。

## Issue 摘要

- `FR-0012` 要求 lifecycle truth 完全归 Core：资源获取、bundle 校验、lease 收口都不能漂移到 adapter。
- 这次收口同时补上 guardian 指出的三条 host-side 缺口：
  - 真实执行面必须有受支持的 managed resource bootstrap / migration 入口。
  - 共享 lifecycle store 中的 `account` 资源不能再是无差别池，必须与当前 `adapter_key` 兼容或 fail-closed。
  - 未打标签的 legacy `account` truth 也不能作为兼容 fallback，验证证据必须显式覆盖 canonical managed truth。
- bootstrap 入口最终落在 `syvert/` runtime 包内，保持 `implementation` PR 与 governance 路径分类隔离。

## Scope

- runtime 注入 `AdapterExecutionContext`
- Core 侧资源策略、acquire / release / cleanup 收口
- xhs / douyin reference adapter 改造为只消费注入 bundle
- host-side managed resource bootstrap / migration 入口
- shared-store 账号隔离与 strict fail-closed 选择语义
- 相关 contract harness / regression / runtime 单测更新

## 关联事项

- Issue: #181
- item_key: `CHORE-0136-fr-0012-runtime-adapter-closeout`
- item_type: `CHORE`
- release: `v0.4.0`
- sprint: `2026-S17`
- Closing: Fixes #181

## 风险

- 风险级别：`normal`
- 审查关注：
  - `acquire()` 成功后的 host-side bundle 校验失败、adapter 失败、非法 hint、`release()` 失败是否都按 Core 单一 ownership 正确 settle lease。
  - lifecycle truth 的 `capability` 是否始终保持 `content_detail_by_url`，没有被 adapter-facing `content_detail` 回写到 bundle / lease / release。
  - reference adapter 是否已经 fail-closed 到只消费注入资源，没有重新打开 session 文件、环境变量或默认 provider 的隐式资源来源面。
  - bootstrap / migration 入口是否只在 host-side 解析默认 lifecycle store，并在写入前校验 canonical account material，而不是再次把资源来源逻辑漏回 adapter 层。
  - shared store 中同时存在 xhs / douyin 账号时，host-side 是否只会选择 `managed_adapter_key` 与当前 `adapter_key` 一致的账号；若无兼容账号、账号未打标签、标签非法或 `material` 非对象，是否都会在进入 adapter 前按 `resource_unavailable` fail-closed。

## Rollout

- 真实 host-side 执行前，先通过 `python3 -m syvert.resource_bootstrap_cli` seed 必需的 `account` / `proxy` 资源。
- account 来源支持两种模式：
  - `--account-material-file`：直接导入 canonical `account.material` JSON
  - `--account-session-file`：从 legacy `xhs` / `douyin` session 文件迁移为 canonical `account.material`
- 参考命令：
  - `python3 -m syvert.resource_bootstrap_cli --adapter xhs --account-resource-id xhs-account-main --account-session-file ~/.config/syvert/xhs.session.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
  - `python3 -m syvert.resource_bootstrap_cli --adapter douyin --account-resource-id douyin-account-main --account-material-file ./ops/douyin-account.json --proxy-resource-id proxy-main --proxy-material-file ./ops/proxy-main.json`
- store 位置继续遵循 `SYVERT_RESOURCE_LIFECYCLE_STORE_FILE` / `~/.syvert/resource-lifecycle.json`；如需显式切换文件，可附加 `--store-file <path>`。
- 同一份 lifecycle store 若同时装入多套 reference adapter 账号，host-side `acquire()` 会只选择 `managed_adapter_key` 与当前 `adapter_key` 一致的 `account` 资源；若只有不兼容账号、未打标签账号或非法标签账号，则在进入 adapter 前按 `resource_unavailable` fail-closed。

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_resource_bootstrap tests.runtime.test_contract_harness_automation tests.runtime.test_real_adapter_regression tests.runtime.test_cli`
  - `python3 -m unittest tests.runtime.test_resource_lifecycle tests.runtime.test_resource_lifecycle_store tests.runtime.test_runtime tests.runtime.test_executor tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_cli tests.runtime.test_real_adapter_regression tests.runtime.test_version_gate tests.runtime.test_resource_bootstrap`
  - `python3 -m unittest tests.runtime.test_platform_leakage`
  - `python3 -m py_compile syvert/resource_lifecycle.py syvert/real_adapter_regression.py tests/runtime/resource_fixtures.py tests/runtime/contract_harness/automation.py tests/runtime/test_resource_lifecycle.py tests/runtime/test_resource_lifecycle_store.py tests/runtime/test_resource_bootstrap.py tests/runtime/test_runtime.py tests/runtime/test_executor.py tests/runtime/test_contract_harness_host.py tests/runtime/test_cli.py tests/runtime/test_xhs_adapter.py tests/runtime/test_douyin_adapter.py`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main`
- 未执行：
  - 最新 head 的 guardian 审查
  - 最新 head 的 GitHub merge gate

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
