### PR TITLE
feat(runtime): 落地 FR-0014 Core 资源能力匹配

### DIFF
--- a/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
+++ b/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
@@ -49,8 +49,8 @@
   - `syvert/runtime.py` 已新增 canonical matcher surface：`ResourceCapabilityMatcherInput`、`ResourceCapabilityMatchResult`、`match_resource_capabilities(...)`、`resolve_runtime_available_resource_capabilities(...)`。
   - `execute_task_internal()` 已消费 `lookup_resource_requirement(adapter_key, capability_family)`，并在 acquire 前完成 matcher gate：缺声明、坏声明以及未批准 capability projection 收口为 `invalid_resource_requirement`，合法但不满足声明的情况收口为 `resource_unavailable`。
   - runtime-reaching stub / CLI / contract harness 夹具已统一迁移到可追溯的 `xhs` canonical declaration truth，避免继续依赖无效 `stub`/`fake:*` baseline。
-  - `syvert/registry.py` 已补充 matcher 复用的 approved evidence refs 入口，避免为 `none` 语义另造第二套 evidence 真相。
-  - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已覆盖：required/unmatched、未批准 projection fail-closed、pure matcher `none` 语义与 runtime entrypoint 的当前 registry baseline 边界。
+  - `validate_resource_capability_matcher_input()` 现已直接经 `AdapterRegistry.from_mapping(...)` 复用 `FR-0013` canonical materialization，避免 matcher/public runtime 与 registry 对 `none` 模式或 evidence baseline 产生双真相。
+  - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已覆盖：required/unmatched、未批准 projection fail-closed、缺声明/坏声明 fail-closed，以及 `none` 模式在当前 registry baseline 下继续收口为 `invalid_resource_requirement`。
   - 当前 implementation PR 已创建为 `#214`，当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
 
 ## 下一步动作
@@ -73,9 +73,9 @@
 ## 已验证项
 
 - `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_registry tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_contract_harness_validation_tool`
-  - 结果：`Ran 278 tests in 5.435s`，`OK`
+  - 结果：`Ran 286 tests in 5.911s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression`
-  - 结果：当前受审实现已覆盖 matcher / runtime / 未批准 projection / adapter regression 路径；最新本地复跑 `Ran 245 tests in 5.382s`，`OK`
+  - 结果：当前受审实现已覆盖 matcher / runtime / 未批准 projection / adapter regression 路径；最新本地复跑 `Ran 248 tests in 5.332s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/workflow_guard.py --mode ci`

--- a/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
+++ b/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
@@ -44,14 +44,14 @@
 
 - 当前 worktree：`/Users/mc/code/worktrees/syvert/issue-196-fr-0014-core`
 - 当前分支：`issue-196-fr-0014-core`
-- 当前实现 checkpoint：`5f9d5d821882490071ec624979840d75c36311a5`
+- 当前实现 checkpoint：`e4e8f1dc896b681db632ab1409b41ec451c5f70d`
 - 当前状态：
   - `syvert/runtime.py` 已新增 canonical matcher surface：`ResourceCapabilityMatcherInput`、`ResourceCapabilityMatchResult`、`match_resource_capabilities(...)`、`resolve_runtime_available_resource_capabilities(...)`。
   - `execute_task_internal()` 已消费 `lookup_resource_requirement(adapter_key, capability_family)`，并在 acquire 前完成 matcher gate：缺声明、坏声明以及未批准 capability projection 收口为 `invalid_resource_requirement`，合法但不满足声明的情况收口为 `resource_unavailable`。
   - runtime-reaching stub / CLI / contract harness 夹具已统一迁移到可追溯的 `xhs` canonical declaration truth，避免继续依赖无效 `stub`/`fake:*` baseline。
   - `syvert/registry.py` 已补充 matcher 复用的 approved evidence refs 入口，使 pure matcher 可以消费 `FR-0015` 批准词汇与共享证据，同时不改变 production declaration materialization 的 current baseline。
   - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已覆盖：required/unmatched、未批准 projection fail-closed、pure matcher `none` 语义，以及 runtime entrypoint 在当前 registry baseline 下对 `none` declaration 继续 fail-closed 的边界。
-  - 当前 implementation PR 已创建为 `#214`，本文件用于绑定 `5f9d5d821882490071ec624979840d75c36311a5` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
+  - 当前 implementation PR 已创建为 `#214`，本文件用于绑定 `e4e8f1dc896b681db632ab1409b41ec451c5f70d` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
 
 ## 下一步动作
 
@@ -101,4 +101,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `5f9d5d821882490071ec624979840d75c36311a5`
+- `e4e8f1dc896b681db632ab1409b41ec451c5f70d`

--- a/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
+++ b/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
@@ -44,14 +44,14 @@
 
 - 当前 worktree：`/Users/mc/code/worktrees/syvert/issue-196-fr-0014-core`
 - 当前分支：`issue-196-fr-0014-core`
-- 当前实现 checkpoint：`ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6`
+- 当前实现 checkpoint：`5f9d5d821882490071ec624979840d75c36311a5`
 - 当前状态：
   - `syvert/runtime.py` 已新增 canonical matcher surface：`ResourceCapabilityMatcherInput`、`ResourceCapabilityMatchResult`、`match_resource_capabilities(...)`、`resolve_runtime_available_resource_capabilities(...)`。
   - `execute_task_internal()` 已消费 `lookup_resource_requirement(adapter_key, capability_family)`，并在 acquire 前完成 matcher gate：缺声明、坏声明以及未批准 capability projection 收口为 `invalid_resource_requirement`，合法但不满足声明的情况收口为 `resource_unavailable`。
   - runtime-reaching stub / CLI / contract harness 夹具已统一迁移到可追溯的 `xhs` canonical declaration truth，避免继续依赖无效 `stub`/`fake:*` baseline。
   - `validate_resource_capability_matcher_input()` 现已直接经 `AdapterRegistry.from_mapping(...)` 复用 `FR-0013` canonical materialization，避免 matcher/public runtime 与 registry 对 `none` 模式或 evidence baseline 产生双真相。
   - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已覆盖：required/unmatched、未批准 projection fail-closed、缺声明/坏声明 fail-closed，以及 `none` 模式在当前 registry baseline 下继续收口为 `invalid_resource_requirement`。
-  - 当前 implementation PR 已创建为 `#214`，当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
+  - 当前 implementation PR 已创建为 `#214`，本文件用于绑定 `5f9d5d821882490071ec624979840d75c36311a5` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
 
 ## 下一步动作
 
@@ -101,4 +101,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6`
+- `5f9d5d821882490071ec624979840d75c36311a5`

--- a/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
+++ b/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
@@ -49,8 +49,8 @@
   - `syvert/runtime.py` 已新增 canonical matcher surface：`ResourceCapabilityMatcherInput`、`ResourceCapabilityMatchResult`、`match_resource_capabilities(...)`、`resolve_runtime_available_resource_capabilities(...)`。
   - `execute_task_internal()` 已消费 `lookup_resource_requirement(adapter_key, capability_family)`，并在 acquire 前完成 matcher gate：缺声明、坏声明以及未批准 capability projection 收口为 `invalid_resource_requirement`，合法但不满足声明的情况收口为 `resource_unavailable`。
   - runtime-reaching stub / CLI / contract harness 夹具已统一迁移到可追溯的 `xhs` canonical declaration truth，避免继续依赖无效 `stub`/`fake:*` baseline。
-  - `validate_resource_capability_matcher_input()` 现已直接经 `AdapterRegistry.from_mapping(...)` 复用 `FR-0013` canonical materialization，避免 matcher/public runtime 与 registry 对 `none` 模式或 evidence baseline 产生双真相。
-  - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已覆盖：required/unmatched、未批准 projection fail-closed、缺声明/坏声明 fail-closed，以及 `none` 模式在当前 registry baseline 下继续收口为 `invalid_resource_requirement`。
+  - `syvert/registry.py` 已补充 matcher 复用的 approved evidence refs 入口，使 pure matcher 可以消费 `FR-0015` 批准词汇与共享证据，同时不改变 production declaration materialization 的 current baseline。
+  - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已覆盖：required/unmatched、未批准 projection fail-closed、pure matcher `none` 语义，以及 runtime entrypoint 在当前 registry baseline 下对 `none` declaration 继续 fail-closed 的边界。
   - 当前 implementation PR 已创建为 `#214`，本文件用于绑定 `5f9d5d821882490071ec624979840d75c36311a5` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
 
 ## 下一步动作
@@ -73,9 +73,9 @@
 ## 已验证项
 
 - `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_registry tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_contract_harness_validation_tool`
-  - 结果：`Ran 286 tests in 5.911s`，`OK`
+  - 结果：`Ran 288 tests in 5.837s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression`
-  - 结果：当前受审实现已覆盖 matcher / runtime / 未批准 projection / adapter regression 路径；最新本地复跑 `Ran 248 tests in 5.332s`，`OK`
+  - 结果：当前受审实现已覆盖 matcher / runtime / 未批准 projection / adapter regression 路径；最新本地复跑 `Ran 250 tests in 6.493s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/workflow_guard.py --mode ci`

--- a/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
+++ b/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
@@ -21,6 +21,7 @@
 ## 范围
 
 - 本次纳入：
+  - `syvert/registry.py`
   - `syvert/runtime.py`
   - `docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md`
   - `tests/runtime/test_resource_capability_matcher.py`
@@ -46,9 +47,10 @@
 - 当前实现 checkpoint：`ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6`
 - 当前状态：
   - `syvert/runtime.py` 已新增 canonical matcher surface：`ResourceCapabilityMatcherInput`、`ResourceCapabilityMatchResult`、`match_resource_capabilities(...)`、`resolve_runtime_available_resource_capabilities(...)`。
-  - `execute_task_internal()` 已消费 `lookup_resource_requirement(adapter_key, capability_family)`，并在 acquire 前完成 matcher gate：缺声明/坏声明/坏 projection 收口为 `invalid_resource_requirement`，合法但不满足声明的情况收口为 `resource_unavailable`。
+  - `execute_task_internal()` 已消费 `lookup_resource_requirement(adapter_key, capability_family)`，并在 acquire 前完成 matcher gate：缺声明、坏声明以及未批准 capability projection 收口为 `invalid_resource_requirement`，合法但不满足声明的情况收口为 `resource_unavailable`。
   - runtime-reaching stub / CLI / contract harness 夹具已统一迁移到可追溯的 `xhs` canonical declaration truth，避免继续依赖无效 `stub`/`fake:*` baseline。
-  - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已在实现 checkpoint `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 上通过。
+  - `syvert/registry.py` 已补充 matcher 复用的 approved evidence refs 入口，避免为 `none` 语义另造第二套 evidence 真相。
+  - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已覆盖：required/unmatched、未批准 projection fail-closed、pure matcher `none` 语义与 runtime entrypoint 的当前 registry baseline 边界。
   - 当前 implementation PR 已创建为 `#214`，当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
 
 ## 下一步动作
@@ -73,7 +75,7 @@
 - `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_registry tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_contract_harness_validation_tool`
   - 结果：`Ran 278 tests in 5.435s`，`OK`
 - `python3 -m unittest tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression`
-  - 结果：在 checkpoint `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 上 `Ran 230 tests in 5.332s`，`OK`
+  - 结果：当前受审实现已覆盖 matcher / runtime / 未批准 projection / adapter regression 路径；最新本地复跑 `Ran 245 tests in 5.382s`，`OK`
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过
 - `python3 scripts/workflow_guard.py --mode ci`

--- a/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
+++ b/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
@@ -9,41 +9,53 @@
 - sprint：`2026-S18`
 - 关联 spec：`docs/specs/FR-0014-core-resource-capability-matching/`
 - 关联 decision：`docs/decisions/ADR-0001-governance-bootstrap-contract.md`
-- 关联 PR：`待创建`
+- 关联 PR：`#214`
 - 状态：`active`
 - active 收口事项：`CHORE-0142-fr-0014-runtime-closeout`
 
 ## 目标
 
-- 收口 `FR-0014` runtime implementation 回合中与 matcher truth、evidence baseline、declaration lookup 直接相关的执行证据。
-- 确保 `#196` 在进入受控 PR 前具备可复验的 test truth：`FR-0014 matcher` 与 `FR-0015 approved capability baseline`、`#195 declaration lookup` 三者一致。
+- 收口 `FR-0014` runtime implementation 回合，确保 Core 只基于 `#195` 已冻结的声明 carrier 与当前 runtime 能力集合执行纯粹的 `matched / unmatched` 判断。
+- 把 `#196` 的执行真相统一沉淀到单一 active `exec-plan`，使 matcher truth、error taxonomy、测试证据、PR head 与后续 guardian / merge gate 可以对齐到同一上下文。
 
 ## 范围
 
 - 本次纳入：
+  - `syvert/runtime.py`
   - `docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md`
+  - `tests/runtime/test_resource_capability_matcher.py`
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_task_record.py`
+  - `tests/runtime/test_task_record_store.py`
+  - `tests/runtime/test_cli.py`
   - `tests/runtime/test_resource_capability_evidence.py`
+  - `tests/runtime/test_xhs_adapter.py`
+  - `tests/runtime/test_douyin_adapter.py`
+  - `tests/runtime/test_real_adapter_regression.py`
+  - 与 runtime-reaching matcher 回归直接相关的 test fixture / contract harness 文件
 - 本次不纳入：
-  - CLI / contract harness 变更
-  - formal spec 语义改写（`FR-0014` / `FR-0015`）
-  - 非 `#196` 事项的执行计划与治理工件
+  - `FR-0013` / `FR-0014` / `FR-0015` formal spec 语义改写
+  - acquire contract 改写或 `requested_slots` 真相迁移
+  - provider 选择、排序、偏好、fallback 语义
+  - 非 `#196` 事项的治理工件
 
 ## 当前停点
 
 - 当前 worktree：`/Users/mc/code/worktrees/syvert/issue-196-fr-0014-core`
 - 当前分支：`issue-196-fr-0014-core`
-- 当前实现 checkpoint：`7fa2f9715f8e831fa6032b793287623f0d2f6e28`
+- 当前实现 checkpoint：`ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6`
 - 当前状态：
-  - `#196` 的 GitHub Work Item 元数据已存在（`item_key/item_type/release/sprint`），但此前缺少 active `exec-plan` 文件，导致 `open_pr` preflight 阻断。
-  - `tests/runtime/test_resource_capability_evidence.py` 已覆盖 frozen evidence、runtime slots、matcher 对齐、以及 fail-closed 漂移路径。
-  - 当前回合补充了“`#195` declaration lookup -> `FR-0014 matcher` -> `FR-0015 approved capability ids`”的直接联动断言，避免仅通过 helper baseline 间接验证。
+  - `syvert/runtime.py` 已新增 canonical matcher surface：`ResourceCapabilityMatcherInput`、`ResourceCapabilityMatchResult`、`match_resource_capabilities(...)`、`resolve_runtime_available_resource_capabilities(...)`。
+  - `execute_task_internal()` 已消费 `lookup_resource_requirement(adapter_key, capability_family)`，并在 acquire 前完成 matcher gate：缺声明/坏声明/坏 projection 收口为 `invalid_resource_requirement`，合法但不满足声明的情况收口为 `resource_unavailable`。
+  - runtime-reaching stub / CLI / contract harness 夹具已统一迁移到可追溯的 `xhs` canonical declaration truth，避免继续依赖无效 `stub`/`fake:*` baseline。
+  - matcher unit tests、runtime / task-record / CLI / evidence / dual-reference adapter / contract harness 回归已在实现 checkpoint `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 上通过。
+  - 当前 implementation PR 已创建为 `#214`，当前回合已进入 `metadata-only closeout follow-up`：本文件用于绑定 `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 对应的 implementation checkpoint 与后续 review / merge gate 真相。
 
 ## 下一步动作
 
-- 基于当前 active `exec-plan` 继续补齐 `#196` implementation 变更与验证证据。
-- 在当前分支形成可审查提交后，执行 `open_pr --class implementation --issue 196 ... --dry-run` 验证受控入口。
-- 创建 implementation PR，进入 guardian review 与 merge gate。
-- 合入后同步 `#196` / exec-plan / PR / guardian / main truth 一致性。
+- 对 `#214` 运行 guardian review，并以当前 PR head 为准收口 verdict / `safe_to_merge`。
+- 等待 GitHub checks 绑定到当前 PR head 全绿后，经 `merge_pr` 执行受控 squash merge。
+- 合入后同步 `#196` / exec-plan / guardian / main truth 一致性。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -58,12 +70,22 @@
 
 ## 已验证项
 
-- `python3 -m unittest tests.runtime.test_resource_capability_evidence -v`
-  - 结果：`Ran 25 tests`，`OK`
-- `python3 -m unittest tests.runtime.test_resource_capability_matcher tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_resource_capability_evidence -v`
-  - 结果：`Ran 42 tests`，`OK`
-- `python3 scripts/governance_status.py --issue 196 --format json`
-  - 结果：当前分支/worktree 绑定到 `#196`，此前 `item_context` 为空（缺 active exec-plan）；本文件创建后可作为 `open_pr` 前置上下文载体。
+- `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_registry tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_contract_harness_validation_tool`
+  - 结果：`Ran 278 tests in 5.435s`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression`
+  - 结果：在 checkpoint `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6` 上 `Ran 230 tests in 5.332s`，`OK`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过（`PR class: implementation` / `变更类别: docs, implementation`）
+- `python3 scripts/governance_gate.py --mode ci --base-sha \"$(git merge-base origin/main HEAD)\" --head-sha \"$(git rev-parse HEAD)\" --head-ref issue-196-fr-0014-core`
+  - 结果：通过
+- `python3 scripts/open_pr.py --class implementation --issue 196 --item-key CHORE-0142-fr-0014-runtime-closeout --item-type CHORE --release v0.5.0 --sprint 2026-S18 --title 'feat(runtime): 落地 FR-0014 Core 资源能力匹配' --base main --closing fixes --dry-run`
+  - 结果：通过
+- `python3 scripts/open_pr.py --class implementation --issue 196 --item-key CHORE-0142-fr-0014-runtime-closeout --item-type CHORE --release v0.5.0 --sprint 2026-S18 --title 'feat(runtime): 落地 FR-0014 Core 资源能力匹配' --base main --closing fixes`
+  - 结果：已创建当前受审 implementation PR `#214 https://github.com/MC-and-his-Agents/Syvert/pull/214`
 
 ## 未决风险
 
@@ -77,4 +99,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `7fa2f9715f8e831fa6032b793287623f0d2f6e28`
+- `ab994a0e9859f2357cc21c4ee3fa6d1388a3fea6`

--- a/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
+++ b/docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md
@@ -1,0 +1,80 @@
+# CHORE-0142-fr-0014-runtime-closeout 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0142-fr-0014-runtime-closeout`
+- Issue：`#196`
+- item_type：`CHORE`
+- release：`v0.5.0`
+- sprint：`2026-S18`
+- 关联 spec：`docs/specs/FR-0014-core-resource-capability-matching/`
+- 关联 decision：`docs/decisions/ADR-0001-governance-bootstrap-contract.md`
+- 关联 PR：`待创建`
+- 状态：`active`
+- active 收口事项：`CHORE-0142-fr-0014-runtime-closeout`
+
+## 目标
+
+- 收口 `FR-0014` runtime implementation 回合中与 matcher truth、evidence baseline、declaration lookup 直接相关的执行证据。
+- 确保 `#196` 在进入受控 PR 前具备可复验的 test truth：`FR-0014 matcher` 与 `FR-0015 approved capability baseline`、`#195 declaration lookup` 三者一致。
+
+## 范围
+
+- 本次纳入：
+  - `docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md`
+  - `tests/runtime/test_resource_capability_evidence.py`
+- 本次不纳入：
+  - CLI / contract harness 变更
+  - formal spec 语义改写（`FR-0014` / `FR-0015`）
+  - 非 `#196` 事项的执行计划与治理工件
+
+## 当前停点
+
+- 当前 worktree：`/Users/mc/code/worktrees/syvert/issue-196-fr-0014-core`
+- 当前分支：`issue-196-fr-0014-core`
+- 当前实现 checkpoint：`7fa2f9715f8e831fa6032b793287623f0d2f6e28`
+- 当前状态：
+  - `#196` 的 GitHub Work Item 元数据已存在（`item_key/item_type/release/sprint`），但此前缺少 active `exec-plan` 文件，导致 `open_pr` preflight 阻断。
+  - `tests/runtime/test_resource_capability_evidence.py` 已覆盖 frozen evidence、runtime slots、matcher 对齐、以及 fail-closed 漂移路径。
+  - 当前回合补充了“`#195` declaration lookup -> `FR-0014 matcher` -> `FR-0015 approved capability ids`”的直接联动断言，避免仅通过 helper baseline 间接验证。
+
+## 下一步动作
+
+- 基于当前 active `exec-plan` 继续补齐 `#196` implementation 变更与验证证据。
+- 在当前分支形成可审查提交后，执行 `open_pr --class implementation --issue 196 ... --dry-run` 验证受控入口。
+- 创建 implementation PR，进入 guardian review 与 merge gate。
+- 合入后同步 `#196` / exec-plan / PR / guardian / main truth 一致性。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 支撑 `v0.5.0`：确保 `FR-0014` 资源能力匹配实现可稳定消费 `FR-0015` 批准能力词汇，并与 `#195` 声明查找语义保持一致。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0014` implementation closeout Work Item，负责 matcher runtime 语义与证据消费链路收口。
+- 阻塞：
+  - 若 `#196` 的实现与 `#195` declaration carrier 或 `FR-0015` approved baseline 脱节，guardian 会持续给出同类阻断。
+  - 若未维持 active `exec-plan` 与受控入口字段一致，`open_pr` 无法进入下一阶段。
+
+## 已验证项
+
+- `python3 -m unittest tests.runtime.test_resource_capability_evidence -v`
+  - 结果：`Ran 25 tests`，`OK`
+- `python3 -m unittest tests.runtime.test_resource_capability_matcher tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_resource_capability_evidence -v`
+  - 结果：`Ran 42 tests`，`OK`
+- `python3 scripts/governance_status.py --issue 196 --format json`
+  - 结果：当前分支/worktree 绑定到 `#196`，此前 `item_context` 为空（缺 active exec-plan）；本文件创建后可作为 `open_pr` 前置上下文载体。
+
+## 未决风险
+
+- 当前仓库存在并行未提交改动；若 `runtime/declaration` 实现继续变化，测试可能需再次同步断言细节。
+- `FR-0015` evidence baseline 仍依赖 frozen pointer 与 formal research 对齐；上游符号或路径漂移会触发 fail-closed。
+- 在 PR 收口阶段，仍需持续关注 guardian 是否重复同类阻断，避免只修单点症状。
+
+## 回滚方式
+
+- 如需回滚，使用独立 revert PR 撤销本事项在 exec-plan 与 runtime evidence tests 的增量修改。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `7fa2f9715f8e831fa6032b793287623f0d2f6e28`

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -206,6 +206,10 @@ def baseline_required_resource_requirement_declaration(
     )
 
 
+def approved_resource_requirement_evidence_refs() -> frozenset[str]:
+    return _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS
+
+
 def _build_adapter_declaration(adapter_key: str, adapter: Any) -> AdapterDeclaration:
     _validate_adapter_execute(adapter_key, adapter)
     capabilities = _get_adapter_attribute(adapter, "supported_capabilities")

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -210,6 +210,19 @@ def approved_resource_requirement_evidence_refs() -> frozenset[str]:
     return _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS
 
 
+def approved_resource_requirement_evidence_refs_for(
+    *,
+    adapter_key: str,
+    capability: str,
+) -> frozenset[str]:
+    return frozenset(
+        evidence_ref
+        for record in _APPROVED_FROZEN_RESOURCE_CAPABILITY_RECORDS
+        if record.adapter_key == adapter_key and record.capability == capability
+        for evidence_ref in record.evidence_refs
+    )
+
+
 def _build_adapter_declaration(adapter_key: str, adapter: Any) -> AdapterDeclaration:
     _validate_adapter_execute(adapter_key, adapter)
     capabilities = _get_adapter_attribute(adapter, "supported_capabilities")

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -206,23 +206,6 @@ def baseline_required_resource_requirement_declaration(
     )
 
 
-def approved_resource_requirement_evidence_refs() -> frozenset[str]:
-    return _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS
-
-
-def approved_resource_requirement_evidence_refs_for(
-    *,
-    adapter_key: str,
-    capability: str,
-) -> frozenset[str]:
-    return frozenset(
-        evidence_ref
-        for record in _APPROVED_FROZEN_RESOURCE_CAPABILITY_RECORDS
-        if record.adapter_key == adapter_key and record.capability == capability
-        for evidence_ref in record.evidence_refs
-    )
-
-
 def _build_adapter_declaration(adapter_key: str, adapter: Any) -> AdapterDeclaration:
     _validate_adapter_execute(adapter_key, adapter)
     capabilities = _get_adapter_attribute(adapter, "supported_capabilities")

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -206,6 +206,23 @@ def baseline_required_resource_requirement_declaration(
     )
 
 
+def approved_resource_requirement_evidence_refs() -> frozenset[str]:
+    return _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS
+
+
+def approved_resource_requirement_evidence_refs_for(
+    *,
+    adapter_key: str,
+    capability: str,
+) -> frozenset[str]:
+    return frozenset(
+        evidence_ref
+        for record in _APPROVED_FROZEN_RESOURCE_CAPABILITY_RECORDS
+        if record.adapter_key == adapter_key and record.capability == capability
+        for evidence_ref in record.evidence_refs
+    )
+
+
 def _build_adapter_declaration(adapter_key: str, adapter: Any) -> AdapterDeclaration:
     _validate_adapter_execute(adapter_key, adapter)
     capabilities = _get_adapter_attribute(adapter, "supported_capabilities")

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -12,7 +12,6 @@ from syvert.registry import (
     AdapterResourceRequirementDeclaration,
     RegistryError,
     RESOURCE_DEPENDENCY_MODE_NONE,
-    RESOURCE_DEPENDENCY_MODE_REQUIRED,
 )
 from syvert.resource_capability_evidence import approved_resource_capability_ids
 from syvert.task_record import (
@@ -1515,55 +1514,38 @@ def _validate_matcher_requirement_declaration(
             },
         )
 
-    resource_dependency_mode = _require_matcher_non_empty_string(
-        raw_value.resource_dependency_mode,
-        field_name="requirement_declaration.resource_dependency_mode",
-        details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
-    )
-    if resource_dependency_mode not in {RESOURCE_DEPENDENCY_MODE_NONE, RESOURCE_DEPENDENCY_MODE_REQUIRED}:
+    try:
+        registry = AdapterRegistry.from_mapping(
+            {
+                expected_adapter_key: _MatcherRequirementValidationAdapter(
+                    supported_capability=expected_capability,
+                    requirement_declaration=raw_value,
+                )
+            }
+        )
+    except RegistryError as error:
         raise ResourceCapabilityMatcherContractError(
-            "matcher requirement_declaration.resource_dependency_mode 仅允许 none|required",
+            "matcher requirement_declaration 必须满足 FR-0013 canonical contract",
             details={
                 "task_id": task_id,
-                "adapter_key": adapter_key,
-                "capability": capability,
-                "resource_dependency_mode": resource_dependency_mode,
+                "adapter_key": expected_adapter_key,
+                "capability": expected_capability,
+                "registry_error_code": error.code,
+                **error.details,
+            },
+        ) from error
+
+    validated_requirement = registry.lookup_resource_requirement(expected_adapter_key, expected_capability)
+    if validated_requirement is None:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration 必须与当前 adapter/capability 上下文对齐",
+            details={
+                "task_id": task_id,
+                "adapter_key": expected_adapter_key,
+                "capability": expected_capability,
             },
         )
-
-    required_capabilities = _normalize_available_resource_capabilities(
-        raw_value.required_capabilities,
-        task_id=task_id,
-        adapter_key=adapter_key,
-        capability=capability,
-        field_name="requirement_declaration.required_capabilities",
-    )
-    if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE and required_capabilities:
-        raise ResourceCapabilityMatcherContractError(
-            "matcher requirement_declaration 在 none 模式下不得声明 required_capabilities",
-            details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
-        )
-    if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_REQUIRED and not required_capabilities:
-        raise ResourceCapabilityMatcherContractError(
-            "matcher requirement_declaration 在 required 模式下必须声明 required_capabilities",
-            details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
-        )
-
-    evidence_refs = _normalize_non_empty_string_tuple(
-        raw_value.evidence_refs,
-        task_id=task_id,
-        adapter_key=adapter_key,
-        capability=capability,
-        field_name="requirement_declaration.evidence_refs",
-        allow_empty=False,
-    )
-    return AdapterResourceRequirementDeclaration(
-        adapter_key=adapter_key,
-        capability=capability,
-        resource_dependency_mode=resource_dependency_mode,
-        required_capabilities=required_capabilities,
-        evidence_refs=evidence_refs,
-    )
+    return validated_requirement
 
 
 def _normalize_available_resource_capabilities(
@@ -1673,3 +1655,20 @@ def _normalize_non_empty_string_tuple(
             details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
         )
     return tuple(values)
+
+
+class _MatcherRequirementValidationAdapter:
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({LEGACY_COLLECTION_MODE})
+
+    def __init__(
+        self,
+        *,
+        supported_capability: str,
+        requirement_declaration: AdapterResourceRequirementDeclaration,
+    ) -> None:
+        self.supported_capabilities = frozenset({supported_capability})
+        self.resource_requirement_declarations = (requirement_declaration,)
+
+    def execute(self, request: Any) -> dict[str, Any]:
+        raise AssertionError("matcher validation adapter must never execute")

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -12,7 +12,7 @@ from syvert.registry import (
     AdapterResourceRequirementDeclaration,
     RegistryError,
     RESOURCE_DEPENDENCY_MODE_NONE,
-    approved_resource_requirement_evidence_refs,
+    approved_resource_requirement_evidence_refs_for,
 )
 from syvert.resource_capability_evidence import approved_resource_capability_ids
 from syvert.task_record import (
@@ -50,7 +50,6 @@ MATCH_STATUS_UNMATCHED = "unmatched"
 _ALLOWED_MATCH_STATUSES = frozenset({MATCH_STATUS_MATCHED, MATCH_STATUS_UNMATCHED})
 _ALLOWED_MATCHER_CAPABILITIES = frozenset({CONTENT_DETAIL})
 _APPROVED_RESOURCE_CAPABILITY_IDS = approved_resource_capability_ids()
-_APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS = approved_resource_requirement_evidence_refs()
 
 if TYPE_CHECKING:
     from syvert.resource_lifecycle import ResourceBundle
@@ -1545,10 +1544,14 @@ def _validate_matcher_requirement_declaration(
             field_name="requirement_declaration.evidence_refs",
             allow_empty=False,
         )
+        approved_evidence_refs = approved_resource_requirement_evidence_refs_for(
+            adapter_key=adapter_key,
+            capability=capability,
+        )
         unknown_evidence_refs = tuple(
             evidence_ref
             for evidence_ref in evidence_refs
-            if evidence_ref not in _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS
+            if evidence_ref not in approved_evidence_refs
         )
         if unknown_evidence_refs:
             raise ResourceCapabilityMatcherContractError(

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -932,7 +932,7 @@ def match_resource_capabilities(input_value: ResourceCapabilityMatcherInput) -> 
 def validate_resource_capability_matcher_input(
     input_value: ResourceCapabilityMatcherInput,
 ) -> ResourceCapabilityMatcherInput:
-    if not isinstance(input_value, ResourceCapabilityMatcherInput):
+    if type(input_value) is not ResourceCapabilityMatcherInput:
         raise ResourceCapabilityMatcherContractError(
             "matcher 输入必须为 ResourceCapabilityMatcherInput",
             details={"actual_type": type(input_value).__name__},
@@ -1482,7 +1482,7 @@ def _validate_matcher_requirement_declaration(
     expected_capability: str,
     task_id: str,
 ) -> AdapterResourceRequirementDeclaration:
-    if not isinstance(raw_value, AdapterResourceRequirementDeclaration):
+    if type(raw_value) is not AdapterResourceRequirementDeclaration:
         raise ResourceCapabilityMatcherContractError(
             "matcher requirement_declaration 必须是 AdapterResourceRequirementDeclaration",
             details={"task_id": task_id, "actual_type": type(raw_value).__name__},

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -272,25 +272,18 @@ def execute_task_internal(
     try:
         registry = AdapterRegistry.from_mapping(adapters)
     except RegistryError as error:
-        if (
-            error.code == "invalid_adapter_resource_requirements"
-            and error.details.get("adapter_key") == adapter_key
-        ):
-            # Runtime only admits declarations that registry can materialize.
-            # Pure matcher-only `none` semantics stay unreachable here until FR-0013
-            # freezes a canonical runtime declaration baseline for that mode.
+        requested_resource_requirement_error = _requested_adapter_resource_requirement_error(
+            adapters=adapters,
+            adapter_key=adapter_key,
+            error=error,
+        )
+        if requested_resource_requirement_error is not None:
             return TaskExecutionResult(
                 failure_envelope(
                     task_id,
                     adapter_key,
                     capability,
-                    invalid_resource_requirement_error(
-                        error.message,
-                        details={
-                            "registry_error_code": error.code,
-                            **error.details,
-                        },
-                    ),
+                    requested_resource_requirement_error,
                 ),
                 None,
             )
@@ -1715,6 +1708,40 @@ def _normalize_non_empty_string_tuple(
             details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
         )
     return tuple(values)
+
+
+def _requested_adapter_resource_requirement_error(
+    *,
+    adapters: Mapping[str, Any],
+    adapter_key: str,
+    error: RegistryError,
+) -> dict[str, Any] | None:
+    if error.code != "invalid_adapter_resource_requirements":
+        return None
+    if error.details.get("adapter_key") == adapter_key:
+        return invalid_resource_requirement_error(
+            error.message,
+            details={"registry_error_code": error.code, **error.details},
+        )
+
+    try:
+        requested_adapter = adapters[adapter_key]
+    except Exception:
+        return None
+
+    try:
+        AdapterRegistry.from_mapping({adapter_key: requested_adapter})
+    except RegistryError as requested_error:
+        if requested_error.code != "invalid_adapter_resource_requirements":
+            return None
+        return invalid_resource_requirement_error(
+            requested_error.message,
+            details={
+                "registry_error_code": requested_error.code,
+                **requested_error.details,
+            },
+        )
+    return None
 
 
 class _MatcherRequirementValidationAdapter:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1514,6 +1514,40 @@ def _validate_matcher_requirement_declaration(
             },
         )
 
+    resource_dependency_mode = _require_matcher_non_empty_string(
+        raw_value.resource_dependency_mode,
+        field_name="requirement_declaration.resource_dependency_mode",
+        details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+    )
+    if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE:
+        required_capabilities = _normalize_available_resource_capabilities(
+            raw_value.required_capabilities,
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            field_name="requirement_declaration.required_capabilities",
+        )
+        if required_capabilities:
+            raise ResourceCapabilityMatcherContractError(
+                "matcher requirement_declaration 在 none 模式下不得声明 required_capabilities",
+                details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+            )
+        evidence_refs = _normalize_non_empty_string_tuple(
+            raw_value.evidence_refs,
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            field_name="requirement_declaration.evidence_refs",
+            allow_empty=False,
+        )
+        return AdapterResourceRequirementDeclaration(
+            adapter_key=adapter_key,
+            capability=capability,
+            resource_dependency_mode=resource_dependency_mode,
+            required_capabilities=required_capabilities,
+            evidence_refs=evidence_refs,
+        )
+
     try:
         registry = AdapterRegistry.from_mapping(
             {

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -12,6 +12,7 @@ from syvert.registry import (
     AdapterResourceRequirementDeclaration,
     RegistryError,
     RESOURCE_DEPENDENCY_MODE_NONE,
+    approved_resource_requirement_evidence_refs,
 )
 from syvert.resource_capability_evidence import approved_resource_capability_ids
 from syvert.task_record import (
@@ -49,6 +50,7 @@ MATCH_STATUS_UNMATCHED = "unmatched"
 _ALLOWED_MATCH_STATUSES = frozenset({MATCH_STATUS_MATCHED, MATCH_STATUS_UNMATCHED})
 _ALLOWED_MATCHER_CAPABILITIES = frozenset({CONTENT_DETAIL})
 _APPROVED_RESOURCE_CAPABILITY_IDS = approved_resource_capability_ids()
+_APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS = approved_resource_requirement_evidence_refs()
 
 if TYPE_CHECKING:
     from syvert.resource_lifecycle import ResourceBundle
@@ -1540,6 +1542,21 @@ def _validate_matcher_requirement_declaration(
             field_name="requirement_declaration.evidence_refs",
             allow_empty=False,
         )
+        unknown_evidence_refs = tuple(
+            evidence_ref
+            for evidence_ref in evidence_refs
+            if evidence_ref not in _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS
+        )
+        if unknown_evidence_refs:
+            raise ResourceCapabilityMatcherContractError(
+                "matcher requirement_declaration.evidence_refs 必须绑定到 FR-0015 已批准共享证据",
+                details={
+                    "task_id": task_id,
+                    "adapter_key": adapter_key,
+                    "capability": capability,
+                    "unknown_evidence_refs": unknown_evidence_refs,
+                },
+            )
         return AdapterResourceRequirementDeclaration(
             adapter_key=adapter_key,
             capability=capability,

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import re
 from typing import TYPE_CHECKING, Any, Callable, Mapping
 from uuid import uuid4
 
-from syvert.registry import AdapterRegistry, RegistryError
+from syvert.registry import (
+    AdapterRegistry,
+    AdapterResourceRequirementDeclaration,
+    RegistryError,
+    RESOURCE_DEPENDENCY_MODE_NONE,
+    RESOURCE_DEPENDENCY_MODE_REQUIRED,
+)
+from syvert.resource_capability_evidence import approved_resource_capability_ids
 from syvert.task_record import (
     TaskRecord,
     TaskRecordContractError,
@@ -37,6 +45,11 @@ DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON = "host_side_bundle_validation_failed"
 DEFAULT_SUCCESS_RELEASE_REASON = "adapter_completed_without_disposition_hint"
 DEFAULT_FAILURE_RELEASE_REASON = "adapter_failed_without_disposition_hint"
 DEFAULT_INVALID_HINT_RELEASE_REASON = "invalid_resource_disposition_hint"
+MATCH_STATUS_MATCHED = "matched"
+MATCH_STATUS_UNMATCHED = "unmatched"
+_ALLOWED_MATCH_STATUSES = frozenset({MATCH_STATUS_MATCHED, MATCH_STATUS_UNMATCHED})
+_ALLOWED_MATCHER_CAPABILITIES = frozenset({CONTENT_DETAIL})
+_APPROVED_RESOURCE_CAPABILITY_IDS = approved_resource_capability_ids()
 
 if TYPE_CHECKING:
     from syvert.resource_lifecycle import ResourceBundle
@@ -142,6 +155,31 @@ class TaskExecutionResult:
     task_record: TaskRecord | None
 
 
+@dataclass(frozen=True)
+class ResourceCapabilityMatcherInput:
+    task_id: str
+    adapter_key: str
+    capability: str
+    requirement_declaration: AdapterResourceRequirementDeclaration
+    available_resource_capabilities: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResourceCapabilityMatchResult:
+    task_id: str
+    adapter_key: str
+    capability: str
+    match_status: str
+
+
+class ResourceCapabilityMatcherContractError(Exception):
+    def __init__(self, message: str, *, details: Mapping[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = "invalid_resource_requirement"
+        self.message = message
+        self.details = dict(details or {})
+
+
 def execute_task(
     request: TaskRequest | CoreTaskRequest,
     *,
@@ -234,6 +272,22 @@ def execute_task_internal(
     try:
         registry = AdapterRegistry.from_mapping(adapters)
     except RegistryError as error:
+        if error.code == "invalid_adapter_resource_requirements":
+            return TaskExecutionResult(
+                failure_envelope(
+                    task_id,
+                    adapter_key,
+                    capability,
+                    invalid_resource_requirement_error(
+                        error.message,
+                        details={
+                            "registry_error_code": error.code,
+                            **error.details,
+                        },
+                    ),
+                ),
+                None,
+            )
         return TaskExecutionResult(
             failure_envelope(
                 task_id,
@@ -248,8 +302,8 @@ def execute_task_internal(
             None,
         )
 
-    declaration = registry.lookup(adapter_key)
-    if declaration is None:
+    adapter_declaration = registry.lookup(adapter_key)
+    if adapter_declaration is None:
         return TaskExecutionResult(
             failure_envelope(
                 task_id,
@@ -260,7 +314,7 @@ def execute_task_internal(
             None,
         )
 
-    supported_capabilities = declaration.supported_capabilities
+    supported_capabilities = adapter_declaration.supported_capabilities
     if capability_family not in supported_capabilities:
         return TaskExecutionResult(
             failure_envelope(
@@ -279,7 +333,7 @@ def execute_task_internal(
             None,
         )
 
-    supported_targets = declaration.supported_targets
+    supported_targets = adapter_declaration.supported_targets
     if normalized_request.target.target_type not in supported_targets:
         return TaskExecutionResult(
             failure_envelope(
@@ -295,7 +349,7 @@ def execute_task_internal(
             None,
         )
 
-    supported_collection_modes = declaration.supported_collection_modes
+    supported_collection_modes = adapter_declaration.supported_collection_modes
     if normalized_request.policy.collection_mode not in supported_collection_modes:
         return TaskExecutionResult(
             failure_envelope(
@@ -307,6 +361,43 @@ def execute_task_internal(
                     f"adapter `{adapter_key}` 不支持 collection_mode `{normalized_request.policy.collection_mode}`",
                     details={"supported_collection_modes": sorted(supported_collection_modes)},
                 ),
+            ),
+            None,
+        )
+
+    resource_requirement_declaration = registry.lookup_resource_requirement(adapter_key, capability_family)
+    if resource_requirement_declaration is None:
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                invalid_resource_requirement_error(
+                    f"adapter `{adapter_key}` 缺少 `{capability_family}` 的资源需求声明",
+                    details={"adapter_key": adapter_key, "capability": capability_family},
+                ),
+            ),
+            None,
+        )
+
+    try:
+        available_resource_capabilities = resolve_runtime_available_resource_capabilities(normalized_request)
+        matcher_input = validate_resource_capability_matcher_input(
+            ResourceCapabilityMatcherInput(
+                task_id=task_id,
+                adapter_key=adapter_key,
+                capability=capability_family,
+                requirement_declaration=resource_requirement_declaration,
+                available_resource_capabilities=available_resource_capabilities,
+            )
+        )
+    except ResourceCapabilityMatcherContractError as error:
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                invalid_resource_requirement_error(error.message, details=error.details),
             ),
             None,
         )
@@ -364,6 +455,32 @@ def execute_task_internal(
         return persistence_error
     if persisted_record is not None:
         record = persisted_record
+
+    match_result = match_resource_capabilities(matcher_input)
+    if match_result.match_status == MATCH_STATUS_UNMATCHED:
+        return finalize_task_execution_result(
+            task_id,
+            adapter_key,
+            capability,
+            record,
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                resource_unavailable_error(
+                    f"adapter `{adapter_key}` 的资源能力声明与当前 runtime 能力集合不匹配",
+                    details={
+                        "adapter_key": adapter_key,
+                        "capability": capability_family,
+                        "match_status": match_result.match_status,
+                        "required_capabilities": list(matcher_input.requirement_declaration.required_capabilities),
+                        "available_resource_capabilities": list(matcher_input.available_resource_capabilities),
+                    },
+                ),
+            ),
+            preserve_envelope_on_record_error=preserve_envelope_on_record_error,
+            task_record_store=store,
+        )
 
     requested_slots = resolve_requested_resource_slots(normalized_request)
     managed_resource_store = None
@@ -453,7 +570,7 @@ def execute_task_internal(
     disposition_hint: ResourceDispositionHint | None = None
     default_release_reason = DEFAULT_SUCCESS_RELEASE_REASON
     try:
-        payload = declaration.adapter.execute(adapter_context)
+        payload = adapter_declaration.adapter.execute(adapter_context)
         payload_error = validate_success_payload(payload)
         if payload_error is not None:
             envelope = failure_envelope(task_id, adapter_key, capability, payload_error)
@@ -794,6 +911,80 @@ def resolve_task_id(task_id_factory: Callable[[], str] | None) -> tuple[str, dic
     )
 
 
+def match_resource_capabilities(input_value: ResourceCapabilityMatcherInput) -> ResourceCapabilityMatchResult:
+    validated_input = validate_resource_capability_matcher_input(input_value)
+    required_capabilities = frozenset(validated_input.requirement_declaration.required_capabilities)
+    available_resource_capabilities = frozenset(validated_input.available_resource_capabilities)
+    if validated_input.requirement_declaration.resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE:
+        match_status = MATCH_STATUS_MATCHED
+    elif required_capabilities.issubset(available_resource_capabilities):
+        match_status = MATCH_STATUS_MATCHED
+    else:
+        match_status = MATCH_STATUS_UNMATCHED
+    return ResourceCapabilityMatchResult(
+        task_id=validated_input.task_id,
+        adapter_key=validated_input.adapter_key,
+        capability=validated_input.capability,
+        match_status=match_status,
+    )
+
+
+def validate_resource_capability_matcher_input(
+    input_value: ResourceCapabilityMatcherInput,
+) -> ResourceCapabilityMatcherInput:
+    if not isinstance(input_value, ResourceCapabilityMatcherInput):
+        raise ResourceCapabilityMatcherContractError(
+            "matcher 输入必须为 ResourceCapabilityMatcherInput",
+            details={"actual_type": type(input_value).__name__},
+        )
+
+    task_id = _require_matcher_non_empty_string(
+        input_value.task_id,
+        field_name="task_id",
+        details={"field_name": "task_id"},
+    )
+    adapter_key = _require_matcher_non_empty_string(
+        input_value.adapter_key,
+        field_name="adapter_key",
+        details={"task_id": task_id},
+    )
+    capability = _require_matcher_non_empty_string(
+        input_value.capability,
+        field_name="capability",
+        details={"task_id": task_id, "adapter_key": adapter_key},
+    )
+    if capability not in _ALLOWED_MATCHER_CAPABILITIES:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher capability 必须是当前已冻结的 adapter-facing capability",
+            details={
+                "task_id": task_id,
+                "adapter_key": adapter_key,
+                "capability": capability,
+            },
+        )
+
+    requirement_declaration = _validate_matcher_requirement_declaration(
+        input_value.requirement_declaration,
+        expected_adapter_key=adapter_key,
+        expected_capability=capability,
+        task_id=task_id,
+    )
+    available_resource_capabilities = _normalize_available_resource_capabilities(
+        input_value.available_resource_capabilities,
+        task_id=task_id,
+        adapter_key=adapter_key,
+        capability=capability,
+    )
+
+    return ResourceCapabilityMatcherInput(
+        task_id=task_id,
+        adapter_key=adapter_key,
+        capability=capability,
+        requirement_declaration=requirement_declaration,
+        available_resource_capabilities=available_resource_capabilities,
+    )
+
+
 def resolve_requested_resource_slots(request: CoreTaskRequest) -> tuple[str, ...] | None:
     slots = RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE.get(
         (request.target.capability, request.policy.collection_mode)
@@ -801,6 +992,21 @@ def resolve_requested_resource_slots(request: CoreTaskRequest) -> tuple[str, ...
     if slots is None:
         return None
     return tuple(slots)
+
+
+def resolve_runtime_available_resource_capabilities(request: CoreTaskRequest) -> tuple[str, ...]:
+    requested_slots = resolve_requested_resource_slots(request)
+    raw_capabilities: tuple[str, ...] | Iterable[str]
+    if requested_slots is None:
+        raw_capabilities = ()
+    else:
+        raw_capabilities = requested_slots
+    return _normalize_available_resource_capabilities(
+        raw_capabilities,
+        task_id="",
+        adapter_key=request.target.adapter_key,
+        capability=CAPABILITY_FAMILY_BY_OPERATION.get(request.target.capability, request.target.capability),
+    )
 
 
 def default_runtime_resource_lifecycle_store():
@@ -1217,6 +1423,14 @@ def runtime_contract_error(code: str, message: str, *, details: Mapping[str, Any
     }
 
 
+def invalid_resource_requirement_error(message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return runtime_contract_error("invalid_resource_requirement", message, details=details)
+
+
+def resource_unavailable_error(message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return runtime_contract_error("resource_unavailable", message, details=details)
+
+
 def classify_adapter_error(error: PlatformAdapterError) -> dict[str, Any]:
     details = error.details if isinstance(error.details, Mapping) else {}
     if error.category == "invalid_input":
@@ -1245,3 +1459,217 @@ def unsupported_error(code: str, message: str, *, details: Mapping[str, Any] | N
         "message": message,
         "details": dict(details or {}),
     }
+
+
+def _require_matcher_non_empty_string(
+    raw_value: Any,
+    *,
+    field_name: str,
+    details: Mapping[str, Any] | None = None,
+) -> str:
+    if not isinstance(raw_value, str) or not raw_value:
+        raise ResourceCapabilityMatcherContractError(
+            f"matcher 输入字段 `{field_name}` 必须为非空字符串",
+            details=details,
+        )
+    return raw_value
+
+
+def _validate_matcher_requirement_declaration(
+    raw_value: Any,
+    *,
+    expected_adapter_key: str,
+    expected_capability: str,
+    task_id: str,
+) -> AdapterResourceRequirementDeclaration:
+    if not isinstance(raw_value, AdapterResourceRequirementDeclaration):
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration 必须是 AdapterResourceRequirementDeclaration",
+            details={"task_id": task_id, "actual_type": type(raw_value).__name__},
+        )
+
+    adapter_key = _require_matcher_non_empty_string(
+        raw_value.adapter_key,
+        field_name="requirement_declaration.adapter_key",
+        details={"task_id": task_id},
+    )
+    capability = _require_matcher_non_empty_string(
+        raw_value.capability,
+        field_name="requirement_declaration.capability",
+        details={"task_id": task_id, "adapter_key": adapter_key},
+    )
+    if capability not in _ALLOWED_MATCHER_CAPABILITIES:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration.capability 未被批准",
+            details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+        )
+    if adapter_key != expected_adapter_key or capability != expected_capability:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher 输入上下文必须与 requirement_declaration 保持一致",
+            details={
+                "task_id": task_id,
+                "expected_adapter_key": expected_adapter_key,
+                "actual_adapter_key": adapter_key,
+                "expected_capability": expected_capability,
+                "actual_capability": capability,
+            },
+        )
+
+    resource_dependency_mode = _require_matcher_non_empty_string(
+        raw_value.resource_dependency_mode,
+        field_name="requirement_declaration.resource_dependency_mode",
+        details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+    )
+    if resource_dependency_mode not in {RESOURCE_DEPENDENCY_MODE_NONE, RESOURCE_DEPENDENCY_MODE_REQUIRED}:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration.resource_dependency_mode 仅允许 none|required",
+            details={
+                "task_id": task_id,
+                "adapter_key": adapter_key,
+                "capability": capability,
+                "resource_dependency_mode": resource_dependency_mode,
+            },
+        )
+
+    required_capabilities = _normalize_available_resource_capabilities(
+        raw_value.required_capabilities,
+        task_id=task_id,
+        adapter_key=adapter_key,
+        capability=capability,
+        field_name="requirement_declaration.required_capabilities",
+    )
+    if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE and required_capabilities:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration 在 none 模式下不得声明 required_capabilities",
+            details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+        )
+    if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_REQUIRED and not required_capabilities:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration 在 required 模式下必须声明 required_capabilities",
+            details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+        )
+
+    evidence_refs = _normalize_non_empty_string_tuple(
+        raw_value.evidence_refs,
+        task_id=task_id,
+        adapter_key=adapter_key,
+        capability=capability,
+        field_name="requirement_declaration.evidence_refs",
+        allow_empty=False,
+    )
+    return AdapterResourceRequirementDeclaration(
+        adapter_key=adapter_key,
+        capability=capability,
+        resource_dependency_mode=resource_dependency_mode,
+        required_capabilities=required_capabilities,
+        evidence_refs=evidence_refs,
+    )
+
+
+def _normalize_available_resource_capabilities(
+    raw_values: Any,
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    field_name: str = "available_resource_capabilities",
+) -> tuple[str, ...]:
+    capabilities = _normalize_non_empty_string_tuple(
+        raw_values,
+        task_id=task_id,
+        adapter_key=adapter_key,
+        capability=capability,
+        field_name=field_name,
+        allow_empty=True,
+    )
+    unknown_capabilities = tuple(
+        value for value in capabilities if value not in _APPROVED_RESOURCE_CAPABILITY_IDS
+    )
+    if unknown_capabilities:
+        raise ResourceCapabilityMatcherContractError(
+            f"matcher `{field_name}` 只能使用 FR-0015 已批准的 resource capability ids",
+            details={
+                "task_id": task_id,
+                "adapter_key": adapter_key,
+                "capability": capability,
+                "unknown_capabilities": unknown_capabilities,
+            },
+        )
+    return capabilities
+
+
+def _normalize_non_empty_string_tuple(
+    raw_values: Any,
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    field_name: str,
+    allow_empty: bool,
+) -> tuple[str, ...]:
+    if raw_values is None:
+        raise ResourceCapabilityMatcherContractError(
+            f"matcher `{field_name}` 必须为去重字符串集合",
+            details={
+                "task_id": task_id,
+                "adapter_key": adapter_key,
+                "capability": capability,
+                "actual_type": "NoneType",
+            },
+        )
+    if isinstance(raw_values, (str, bytes)):
+        raise ResourceCapabilityMatcherContractError(
+            f"matcher `{field_name}` 必须为去重字符串集合",
+            details={
+                "task_id": task_id,
+                "adapter_key": adapter_key,
+                "capability": capability,
+                "actual_type": type(raw_values).__name__,
+            },
+        )
+    try:
+        iterator = iter(raw_values)
+    except TypeError as error:
+        raise ResourceCapabilityMatcherContractError(
+            f"matcher `{field_name}` 必须为去重字符串集合",
+            details={
+                "task_id": task_id,
+                "adapter_key": adapter_key,
+                "capability": capability,
+                "actual_type": type(raw_values).__name__,
+                "error_type": error.__class__.__name__,
+            },
+        ) from error
+
+    values: list[str] = []
+    seen: set[str] = set()
+    for raw_value in iterator:
+        if not isinstance(raw_value, str) or not raw_value:
+            raise ResourceCapabilityMatcherContractError(
+                f"matcher `{field_name}` 只能包含非空字符串",
+                details={
+                    "task_id": task_id,
+                    "adapter_key": adapter_key,
+                    "capability": capability,
+                    "invalid_value": raw_value,
+                },
+            )
+        if raw_value in seen:
+            raise ResourceCapabilityMatcherContractError(
+                f"matcher `{field_name}` 不得包含重复 capability",
+                details={
+                    "task_id": task_id,
+                    "adapter_key": adapter_key,
+                    "capability": capability,
+                    "duplicate_value": raw_value,
+                },
+            )
+        seen.add(raw_value)
+        values.append(raw_value)
+
+    if not allow_empty and not values:
+        raise ResourceCapabilityMatcherContractError(
+            f"matcher `{field_name}` 不得为空",
+            details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+        )
+    return tuple(values)

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -11,8 +11,6 @@ from syvert.registry import (
     AdapterRegistry,
     AdapterResourceRequirementDeclaration,
     RegistryError,
-    RESOURCE_DEPENDENCY_MODE_NONE,
-    approved_resource_requirement_evidence_refs_for,
 )
 from syvert.resource_capability_evidence import approved_resource_capability_ids
 from syvert.task_record import (
@@ -914,9 +912,7 @@ def match_resource_capabilities(input_value: ResourceCapabilityMatcherInput) -> 
     validated_input = validate_resource_capability_matcher_input(input_value)
     required_capabilities = frozenset(validated_input.requirement_declaration.required_capabilities)
     available_resource_capabilities = frozenset(validated_input.available_resource_capabilities)
-    if validated_input.requirement_declaration.resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE:
-        match_status = MATCH_STATUS_MATCHED
-    elif required_capabilities.issubset(available_resource_capabilities):
+    if required_capabilities.issubset(available_resource_capabilities):
         match_status = MATCH_STATUS_MATCHED
     else:
         match_status = MATCH_STATUS_UNMATCHED
@@ -1519,54 +1515,6 @@ def _validate_matcher_requirement_declaration(
         field_name="requirement_declaration.resource_dependency_mode",
         details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
     )
-    if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE:
-        required_capabilities = _normalize_available_resource_capabilities(
-            raw_value.required_capabilities,
-            task_id=task_id,
-            adapter_key=adapter_key,
-            capability=capability,
-            field_name="requirement_declaration.required_capabilities",
-        )
-        if required_capabilities:
-            raise ResourceCapabilityMatcherContractError(
-                "matcher requirement_declaration 在 none 模式下不得声明 required_capabilities",
-                details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
-            )
-        evidence_refs = _normalize_non_empty_string_tuple(
-            raw_value.evidence_refs,
-            task_id=task_id,
-            adapter_key=adapter_key,
-            capability=capability,
-            field_name="requirement_declaration.evidence_refs",
-            allow_empty=False,
-        )
-        approved_evidence_refs = approved_resource_requirement_evidence_refs_for(
-            adapter_key=adapter_key,
-            capability=capability,
-        )
-        unknown_evidence_refs = tuple(
-            evidence_ref
-            for evidence_ref in evidence_refs
-            if evidence_ref not in approved_evidence_refs
-        )
-        if unknown_evidence_refs:
-            raise ResourceCapabilityMatcherContractError(
-                "matcher requirement_declaration.evidence_refs 必须绑定到 FR-0015 已批准共享证据",
-                details={
-                    "task_id": task_id,
-                    "adapter_key": adapter_key,
-                    "capability": capability,
-                    "unknown_evidence_refs": unknown_evidence_refs,
-                },
-            )
-        return AdapterResourceRequirementDeclaration(
-            adapter_key=adapter_key,
-            capability=capability,
-            resource_dependency_mode=resource_dependency_mode,
-            required_capabilities=required_capabilities,
-            evidence_refs=evidence_refs,
-        )
-
     try:
         registry = AdapterRegistry.from_mapping(
             {

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -274,6 +274,9 @@ def execute_task_internal(
         registry = AdapterRegistry.from_mapping(adapters)
     except RegistryError as error:
         if error.code == "invalid_adapter_resource_requirements":
+            # Runtime only admits declarations that registry can materialize.
+            # Pure matcher-only `none` semantics stay unreachable here until FR-0013
+            # freezes a canonical runtime declaration baseline for that mode.
             return TaskExecutionResult(
                 failure_envelope(
                     task_id,

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -11,6 +11,8 @@ from syvert.registry import (
     AdapterRegistry,
     AdapterResourceRequirementDeclaration,
     RegistryError,
+    RESOURCE_DEPENDENCY_MODE_NONE,
+    approved_resource_requirement_evidence_refs_for,
 )
 from syvert.resource_capability_evidence import approved_resource_capability_ids
 from syvert.task_record import (
@@ -1515,6 +1517,54 @@ def _validate_matcher_requirement_declaration(
         field_name="requirement_declaration.resource_dependency_mode",
         details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
     )
+    if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE:
+        required_capabilities = _normalize_available_resource_capabilities(
+            raw_value.required_capabilities,
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            field_name="requirement_declaration.required_capabilities",
+        )
+        if required_capabilities:
+            raise ResourceCapabilityMatcherContractError(
+                "matcher requirement_declaration 在 none 模式下不得声明 required_capabilities",
+                details={"task_id": task_id, "adapter_key": adapter_key, "capability": capability},
+            )
+        evidence_refs = _normalize_non_empty_string_tuple(
+            raw_value.evidence_refs,
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            field_name="requirement_declaration.evidence_refs",
+            allow_empty=False,
+        )
+        approved_evidence_refs = approved_resource_requirement_evidence_refs_for(
+            adapter_key=adapter_key,
+            capability=capability,
+        )
+        unknown_evidence_refs = tuple(
+            evidence_ref
+            for evidence_ref in evidence_refs
+            if evidence_ref not in approved_evidence_refs
+        )
+        if unknown_evidence_refs:
+            raise ResourceCapabilityMatcherContractError(
+                "matcher requirement_declaration.evidence_refs 必须绑定到 FR-0015 已批准共享证据",
+                details={
+                    "task_id": task_id,
+                    "adapter_key": adapter_key,
+                    "capability": capability,
+                    "unknown_evidence_refs": unknown_evidence_refs,
+                },
+            )
+        return AdapterResourceRequirementDeclaration(
+            adapter_key=adapter_key,
+            capability=capability,
+            resource_dependency_mode=resource_dependency_mode,
+            required_capabilities=required_capabilities,
+            evidence_refs=evidence_refs,
+        )
+
     try:
         registry = AdapterRegistry.from_mapping(
             {

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -272,7 +272,10 @@ def execute_task_internal(
     try:
         registry = AdapterRegistry.from_mapping(adapters)
     except RegistryError as error:
-        if error.code == "invalid_adapter_resource_requirements":
+        if (
+            error.code == "invalid_adapter_resource_requirements"
+            and error.details.get("adapter_key") == adapter_key
+        ):
             # Runtime only admits declarations that registry can materialize.
             # Pure matcher-only `none` semantics stay unreachable here until FR-0013
             # freezes a canonical runtime declaration baseline for that mode.

--- a/tests/runtime/adapter_fixtures.py
+++ b/tests/runtime/adapter_fixtures.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
+from tests.runtime.resource_fixtures import baseline_resource_requirement_declarations
 from syvert.runtime import TaskRequest
+
+TEST_ADAPTER_KEY = "xhs"
 
 
 class SuccessfulAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {
             "raw": {"id": "raw-cli-module-1", "url": request.input.url},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-cli-module-1",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -41,16 +45,17 @@ class SuccessfulAdapter:
 
 
 class UnserializableSuccessAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {
             "raw": {"id": "raw-cli-module-2", "bad": object()},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-cli-module-2",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -78,8 +83,8 @@ class UnserializableSuccessAdapter:
 
 
 def build_adapters() -> dict[str, object]:
-    return {"stub": SuccessfulAdapter()}
+    return {TEST_ADAPTER_KEY: SuccessfulAdapter()}
 
 
 def build_unserializable_adapters() -> dict[str, object]:
-    return {"stub": UnserializableSuccessAdapter()}
+    return {TEST_ADAPTER_KEY: UnserializableSuccessAdapter()}

--- a/tests/runtime/contract_harness/fake_adapter.py
+++ b/tests/runtime/contract_harness/fake_adapter.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from tests.runtime.resource_fixtures import baseline_resource_requirement_declarations
 from syvert.runtime import AdapterExecutionContext, PlatformAdapterError
 
 FakeAdapterScenario = Literal["success", "legal_failure", "illegal_payload"]
+HARNESS_DECLARATION_ADAPTER_KEY = "xhs"
 
 
 def _build_success_payload(url: str) -> dict[str, Any]:
@@ -47,6 +49,9 @@ class FakeContractAdapter:
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(
+        adapter_key=HARNESS_DECLARATION_ADAPTER_KEY
+    )
 
     def execute(self, request: AdapterExecutionContext) -> dict[str, Any]:
         self.last_request = request

--- a/tests/runtime/contract_harness/host.py
+++ b/tests/runtime/contract_harness/host.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from syvert.runtime import TaskInput, TaskRequest, execute_task
+from tests.runtime.contract_harness.fake_adapter import HARNESS_DECLARATION_ADAPTER_KEY
 
-DEFAULT_HARNESS_ADAPTER_KEY = "fake"
+DEFAULT_HARNESS_ADAPTER_KEY = HARNESS_DECLARATION_ADAPTER_KEY
 DEFAULT_HARNESS_CAPABILITY = "content_detail_by_url"
 
 

--- a/tests/runtime/contract_harness/samples.py
+++ b/tests/runtime/contract_harness/samples.py
@@ -7,7 +7,10 @@ from enum import Enum
 from typing import Sequence
 
 from syvert.runtime import CONTENT_DETAIL_BY_URL, LEGACY_COLLECTION_MODE
-from tests.runtime.contract_harness.fake_adapter import FakeAdapterScenario
+from tests.runtime.contract_harness.fake_adapter import (
+    FakeAdapterScenario,
+    HARNESS_DECLARATION_ADAPTER_KEY,
+)
 
 
 class ExpectedVerdict(Enum):
@@ -46,7 +49,7 @@ class ContractSample:
 
 
 SUCCESS_PROFILE = FakeAdapterProfile(
-    adapter_key="fake:contract-success",
+    adapter_key=HARNESS_DECLARATION_ADAPTER_KEY,
     scenario="success",
     declared_capabilities=("content_detail",),
     supported_targets=("url",),
@@ -54,7 +57,7 @@ SUCCESS_PROFILE = FakeAdapterProfile(
 )
 
 LEGAL_FAILURE_PROFILE = FakeAdapterProfile(
-    adapter_key="fake:contract-legal-failure",
+    adapter_key=HARNESS_DECLARATION_ADAPTER_KEY,
     scenario="legal_failure",
     declared_capabilities=("content_detail",),
     supported_targets=("url",),
@@ -62,7 +65,7 @@ LEGAL_FAILURE_PROFILE = FakeAdapterProfile(
 )
 
 VIOLATION_PROFILE = FakeAdapterProfile(
-    adapter_key="fake:contract-violation",
+    adapter_key=HARNESS_DECLARATION_ADAPTER_KEY,
     scenario="illegal_payload",
     declared_capabilities=("content_detail",),
     supported_targets=("url",),

--- a/tests/runtime/resource_fixtures.py
+++ b/tests/runtime/resource_fixtures.py
@@ -5,6 +5,7 @@ import tempfile
 from typing import Any
 from unittest import mock
 
+from syvert.registry import baseline_required_resource_requirement_declaration
 from syvert.resource_lifecycle import MANAGED_ACCOUNT_ADAPTER_KEY_FIELD, ResourceBundle, ResourceRecord
 from syvert.resource_lifecycle_store import default_resource_lifecycle_store
 from syvert.resource_trace_store import default_resource_trace_store
@@ -49,6 +50,19 @@ def proxy_material() -> dict[str, Any]:
 
 def managed_account_material(material: dict[str, Any], *, adapter_key: str) -> dict[str, Any]:
     return {**material, MANAGED_ACCOUNT_ADAPTER_KEY_FIELD: adapter_key}
+
+
+def baseline_resource_requirement_declarations(
+    *,
+    adapter_key: str,
+    capability: str = "content_detail",
+) -> tuple[object, ...]:
+    return (
+        baseline_required_resource_requirement_declaration(
+            adapter_key=adapter_key,
+            capability=capability,
+        ),
+    )
 
 
 def build_managed_resource_bundle(
@@ -123,7 +137,7 @@ def seed_default_runtime_resources(
 
 
 class ResourceStoreEnvMixin:
-    resource_store_adapter_key = "stub"
+    resource_store_adapter_key = "xhs"
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -22,26 +22,29 @@ from syvert.task_record import (
 from syvert.task_record_store import LocalTaskRecordStore
 from tests.runtime.resource_fixtures import (
     ResourceStoreEnvMixin,
+    baseline_resource_requirement_declarations,
     douyin_account_material,
     seed_default_runtime_resources,
 )
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_ADAPTER_KEY = "xhs"
 
 
 class SuccessfulAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request):
         url = request.input.url
         return {
             "raw": {"id": "raw-cli-1", "url": url},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-cli-1",
                 "content_type": "unknown",
                 "canonical_url": url,
@@ -69,10 +72,11 @@ class SuccessfulAdapter:
 
 
 class PlatformFailureAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request):
         from syvert.runtime import PlatformAdapterError
@@ -155,7 +159,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
                 "-m",
                 "syvert.cli",
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
             ],
             cwd=REPO_ROOT,
             env=env,
@@ -168,7 +172,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result.stdout, "")
         payload = json.loads(result.stderr)
         self.assertEqual(payload["status"], "failed")
-        self.assertEqual(payload["adapter_key"], "stub")
+        self.assertEqual(payload["adapter_key"], TEST_ADAPTER_KEY)
         self.assertEqual(payload["error"]["category"], "invalid_input")
         self.assertEqual(payload["error"]["code"], "invalid_cli_arguments")
 
@@ -229,7 +233,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
                 "-m",
                 "syvert.cli",
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
@@ -247,7 +251,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["status"], "success")
-        self.assertEqual(payload["adapter_key"], "stub")
+        self.assertEqual(payload["adapter_key"], TEST_ADAPTER_KEY)
 
     def test_cli_persists_task_record_through_default_store_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -262,14 +266,14 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
                 {"SYVERT_RESOURCE_LIFECYCLE_STORE_FILE": str(resource_store_path)},
                 clear=False,
             ):
-                seed_default_runtime_resources()
+                seed_default_runtime_resources(adapter_key=TEST_ADAPTER_KEY)
             result = subprocess.run(
                 [
                     sys.executable,
                     "-m",
                     "syvert.cli",
                     "--adapter",
-                    "stub",
+                    TEST_ADAPTER_KEY,
                     "--capability",
                     "content_detail_by_url",
                     "--url",
@@ -298,13 +302,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
             [
                 "run",
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/run-1",
             ],
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             stdout=stdout,
             stderr=stderr,
             task_id_factory=lambda: "task-cli-run-001",
@@ -315,7 +319,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["task_id"], "task-cli-run-001")
         self.assertEqual(payload["status"], "success")
-        self.assertEqual(payload["adapter_key"], "stub")
+        self.assertEqual(payload["adapter_key"], TEST_ADAPTER_KEY)
 
     def test_query_subcommand_returns_persisted_success_record(self) -> None:
         store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
@@ -325,13 +329,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         legacy_exit_code = main(
             [
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/query-success-1",
             ],
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             stdout=legacy_stdout,
             stderr=legacy_stderr,
             task_id_factory=lambda: "task-cli-query-success-1",
@@ -414,13 +418,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         legacy_exit_code = main(
             [
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/query-failed-1",
             ],
-            adapters={"stub": PlatformFailureAdapter()},
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
             stdout=legacy_stdout,
             stderr=legacy_stderr,
             task_id_factory=lambda: "task-cli-query-failed-1",
@@ -533,13 +537,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         legacy_exit_code = main(
             [
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/query-invalid-marker-1",
             ],
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             stdout=legacy_stdout,
             stderr=legacy_stderr,
             task_id_factory=lambda: "task-cli-query-invalid-marker-1",
@@ -723,13 +727,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
             [
                 "run",
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/shared-run-1",
             ],
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             stdout=run_stdout,
             stderr=run_stderr,
             task_id_factory=lambda: "task-cli-shared-run-1",
@@ -758,13 +762,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         legacy_exit_code = main(
             [
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/shared-legacy-1",
             ],
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             stdout=legacy_stdout,
             stderr=legacy_stderr,
             task_id_factory=lambda: "task-cli-shared-legacy-1",
@@ -779,13 +783,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
             [
                 "run",
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/shared-legacy-1",
             ],
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             stdout=run_stdout,
             stderr=run_stderr,
             task_id_factory=lambda: "task-cli-shared-run-equivalent-1",
@@ -981,14 +985,17 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         stdout = io.StringIO()
         stderr = io.StringIO()
 
-        with mock.patch("syvert.adapters.build_xhs_adapters", return_value={"dup": SuccessfulAdapter()}), mock.patch(
+        with mock.patch(
+            "syvert.adapters.build_xhs_adapters",
+            return_value={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+        ), mock.patch(
             "syvert.adapters.build_douyin_adapters",
-            return_value={"dup": SuccessfulAdapter()},
+            return_value={TEST_ADAPTER_KEY: SuccessfulAdapter()},
         ):
             exit_code = main(
                 [
                     "--adapter",
-                    "dup",
+                    TEST_ADAPTER_KEY,
                     "--capability",
                     "content_detail_by_url",
                     "--url",
@@ -1014,13 +1021,13 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         exit_code = main(
             [
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
                 "https://example.com/posts/1",
             ],
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             stdout=stdout,
             stderr=stderr,
             task_id_factory=lambda: "task-cli-001",
@@ -1031,7 +1038,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["task_id"], "task-cli-001")
         self.assertEqual(payload["status"], "success")
-        self.assertEqual(payload["adapter_key"], "stub")
+        self.assertEqual(payload["adapter_key"], TEST_ADAPTER_KEY)
         self.assertEqual(payload["capability"], "content_detail_by_url")
 
     def test_main_returns_non_zero_for_failed_envelope(self) -> None:
@@ -1093,7 +1100,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
                 "-m",
                 "syvert.cli",
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",
@@ -1178,7 +1185,7 @@ class CliTests(ResourceStoreEnvMixin, unittest.TestCase):
                 "-m",
                 "syvert.cli",
                 "--adapter",
-                "stub",
+                TEST_ADAPTER_KEY,
                 "--capability",
                 "content_detail_by_url",
                 "--url",

--- a/tests/runtime/test_contract_harness_validation_tool.py
+++ b/tests/runtime/test_contract_harness_validation_tool.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+import tempfile
 import unittest
 
+from syvert.resource_lifecycle import ResourceRecord
+from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 from tests.runtime.contract_harness import (
     ContractSampleDefinition,
+    DEFAULT_HARNESS_ADAPTER_KEY,
     FakeContractAdapter,
     HarnessExecutionResult,
     HarnessExecutionInput,
@@ -11,6 +16,7 @@ from tests.runtime.contract_harness import (
     validate_contract_samples,
     execute_harness_sample,
 )
+from tests.runtime.resource_fixtures import generic_account_material, managed_account_material, proxy_material
 
 def build_success_envelope() -> dict[str, object]:
     return {
@@ -214,15 +220,37 @@ class ContractHarnessValidationToolTests(unittest.TestCase):
 
     def test_host_legal_failure_output_can_be_consumed_by_validator(self) -> None:
         sample = ContractSampleDefinition(sample_id="sample-host-legal-failure", expected_outcome="legal_failure")
-        runtime_envelope = execute_harness_sample(
-            HarnessExecutionInput(
-                sample_id="sample-host-legal-failure",
-                url="https://example.com/legal-failure",
-                adapter_key="fake:platform-failure",
-            ),
-            adapters={"fake:platform-failure": FakeContractAdapter(scenario="legal_failure")},
-            task_id="task-host-legal-failure",
-        )
+        with tempfile.TemporaryDirectory(prefix="syvert-harness-validator-") as temp_dir:
+            resource_store = LocalResourceLifecycleStore(Path(temp_dir) / "resource-lifecycle.json")
+            resource_store.seed_resources(
+                [
+                    ResourceRecord(
+                        resource_id="validator-account-001",
+                        resource_type="account",
+                        status="AVAILABLE",
+                        material=managed_account_material(
+                            generic_account_material(),
+                            adapter_key=DEFAULT_HARNESS_ADAPTER_KEY,
+                        ),
+                    ),
+                    ResourceRecord(
+                        resource_id="validator-proxy-001",
+                        resource_type="proxy",
+                        status="AVAILABLE",
+                        material=proxy_material(),
+                    ),
+                ]
+            )
+            runtime_envelope = execute_harness_sample(
+                HarnessExecutionInput(
+                    sample_id="sample-host-legal-failure",
+                    url="https://example.com/legal-failure",
+                    adapter_key=DEFAULT_HARNESS_ADAPTER_KEY,
+                ),
+                adapters={DEFAULT_HARNESS_ADAPTER_KEY: FakeContractAdapter(scenario="legal_failure")},
+                task_id="task-host-legal-failure",
+                resource_lifecycle_store=resource_store,
+            )
         execution_result = HarnessExecutionResult(runtime_envelope=runtime_envelope)
 
         result = validate_contract_sample(sample, execution_result)

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -6,7 +6,7 @@ import unittest
 from unittest import mock
 
 from syvert.runtime import TaskInput, TaskRequest, execute_task
-from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin, baseline_resource_requirement_declarations
 
 
 class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
@@ -33,6 +33,7 @@ class SuccessfulAdapter:
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key="xhs")
 
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {

--- a/tests/runtime/test_resource_capability_evidence.py
+++ b/tests/runtime/test_resource_capability_evidence.py
@@ -28,31 +28,39 @@ from syvert.runtime import (
     CONTENT_DETAIL,
     CONTENT_DETAIL_BY_URL,
     LEGACY_COLLECTION_MODE,
+    MATCH_STATUS_MATCHED,
     RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE,
+    ResourceCapabilityMatcherInput,
     TaskInput,
     TaskRequest,
     execute_task,
+    match_resource_capabilities,
+    resolve_runtime_available_resource_capabilities,
 )
 from tests.runtime.resource_fixtures import (
     ResourceStoreEnvMixin,
+    baseline_resource_requirement_declarations,
     build_managed_resource_bundle,
     douyin_account_material,
     xhs_account_material,
 )
 
+TEST_ADAPTER_KEY = "xhs"
+
 
 class ProxyPathCaptureAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request: AdapterExecutionContext) -> dict[str, object]:
         self.last_request = request
         return {
             "raw": {"url": request.input.url},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-proxy-path",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -651,17 +659,30 @@ class ResourceCapabilityEvidenceTests(ResourceStoreEnvMixin, unittest.TestCase):
             RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE[(CONTENT_DETAIL_BY_URL, LEGACY_COLLECTION_MODE)],
             ("account", "proxy"),
         )
+        self.assertEqual(
+            resolve_runtime_available_resource_capabilities(
+                type("Request", (), {
+                    "target": type(
+                        "Target",
+                        (),
+                        {"adapter_key": TEST_ADAPTER_KEY, "capability": CONTENT_DETAIL_BY_URL},
+                    )(),
+                    "policy": type("Policy", (), {"collection_mode": LEGACY_COLLECTION_MODE})(),
+                })()
+            ),
+            ("account", "proxy"),
+        )
 
     def test_proxy_shared_evidence_is_exercised_through_runtime_bundle_binding(self) -> None:
         adapter = ProxyPathCaptureAdapter()
 
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability=CONTENT_DETAIL_BY_URL,
                 input=TaskInput(url="https://example.com/runtime-proxy-evidence"),
             ),
-            adapters={"stub": adapter},
+            adapters={TEST_ADAPTER_KEY: adapter},
             task_id_factory=lambda: "task-proxy-evidence",
         )
 
@@ -671,6 +692,62 @@ class ResourceCapabilityEvidenceTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertIsNotNone(adapter.last_request.resource_bundle.proxy)
         self.assertEqual(adapter.last_request.resource_bundle.capability, CONTENT_DETAIL_BY_URL)
         self.assertEqual(adapter.last_request.resource_bundle.proxy.resource_type, "proxy")
+
+    def test_matcher_stays_aligned_with_reference_adapter_required_capability_baseline(self) -> None:
+        declaration = baseline_required_resource_requirement_declaration(
+            adapter_key="xhs",
+            capability=CONTENT_DETAIL,
+        )
+
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-evidence-match-1",
+                adapter_key="xhs",
+                capability=CONTENT_DETAIL,
+                requirement_declaration=declaration,
+                available_resource_capabilities=resolve_runtime_available_resource_capabilities(
+                    type("Request", (), {
+                        "target": type(
+                            "Target",
+                            (),
+                            {"adapter_key": "xhs", "capability": CONTENT_DETAIL_BY_URL},
+                        )(),
+                        "policy": type("Policy", (), {"collection_mode": LEGACY_COLLECTION_MODE})(),
+                    })()
+                ),
+            )
+        )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
+
+    def test_registry_lookup_declaration_stays_matcher_compatible_with_approved_capability_ids(self) -> None:
+        registry = AdapterRegistry.from_mapping(build_adapters())
+        declaration = registry.lookup_resource_requirement("xhs", CONTENT_DETAIL)
+        self.assertIsNotNone(declaration)
+        assert declaration is not None
+        self.assertEqual(declaration.required_capabilities, ("account", "proxy"))
+        self.assertEqual(frozenset(declaration.required_capabilities), approved_resource_capability_ids())
+
+        available_capabilities = resolve_runtime_available_resource_capabilities(
+            type(
+                "Request",
+                (),
+                {
+                    "target": type("Target", (), {"adapter_key": "xhs", "capability": CONTENT_DETAIL_BY_URL})(),
+                    "policy": type("Policy", (), {"collection_mode": LEGACY_COLLECTION_MODE})(),
+                },
+            )()
+        )
+        match_outcome = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-196-registry-lookup-match",
+                adapter_key="xhs",
+                capability=CONTENT_DETAIL,
+                requirement_declaration=declaration,
+                available_resource_capabilities=available_capabilities,
+            )
+        )
+        self.assertEqual(match_outcome.match_status, MATCH_STATUS_MATCHED)
 
     def test_xhs_account_material_consumption_matches_evidence_baseline(self) -> None:
         material = xhs_account_material()

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -142,6 +142,49 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
 
         self.assertEqual(context.exception.code, "invalid_resource_requirement")
 
+    def test_matcher_rejects_subclassed_matcher_input_carrier(self) -> None:
+        class ShadowMatcherInput(ResourceCapabilityMatcherInput):
+            pass
+
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ShadowMatcherInput(
+                    task_id="task-match-shadow-input-subclass",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=baseline_required_resource_requirement_declaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                    ),
+                    available_resource_capabilities=("account", "proxy"),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+    def test_matcher_rejects_subclassed_requirement_declaration_carrier(self) -> None:
+        class ShadowRequirementDeclaration(AdapterResourceRequirementDeclaration):
+            pass
+
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-shadow-declaration-subclass",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=ShadowRequirementDeclaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_dependency_mode="required",
+                        required_capabilities=("account", "proxy"),
+                        evidence_refs=("xhs:content_detail:account", "xhs:content_detail:proxy"),
+                    ),
+                    available_resource_capabilities=("account", "proxy"),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -52,73 +52,33 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
 
         self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
 
-    def test_matcher_keeps_none_mode_semantics_in_pure_matcher_layer(self) -> None:
-        approved_evidence_refs = baseline_required_resource_requirement_declaration(
+    def test_matcher_rejects_none_mode_declaration_until_registry_baseline_exists(self) -> None:
+        approved_required_evidence_refs = baseline_required_resource_requirement_declaration(
             adapter_key="xhs",
             capability="content_detail",
         ).evidence_refs
-        result = match_resource_capabilities(
-            ResourceCapabilityMatcherInput(
-                task_id="task-match-none",
-                adapter_key="xhs",
-                capability="content_detail",
-                requirement_declaration=AdapterResourceRequirementDeclaration(
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-none",
                     adapter_key="xhs",
                     capability="content_detail",
-                    resource_dependency_mode="none",
-                    required_capabilities=(),
-                    evidence_refs=approved_evidence_refs,
-                ),
-                available_resource_capabilities=(),
+                    requirement_declaration=AdapterResourceRequirementDeclaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_dependency_mode="none",
+                        required_capabilities=(),
+                        evidence_refs=approved_required_evidence_refs,
+                    ),
+                    available_resource_capabilities=(),
+                )
             )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+        self.assertEqual(
+            context.exception.details["registry_error_code"],
+            "invalid_adapter_resource_requirements",
         )
-
-        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
-
-    def test_matcher_rejects_none_mode_declaration_with_unapproved_evidence_refs(self) -> None:
-        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
-            match_resource_capabilities(
-                ResourceCapabilityMatcherInput(
-                    task_id="task-match-none-invalid-evidence",
-                    adapter_key="xhs",
-                    capability="content_detail",
-                    requirement_declaration=AdapterResourceRequirementDeclaration(
-                        adapter_key="xhs",
-                        capability="content_detail",
-                        resource_dependency_mode="none",
-                        required_capabilities=(),
-                        evidence_refs=("matcher:none-mode",),
-                    ),
-                    available_resource_capabilities=(),
-                )
-            )
-
-        self.assertEqual(context.exception.code, "invalid_resource_requirement")
-
-    def test_matcher_rejects_none_mode_declaration_with_wrong_adapter_evidence_provenance(self) -> None:
-        wrong_provenance_refs = baseline_required_resource_requirement_declaration(
-            adapter_key="douyin",
-            capability="content_detail",
-        ).evidence_refs
-
-        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
-            match_resource_capabilities(
-                ResourceCapabilityMatcherInput(
-                    task_id="task-match-none-wrong-provenance",
-                    adapter_key="xhs",
-                    capability="content_detail",
-                    requirement_declaration=AdapterResourceRequirementDeclaration(
-                        adapter_key="xhs",
-                        capability="content_detail",
-                        resource_dependency_mode="none",
-                        required_capabilities=(),
-                        evidence_refs=wrong_provenance_refs,
-                    ),
-                    available_resource_capabilities=(),
-                )
-            )
-
-        self.assertEqual(context.exception.code, "invalid_resource_requirement")
 
     def test_matcher_rejects_context_mismatch_between_input_and_declaration(self) -> None:
         with self.assertRaises(ResourceCapabilityMatcherContractError) as context:

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -95,6 +95,31 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
 
         self.assertEqual(context.exception.code, "invalid_resource_requirement")
 
+    def test_matcher_rejects_none_mode_declaration_with_wrong_adapter_evidence_provenance(self) -> None:
+        wrong_provenance_refs = baseline_required_resource_requirement_declaration(
+            adapter_key="douyin",
+            capability="content_detail",
+        ).evidence_refs
+
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-none-wrong-provenance",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=AdapterResourceRequirementDeclaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_dependency_mode="none",
+                        required_capabilities=(),
+                        evidence_refs=wrong_provenance_refs,
+                    ),
+                    available_resource_capabilities=(),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
     def test_matcher_rejects_context_mismatch_between_input_and_declaration(self) -> None:
         with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
             match_resource_capabilities(

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -52,24 +52,25 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
 
         self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
 
-    def test_matcher_keeps_none_mode_semantics_in_pure_matcher_layer(self) -> None:
-        result = match_resource_capabilities(
-            ResourceCapabilityMatcherInput(
-                task_id="task-match-none",
-                adapter_key="stub",
-                capability="content_detail",
-                requirement_declaration=AdapterResourceRequirementDeclaration(
+    def test_matcher_rejects_none_mode_declaration_without_canonical_evidence_baseline(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-none",
                     adapter_key="stub",
                     capability="content_detail",
-                    resource_dependency_mode="none",
-                    required_capabilities=(),
-                    evidence_refs=("matcher:none-mode",),
-                ),
-                available_resource_capabilities=(),
+                    requirement_declaration=AdapterResourceRequirementDeclaration(
+                        adapter_key="stub",
+                        capability="content_detail",
+                        resource_dependency_mode="none",
+                        required_capabilities=(),
+                        evidence_refs=("matcher:none-mode",),
+                    ),
+                    available_resource_capabilities=(),
+                )
             )
-        )
 
-        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
 
     def test_matcher_rejects_context_mismatch_between_input_and_declaration(self) -> None:
         with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
@@ -117,6 +118,26 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
                         capability="content_detail",
                     ),
                     available_resource_capabilities=("account", "account"),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+    def test_matcher_rejects_required_declaration_with_noncanonical_evidence_refs(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-forged-evidence",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=AdapterResourceRequirementDeclaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_dependency_mode="required",
+                        required_capabilities=("account", "proxy"),
+                        evidence_refs=("forged:evidence",),
+                    ),
+                    available_resource_capabilities=("account", "proxy"),
                 )
             )
 

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -52,15 +52,34 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
 
         self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
 
-    def test_matcher_rejects_none_mode_declaration_until_registry_baseline_exists(self) -> None:
-        approved_required_evidence_refs = baseline_required_resource_requirement_declaration(
+    def test_matcher_keeps_none_mode_semantics_in_pure_matcher_layer(self) -> None:
+        approved_evidence_refs = baseline_required_resource_requirement_declaration(
             adapter_key="xhs",
             capability="content_detail",
         ).evidence_refs
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-match-none",
+                adapter_key="xhs",
+                capability="content_detail",
+                requirement_declaration=AdapterResourceRequirementDeclaration(
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    resource_dependency_mode="none",
+                    required_capabilities=(),
+                    evidence_refs=approved_evidence_refs,
+                ),
+                available_resource_capabilities=(),
+            )
+        )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
+
+    def test_matcher_rejects_none_mode_declaration_with_unapproved_evidence_refs(self) -> None:
         with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
             match_resource_capabilities(
                 ResourceCapabilityMatcherInput(
-                    task_id="task-match-none",
+                    task_id="task-match-none-invalid-evidence",
                     adapter_key="xhs",
                     capability="content_detail",
                     requirement_declaration=AdapterResourceRequirementDeclaration(
@@ -68,17 +87,38 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
                         capability="content_detail",
                         resource_dependency_mode="none",
                         required_capabilities=(),
-                        evidence_refs=approved_required_evidence_refs,
+                        evidence_refs=("matcher:none-mode",),
                     ),
                     available_resource_capabilities=(),
                 )
             )
 
         self.assertEqual(context.exception.code, "invalid_resource_requirement")
-        self.assertEqual(
-            context.exception.details["registry_error_code"],
-            "invalid_adapter_resource_requirements",
-        )
+
+    def test_matcher_rejects_none_mode_declaration_with_wrong_adapter_evidence_provenance(self) -> None:
+        wrong_provenance_refs = baseline_required_resource_requirement_declaration(
+            adapter_key="douyin",
+            capability="content_detail",
+        ).evidence_refs
+
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-none-wrong-provenance",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=AdapterResourceRequirementDeclaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_dependency_mode="none",
+                        required_capabilities=(),
+                        evidence_refs=wrong_provenance_refs,
+                    ),
+                    available_resource_capabilities=(),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
 
     def test_matcher_rejects_context_mismatch_between_input_and_declaration(self) -> None:
         with self.assertRaises(ResourceCapabilityMatcherContractError) as context:

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -53,23 +53,47 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
         self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
 
     def test_matcher_keeps_none_mode_semantics_in_pure_matcher_layer(self) -> None:
+        approved_evidence_refs = baseline_required_resource_requirement_declaration(
+            adapter_key="xhs",
+            capability="content_detail",
+        ).evidence_refs
         result = match_resource_capabilities(
             ResourceCapabilityMatcherInput(
                 task_id="task-match-none",
-                adapter_key="stub",
+                adapter_key="xhs",
                 capability="content_detail",
                 requirement_declaration=AdapterResourceRequirementDeclaration(
-                    adapter_key="stub",
+                    adapter_key="xhs",
                     capability="content_detail",
                     resource_dependency_mode="none",
                     required_capabilities=(),
-                    evidence_refs=("matcher:none-mode",),
+                    evidence_refs=approved_evidence_refs,
                 ),
                 available_resource_capabilities=(),
             )
         )
 
         self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
+
+    def test_matcher_rejects_none_mode_declaration_with_unapproved_evidence_refs(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-none-invalid-evidence",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=AdapterResourceRequirementDeclaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_dependency_mode="none",
+                        required_capabilities=(),
+                        evidence_refs=("matcher:none-mode",),
+                    ),
+                    available_resource_capabilities=(),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
 
     def test_matcher_rejects_context_mismatch_between_input_and_declaration(self) -> None:
         with self.assertRaises(ResourceCapabilityMatcherContractError) as context:

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import unittest
+
+from syvert.registry import (
+    AdapterResourceRequirementDeclaration,
+    baseline_required_resource_requirement_declaration,
+)
+from syvert.runtime import (
+    MATCH_STATUS_MATCHED,
+    MATCH_STATUS_UNMATCHED,
+    ResourceCapabilityMatcherContractError,
+    ResourceCapabilityMatcherInput,
+    match_resource_capabilities,
+)
+
+
+class ResourceCapabilityMatcherTests(unittest.TestCase):
+    def test_matcher_returns_matched_when_available_capabilities_cover_required_capabilities(self) -> None:
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-match-1",
+                adapter_key="xhs",
+                capability="content_detail",
+                requirement_declaration=baseline_required_resource_requirement_declaration(
+                    adapter_key="xhs",
+                    capability="content_detail",
+                ),
+                available_resource_capabilities=("account", "proxy"),
+            )
+        )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
+        self.assertEqual(
+            tuple(result.__dict__.keys()),
+            ("task_id", "adapter_key", "capability", "match_status"),
+        )
+
+    def test_matcher_returns_unmatched_when_available_capabilities_are_subset_of_required_capabilities(self) -> None:
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-match-2",
+                adapter_key="douyin",
+                capability="content_detail",
+                requirement_declaration=baseline_required_resource_requirement_declaration(
+                    adapter_key="douyin",
+                    capability="content_detail",
+                ),
+                available_resource_capabilities=("account",),
+            )
+        )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
+
+    def test_matcher_keeps_none_mode_semantics_in_pure_matcher_layer(self) -> None:
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-match-none",
+                adapter_key="stub",
+                capability="content_detail",
+                requirement_declaration=AdapterResourceRequirementDeclaration(
+                    adapter_key="stub",
+                    capability="content_detail",
+                    resource_dependency_mode="none",
+                    required_capabilities=(),
+                    evidence_refs=("matcher:none-mode",),
+                ),
+                available_resource_capabilities=(),
+            )
+        )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
+
+    def test_matcher_rejects_context_mismatch_between_input_and_declaration(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-context-mismatch",
+                    adapter_key="douyin",
+                    capability="content_detail",
+                    requirement_declaration=baseline_required_resource_requirement_declaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                    ),
+                    available_resource_capabilities=("account", "proxy"),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+    def test_matcher_rejects_unknown_available_capability(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-unknown-capability",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=baseline_required_resource_requirement_declaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                    ),
+                    available_resource_capabilities=("account", "browser_state"),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+    def test_matcher_rejects_duplicate_available_capability(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-duplicate-capability",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=baseline_required_resource_requirement_declaration(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                    ),
+                    available_resource_capabilities=("account", "account"),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+    def test_matcher_rejects_shadow_requirement_declaration_carrier(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-shadow-carrier",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration={  # type: ignore[arg-type]
+                        "adapter_key": "xhs",
+                        "capability": "content_detail",
+                        "resource_dependency_mode": "required",
+                        "required_capabilities": ("account", "proxy"),
+                        "evidence_refs": ("shadow:carrier",),
+                    },
+                    available_resource_capabilities=("account", "proxy"),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -52,25 +52,24 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
 
         self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
 
-    def test_matcher_rejects_none_mode_declaration_without_canonical_evidence_baseline(self) -> None:
-        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
-            match_resource_capabilities(
-                ResourceCapabilityMatcherInput(
-                    task_id="task-match-none",
+    def test_matcher_keeps_none_mode_semantics_in_pure_matcher_layer(self) -> None:
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-match-none",
+                adapter_key="stub",
+                capability="content_detail",
+                requirement_declaration=AdapterResourceRequirementDeclaration(
                     adapter_key="stub",
                     capability="content_detail",
-                    requirement_declaration=AdapterResourceRequirementDeclaration(
-                        adapter_key="stub",
-                        capability="content_detail",
-                        resource_dependency_mode="none",
-                        required_capabilities=(),
-                        evidence_refs=("matcher:none-mode",),
-                    ),
-                    available_resource_capabilities=(),
-                )
+                    resource_dependency_mode="none",
+                    required_capabilities=(),
+                    evidence_refs=("matcher:none-mode",),
+                ),
+                available_resource_capabilities=(),
             )
+        )
 
-        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
 
     def test_matcher_rejects_context_mismatch_between_input_and_declaration(self) -> None:
         with self.assertRaises(ResourceCapabilityMatcherContractError) as context:

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -915,6 +915,39 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             "invalid_adapter_resource_requirements",
         )
 
+    def test_execute_task_rejects_invalid_runtime_capability_projection_before_task_record(self) -> None:
+        with mock.patch.dict(
+            runtime_module.RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE,
+            {
+                (
+                    runtime_module.CONTENT_DETAIL_BY_URL,
+                    runtime_module.LEGACY_COLLECTION_MODE,
+                ): ("account", "browser_state")
+            },
+            clear=True,
+        ), mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=AssertionError("acquire should not run for invalid runtime capability projections"),
+        ):
+            outcome = execute_task_with_record(
+                TaskRequest(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/posts/invalid-runtime-capability-projection"),
+                ),
+                adapters={TEST_ADAPTER_KEY: NeverCalledAdapter()},
+                task_id_factory=lambda: "task-invalid-runtime-capability-projection",
+            )
+
+        self.assertEqual(outcome.envelope["status"], "failed")
+        self.assertEqual(outcome.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(outcome.envelope["error"]["code"], "invalid_resource_requirement")
+        self.assertEqual(
+            outcome.envelope["error"]["details"]["unknown_capabilities"],
+            ("browser_state",),
+        )
+        self.assertIsNone(outcome.task_record)
+
     def test_execute_task_returns_resource_unavailable_when_runtime_capability_projection_is_unmatched(self) -> None:
         with mock.patch.dict(
             runtime_module.RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE,

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -26,14 +26,18 @@ from syvert.runtime import (
     TaskInput,
     TaskRequest,
     execute_task,
+    execute_task_with_record,
 )
 from tests.runtime.resource_fixtures import (
     ResourceStoreEnvMixin,
+    baseline_resource_requirement_declarations,
     generic_account_material,
     managed_account_material,
     proxy_material,
     seed_default_runtime_resources,
 )
+
+TEST_ADAPTER_KEY = "xhs"
 
 
 class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
@@ -63,8 +67,12 @@ class ExtendedTaskRequest(TaskRequest):
     extra: str
 
 
-class SuccessfulAdapter:
-    adapter_key = "stub"
+class StubContentDetailDeclarationMixin:
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
+
+
+class SuccessfulAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -77,7 +85,7 @@ class SuccessfulAdapter:
                 "url": request.input.url,
             },
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-1",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -104,8 +112,8 @@ class SuccessfulAdapter:
         }
 
 
-class MissingRawAdapter:
-    adapter_key = "stub"
+class MissingRawAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -113,7 +121,7 @@ class MissingRawAdapter:
     def execute(self, request: TaskRequest) -> dict[str, object]:
         return {
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-1",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -140,8 +148,8 @@ class MissingRawAdapter:
         }
 
 
-class NonePayloadAdapter:
-    adapter_key = "stub"
+class NonePayloadAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -150,8 +158,8 @@ class NonePayloadAdapter:
         return None
 
 
-class ListPayloadAdapter:
-    adapter_key = "stub"
+class ListPayloadAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -160,8 +168,8 @@ class ListPayloadAdapter:
         return []
 
 
-class CrashingAdapter:
-    adapter_key = "stub"
+class CrashingAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -170,8 +178,8 @@ class CrashingAdapter:
         raise RuntimeError("boom")
 
 
-class PlatformErrorWithBadDetailsAdapter:
-    adapter_key = "stub"
+class PlatformErrorWithBadDetailsAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -182,8 +190,8 @@ class PlatformErrorWithBadDetailsAdapter:
         raise PlatformAdapterError(code="platform_broken", message="bad details", details=None)
 
 
-class PlatformFailureAdapter:
-    adapter_key = "stub"
+class PlatformFailureAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -196,8 +204,8 @@ class PlatformFailureAdapter:
         )
 
 
-class InvalidatingHintAdapter:
-    adapter_key = "stub"
+class InvalidatingHintAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -207,7 +215,7 @@ class InvalidatingHintAdapter:
         return {
             "raw": {"id": "raw-invalid-hint"},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-invalid-hint",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -239,8 +247,8 @@ class InvalidatingHintAdapter:
         }
 
 
-class LeaseIdMismatchHintAdapter:
-    adapter_key = "stub"
+class LeaseIdMismatchHintAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -249,7 +257,7 @@ class LeaseIdMismatchHintAdapter:
         return {
             "raw": {"id": "raw-bad-hint"},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-bad-hint",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -281,8 +289,8 @@ class LeaseIdMismatchHintAdapter:
         }
 
 
-class InvalidTargetStatusHintAdapter:
-    adapter_key = "stub"
+class InvalidTargetStatusHintAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -292,7 +300,7 @@ class InvalidTargetStatusHintAdapter:
         return {
             "raw": {"id": "raw-bad-status-hint"},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-bad-status-hint",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -324,8 +332,8 @@ class InvalidTargetStatusHintAdapter:
         }
 
 
-class NeverCalledAdapter:
-    adapter_key = "stub"
+class NeverCalledAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -334,8 +342,8 @@ class NeverCalledAdapter:
         raise AssertionError("adapter should not be called")
 
 
-class PrePlatformValidationAdapter:
-    adapter_key = "stub"
+class PrePlatformValidationAdapter(StubContentDetailDeclarationMixin):
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -349,8 +357,37 @@ class PrePlatformValidationAdapter:
         )
 
 
+class MissingResourceRequirementAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
+class InvalidResourceRequirementDeclarationAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = (
+        {
+            "adapter_key": TEST_ADAPTER_KEY,
+            "capability": "content_detail",
+            "resource_dependency_mode": "required",
+            "required_capabilities": ("account", "browser_state"),
+            "evidence_refs": ("fr-0015:runtime:content-detail-by-url-hybrid:requested-slots",),
+        },
+    )
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
 class NoneCapabilitiesAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = None
 
     def execute(self, request: TaskRequest):
@@ -358,7 +395,7 @@ class NoneCapabilitiesAdapter:
 
 
 class NonContainerCapabilitiesAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = 123
 
     def execute(self, request: TaskRequest):
@@ -366,7 +403,7 @@ class NonContainerCapabilitiesAdapter:
 
 
 class NonStringCapabilitiesAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = ("content_detail", 1)
 
     def execute(self, request: TaskRequest):
@@ -374,7 +411,7 @@ class NonStringCapabilitiesAdapter:
 
 
 class MissingCapabilitiesAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
 
     def execute(self, request: TaskRequest):
         raise AssertionError("execute should not be called")
@@ -387,7 +424,7 @@ class BrokenCapabilitiesIterable:
 
 
 class BrokenIterableCapabilitiesAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = BrokenCapabilitiesIterable()
 
     def execute(self, request: TaskRequest):
@@ -413,18 +450,18 @@ class DuplicateAdapterRegistry(Mapping[str, object]):
         self._adapter = adapter
 
     def __iter__(self) -> Iterator[str]:
-        return iter(("stub", "stub"))
+        return iter((TEST_ADAPTER_KEY, TEST_ADAPTER_KEY))
 
     def __len__(self) -> int:
         return 2
 
     def __getitem__(self, key: str) -> object:
-        if key != "stub":
+        if key != TEST_ADAPTER_KEY:
             raise KeyError(key)
         return self._adapter
 
     def items(self) -> Iterator[Tuple[str, object]]:
-        return iter((("stub", self._adapter), ("stub", self._adapter)))
+        return iter(((TEST_ADAPTER_KEY, self._adapter), (TEST_ADAPTER_KEY, self._adapter)))
 
 
 class ExplodingRequestMapping(dict):
@@ -433,7 +470,7 @@ class ExplodingRequestMapping(dict):
 
 
 class MissingTargetsAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_collection_modes = frozenset({"hybrid"})
 
@@ -442,7 +479,7 @@ class MissingTargetsAdapter:
 
 
 class UnsupportedHybridCollectionModeAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"authenticated"})
@@ -452,7 +489,7 @@ class UnsupportedHybridCollectionModeAdapter:
 
 
 class BroadAxesAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url", "content_id", "creator_id", "keyword"})
     supported_collection_modes = frozenset({"public", "authenticated", "hybrid"})
@@ -462,7 +499,7 @@ class BroadAxesAdapter:
 
 
 class MissingCollectionModesAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
 
@@ -471,7 +508,7 @@ class MissingCollectionModesAdapter:
 
 
 class MissingExecuteAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -492,19 +529,19 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_builds_success_envelope_from_adapter_payload(self) -> None:
         adapter = SuccessfulAdapter()
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": adapter},
+            adapters={TEST_ADAPTER_KEY: adapter},
             task_id_factory=lambda: "task-001",
         )
 
         self.assertEqual(envelope["task_id"], "task-001")
-        self.assertEqual(envelope["adapter_key"], "stub")
+        self.assertEqual(envelope["adapter_key"], TEST_ADAPTER_KEY)
         self.assertEqual(envelope["capability"], "content_detail_by_url")
         self.assertEqual(envelope["status"], "success")
         self.assertIn("raw", envelope)
@@ -521,7 +558,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         adapter = SuccessfulAdapter()
         request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/posts/2",
@@ -531,13 +568,13 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": adapter},
+            adapters={TEST_ADAPTER_KEY: adapter},
             task_id_factory=lambda: "task-001b",
         )
 
         self.assertEqual(envelope["task_id"], "task-001b")
         self.assertEqual(envelope["status"], "success")
-        self.assertEqual(envelope["adapter_key"], "stub")
+        self.assertEqual(envelope["adapter_key"], TEST_ADAPTER_KEY)
         self.assertEqual(envelope["normalized"]["canonical_url"], request.target.target_value)
         self.assertIsInstance(adapter.last_request, AdapterExecutionContext)
         self.assertEqual(adapter.last_request.request.capability, "content_detail")
@@ -551,13 +588,13 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         legacy_adapter = SuccessfulAdapter()
         native_adapter = SuccessfulAdapter()
         legacy_request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/legacy-native"),
         )
         native_request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/posts/legacy-native",
@@ -567,12 +604,12 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         legacy_envelope = execute_task(
             legacy_request,
-            adapters={"stub": legacy_adapter},
+            adapters={TEST_ADAPTER_KEY: legacy_adapter},
             task_id_factory=lambda: "task-legacy-map",
         )
         native_envelope = execute_task(
             native_request,
-            adapters={"stub": native_adapter},
+            adapters={TEST_ADAPTER_KEY: native_adapter},
             task_id_factory=lambda: "task-native-map",
         )
 
@@ -592,7 +629,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_rejects_unknown_target_type(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="unknown_type",
                 target_value="https://example.com/posts/2",
@@ -602,7 +639,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-invalid-target-type",
         )
 
@@ -613,7 +650,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_rejects_unknown_collection_mode(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/posts/2",
@@ -623,7 +660,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-invalid-collection-mode",
         )
 
@@ -634,7 +671,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_rejects_non_url_target_at_shared_projection_guard(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="content_id",
                 target_value="abc123",
@@ -644,7 +681,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": BroadAxesAdapter()},
+            adapters={TEST_ADAPTER_KEY: BroadAxesAdapter()},
             task_id_factory=lambda: "task-non-url-target",
         )
 
@@ -655,7 +692,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_rejects_public_collection_mode_at_shared_projection_guard(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/posts/2",
@@ -665,7 +702,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": BroadAxesAdapter()},
+            adapters={TEST_ADAPTER_KEY: BroadAxesAdapter()},
             task_id_factory=lambda: "task-public-mode",
         )
 
@@ -676,7 +713,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_rejects_authenticated_collection_mode_at_shared_projection_guard(self) -> None:
         request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/posts/2",
@@ -686,7 +723,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": BroadAxesAdapter()},
+            adapters={TEST_ADAPTER_KEY: BroadAxesAdapter()},
             task_id_factory=lambda: "task-authenticated-mode",
         )
 
@@ -714,14 +751,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_legacy_request_when_adapter_lacks_supported_targets(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": MissingTargetsAdapter()},
+            adapters={TEST_ADAPTER_KEY: MissingTargetsAdapter()},
             task_id_factory=lambda: "task-missing-targets",
         )
 
@@ -731,14 +768,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_legacy_request_when_adapter_does_not_declare_hybrid_mode(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": UnsupportedHybridCollectionModeAdapter()},
+            adapters={TEST_ADAPTER_KEY: UnsupportedHybridCollectionModeAdapter()},
             task_id_factory=lambda: "task-unsupported-hybrid",
         )
 
@@ -748,14 +785,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_missing_supported_collection_modes(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": MissingCollectionModesAdapter()},
+            adapters={TEST_ADAPTER_KEY: MissingCollectionModesAdapter()},
             task_id_factory=lambda: "task-missing-collection-modes",
         )
 
@@ -765,13 +802,13 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_legacy_and_native_requests_with_same_hybrid_admission_error(self) -> None:
         legacy_request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/no-hybrid"),
         )
         native_request = CoreTaskRequest(
             target=InputTarget(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/posts/no-hybrid",
@@ -781,12 +818,12 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         legacy_envelope = execute_task(
             legacy_request,
-            adapters={"stub": UnsupportedHybridCollectionModeAdapter()},
+            adapters={TEST_ADAPTER_KEY: UnsupportedHybridCollectionModeAdapter()},
             task_id_factory=lambda: "task-legacy-no-hybrid",
         )
         native_envelope = execute_task(
             native_request,
-            adapters={"stub": UnsupportedHybridCollectionModeAdapter()},
+            adapters={TEST_ADAPTER_KEY: UnsupportedHybridCollectionModeAdapter()},
             task_id_factory=lambda: "task-native-no-hybrid",
         )
 
@@ -798,16 +835,76 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(native_envelope["error"]["code"], "collection_mode_not_supported")
         self.assertEqual(legacy_envelope["error"]["details"], native_envelope["error"]["details"])
 
+    def test_execute_task_fails_closed_when_adapter_lacks_resource_requirement_declaration(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/missing-resource-requirement"),
+            ),
+            adapters={TEST_ADAPTER_KEY: MissingResourceRequirementAdapter()},
+            task_id_factory=lambda: "task-missing-resource-requirement",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_requirement")
+
+    def test_execute_task_maps_registry_resource_requirement_validation_failure_to_invalid_resource_requirement(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/bad-resource-requirement"),
+            ),
+            adapters={TEST_ADAPTER_KEY: InvalidResourceRequirementDeclarationAdapter()},
+            task_id_factory=lambda: "task-bad-resource-requirement",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_requirement")
+        self.assertEqual(
+            envelope["error"]["details"]["registry_error_code"],
+            "invalid_adapter_resource_requirements",
+        )
+
+    def test_execute_task_returns_resource_unavailable_when_runtime_capability_projection_is_unmatched(self) -> None:
+        with mock.patch.dict(
+            runtime_module.RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE,
+            {(runtime_module.CONTENT_DETAIL_BY_URL, runtime_module.LEGACY_COLLECTION_MODE): ("account",)},
+            clear=True,
+        ), mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=AssertionError("acquire should not run when matcher is unmatched"),
+        ):
+            outcome = execute_task_with_record(
+                TaskRequest(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/posts/unmatched-runtime-capabilities"),
+                ),
+                adapters={TEST_ADAPTER_KEY: NeverCalledAdapter()},
+                task_id_factory=lambda: "task-unmatched-runtime-capabilities",
+            )
+
+        self.assertEqual(outcome.envelope["status"], "failed")
+        self.assertEqual(outcome.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(outcome.envelope["error"]["code"], "resource_unavailable")
+        self.assertIsNotNone(outcome.task_record)
+        self.assertEqual(outcome.task_record.status, "failed")
+        self.assertEqual(outcome.task_record.result.envelope["error"]["code"], "resource_unavailable")
+
     def test_execute_task_rejects_unsupported_capability(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="search",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-unsupported",
         )
 
@@ -817,14 +914,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_success_without_raw_payload(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": MissingRawAdapter()},
+            adapters={TEST_ADAPTER_KEY: MissingRawAdapter()},
             task_id_factory=lambda: "task-003",
         )
 
@@ -834,14 +931,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_when_adapter_returns_none(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": NonePayloadAdapter()},
+            adapters={TEST_ADAPTER_KEY: NonePayloadAdapter()},
             task_id_factory=lambda: "task-004",
         )
 
@@ -851,14 +948,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_when_adapter_returns_non_mapping_payload(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": ListPayloadAdapter()},
+            adapters={TEST_ADAPTER_KEY: ListPayloadAdapter()},
             task_id_factory=lambda: "task-005",
         )
 
@@ -868,14 +965,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_when_adapter_raises_generic_exception(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": CrashingAdapter()},
+            adapters={TEST_ADAPTER_KEY: CrashingAdapter()},
             task_id_factory=lambda: "task-006",
         )
 
@@ -885,14 +982,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_handles_platform_error_with_non_mapping_details(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": PlatformErrorWithBadDetailsAdapter()},
+            adapters={TEST_ADAPTER_KEY: PlatformErrorWithBadDetailsAdapter()},
             task_id_factory=lambda: "task-007",
         )
 
@@ -903,14 +1000,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_wraps_platform_error(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": PlatformFailureAdapter()},
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
             task_id_factory=lambda: "task-platform-failure",
         )
 
@@ -921,7 +1018,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_releases_bundle_when_host_side_validation_fails_after_acquire(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/host-validation"),
         )
@@ -937,7 +1034,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         ):
             envelope = execute_task(
                 request,
-                adapters={"stub": NeverCalledAdapter()},
+                adapters={TEST_ADAPTER_KEY: NeverCalledAdapter()},
                 task_id_factory=lambda: "task-host-validation",
             )
 
@@ -955,7 +1052,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_bundle_with_mismatched_lease_id_before_adapter_and_settles_real_lease(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/host-validation-lease-id"),
         )
@@ -971,7 +1068,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         ):
             envelope = execute_task(
                 request,
-                adapters={"stub": NeverCalledAdapter()},
+                adapters={TEST_ADAPTER_KEY: NeverCalledAdapter()},
                 task_id_factory=lambda: "task-host-validation-lease-id",
             )
 
@@ -985,7 +1082,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_bundle_with_tampered_material_and_acquired_at_before_adapter(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/host-validation-material"),
         )
@@ -1009,7 +1106,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         ):
             envelope = execute_task(
                 request,
-                adapters={"stub": NeverCalledAdapter()},
+                adapters={TEST_ADAPTER_KEY: NeverCalledAdapter()},
                 task_id_factory=lambda: "task-host-validation-material",
             )
 
@@ -1034,7 +1131,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
                         resource_id="account-derived-001",
                         resource_type="account",
                         status="AVAILABLE",
-                        material=managed_account_material(generic_account_material(), adapter_key="stub"),
+                        material=managed_account_material(generic_account_material(), adapter_key=TEST_ADAPTER_KEY),
                     ),
                     ResourceRecord(
                         resource_id="proxy-derived-001",
@@ -1054,11 +1151,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
                     ):
                         envelope = execute_task(
                             TaskRequest(
-                                adapter_key="stub",
+                                adapter_key=TEST_ADAPTER_KEY,
                                 capability="content_detail_by_url",
                                 input=TaskInput(url="https://example.com/posts/derived-trace-store"),
                             ),
-                            adapters={"stub": SuccessfulAdapter()},
+                            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                             task_id_factory=lambda: "task-derived-trace-store",
                             resource_lifecycle_store=lifecycle_store,
                         )
@@ -1080,11 +1177,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_settles_success_without_hint_as_available(self) -> None:
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/posts/no-hint-success"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-no-hint-success",
         )
 
@@ -1101,11 +1198,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_settles_failure_without_hint_as_available(self) -> None:
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/posts/no-hint-failure"),
             ),
-            adapters={"stub": PlatformFailureAdapter()},
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
             task_id_factory=lambda: "task-no-hint-failure",
         )
 
@@ -1121,11 +1218,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_applies_invalidating_hint_without_leaking_internal_field(self) -> None:
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/posts/invalidating-hint"),
             ),
-            adapters={"stub": InvalidatingHintAdapter()},
+            adapters={TEST_ADAPTER_KEY: InvalidatingHintAdapter()},
             task_id_factory=lambda: "task-invalidating-hint",
         )
 
@@ -1141,11 +1238,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_rejects_mismatched_hint_lease_id_and_still_settles_bundle(self) -> None:
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/posts/hint-mismatch"),
             ),
-            adapters={"stub": LeaseIdMismatchHintAdapter()},
+            adapters={TEST_ADAPTER_KEY: LeaseIdMismatchHintAdapter()},
             task_id_factory=lambda: "task-hint-mismatch",
         )
 
@@ -1160,11 +1257,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_rejects_invalid_hint_target_status_and_still_settles_bundle(self) -> None:
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/posts/hint-bad-status"),
             ),
-            adapters={"stub": InvalidTargetStatusHintAdapter()},
+            adapters={TEST_ADAPTER_KEY: InvalidTargetStatusHintAdapter()},
             task_id_factory=lambda: "task-hint-bad-status",
         )
 
@@ -1181,7 +1278,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             "syvert.resource_lifecycle.release",
             return_value={
                 "task_id": "task-release-overrides-success",
-                "adapter_key": "stub",
+                "adapter_key": TEST_ADAPTER_KEY,
                 "capability": "content_detail_by_url",
                 "status": "failed",
                 "error": {
@@ -1194,11 +1291,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         ):
             envelope = execute_task(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/posts/release-success"),
                 ),
-                adapters={"stub": SuccessfulAdapter()},
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                 task_id_factory=lambda: "task-release-overrides-success",
             )
 
@@ -1210,7 +1307,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             "syvert.resource_lifecycle.release",
             return_value={
                 "task_id": "task-release-overrides-failure",
-                "adapter_key": "stub",
+                "adapter_key": TEST_ADAPTER_KEY,
                 "capability": "content_detail_by_url",
                 "status": "failed",
                 "error": {
@@ -1223,11 +1320,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         ):
             envelope = execute_task(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/posts/release-failure"),
                 ),
-                adapters={"stub": PlatformFailureAdapter()},
+                adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
                 task_id_factory=lambda: "task-release-overrides-failure",
             )
 
@@ -1272,14 +1369,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_maps_explicit_pre_platform_adapter_error_to_invalid_input(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": PrePlatformValidationAdapter()},
+            adapters={TEST_ADAPTER_KEY: PrePlatformValidationAdapter()},
             task_id_factory=lambda: "task-preplatform-invalid-input",
         )
 
@@ -1289,14 +1386,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_empty_task_id_from_factory(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "",
         )
 
@@ -1308,14 +1405,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_non_string_task_id_from_factory(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: 123,  # type: ignore[return-value]
         )
 
@@ -1327,14 +1424,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_when_task_id_factory_raises(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
         )
 
@@ -1346,7 +1443,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_extended_task_input_shape(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=ExtendedTaskInput(
                 url="https://example.com/posts/1",
@@ -1356,7 +1453,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-extra-shape",
         )
 
@@ -1366,7 +1463,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_rejects_extended_task_request_shape(self) -> None:
         request = ExtendedTaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
             extra="leaks",
@@ -1374,7 +1471,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-extra-request-shape",
         )
 
@@ -1385,11 +1482,11 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_fails_closed_for_malformed_request_mapping(self) -> None:
         envelope = execute_task(
             {
-                "adapter_key": "stub",
+                "adapter_key": TEST_ADAPTER_KEY,
                 "capability": "content_detail_by_url",
                 "input": {"url": "https://example.com/posts/1"},
             },  # type: ignore[arg-type]
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-malformed-request",
         )
 
@@ -1401,7 +1498,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_fails_closed_for_request_mapping_that_raises_on_get(self) -> None:
         envelope = execute_task(
             ExplodingRequestMapping(),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-exploding-request",
         )
 
@@ -1412,14 +1509,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_none_supported_capabilities(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": NoneCapabilitiesAdapter()},
+            adapters={TEST_ADAPTER_KEY: NoneCapabilitiesAdapter()},
             task_id_factory=lambda: "task-none-caps",
         )
 
@@ -1429,14 +1526,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_missing_supported_capabilities(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": MissingCapabilitiesAdapter()},
+            adapters={TEST_ADAPTER_KEY: MissingCapabilitiesAdapter()},
             task_id_factory=lambda: "task-missing-caps",
         )
 
@@ -1446,7 +1543,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_adapter_registry_that_raises_on_items(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
@@ -1463,7 +1560,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_duplicate_adapter_registry_keys(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
@@ -1481,14 +1578,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_non_container_supported_capabilities(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": NonContainerCapabilitiesAdapter()},
+            adapters={TEST_ADAPTER_KEY: NonContainerCapabilitiesAdapter()},
             task_id_factory=lambda: "task-non-container-caps",
         )
 
@@ -1498,14 +1595,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_non_string_supported_capability(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": NonStringCapabilitiesAdapter()},
+            adapters={TEST_ADAPTER_KEY: NonStringCapabilitiesAdapter()},
             task_id_factory=lambda: "task-non-string-caps",
         )
 
@@ -1515,14 +1612,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_broken_supported_capabilities_iterable(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": BrokenIterableCapabilitiesAdapter()},
+            adapters={TEST_ADAPTER_KEY: BrokenIterableCapabilitiesAdapter()},
             task_id_factory=lambda: "task-broken-caps",
         )
 
@@ -1532,14 +1629,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_execute_task_fails_closed_for_missing_execute_contract(self) -> None:
         request = TaskRequest(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             input=TaskInput(url="https://example.com/posts/1"),
         )
 
         envelope = execute_task(
             request,
-            adapters={"stub": MissingExecuteAdapter()},
+            adapters={TEST_ADAPTER_KEY: MissingExecuteAdapter()},
             task_id_factory=lambda: "task-missing-execute",
         )
 

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -387,6 +387,25 @@ class InvalidResourceRequirementDeclarationAdapter:
         raise AssertionError("execute should not be called")
 
 
+class InvalidSiblingResourceRequirementDeclarationAdapter:
+    adapter_key = "douyin"
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = (
+        {
+            "adapter_key": "douyin",
+            "capability": "content_detail",
+            "resource_dependency_mode": "required",
+            "required_capabilities": ("account", "browser_state"),
+            "evidence_refs": ("fr-0015:runtime:content-detail-by-url-hybrid:requested-slots",),
+        },
+    )
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
 class NoneModeResourceRequirementDeclarationAdapter:
     adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
@@ -891,6 +910,25 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             envelope["error"]["details"]["registry_error_code"],
             "invalid_adapter_resource_requirements",
         )
+
+    def test_execute_task_does_not_misclassify_sibling_declaration_failure_as_requested_invalid_resource_requirement(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/valid-request-invalid-sibling"),
+            ),
+            adapters={
+                TEST_ADAPTER_KEY: SuccessfulAdapter(),
+                "douyin": InvalidSiblingResourceRequirementDeclarationAdapter(),
+            },
+            task_id_factory=lambda: "task-valid-request-invalid-sibling",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_adapter_resource_requirements")
+        self.assertNotIn("registry_error_code", envelope["error"]["details"])
 
     def test_execute_task_keeps_none_mode_declarations_unreachable_until_registry_baseline_exists(self) -> None:
         with mock.patch(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -406,6 +406,40 @@ class InvalidSiblingResourceRequirementDeclarationAdapter:
         raise AssertionError("execute should not be called")
 
 
+class NoneResourceRequirementCollectionAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = None
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
+class ExtraFieldResourceRequirementDeclarationAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = (
+        {
+            "adapter_key": TEST_ADAPTER_KEY,
+            "capability": "content_detail",
+            "resource_dependency_mode": "required",
+            "required_capabilities": ("account", "proxy"),
+            "evidence_refs": baseline_required_resource_requirement_declaration(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail",
+            ).evidence_refs,
+            "unexpected_field": "shadow",
+        },
+    )
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
 class NoneModeResourceRequirementDeclarationAdapter:
     adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
@@ -929,6 +963,44 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["error"]["category"], "runtime_contract")
         self.assertEqual(envelope["error"]["code"], "invalid_adapter_resource_requirements")
         self.assertNotIn("registry_error_code", envelope["error"]["details"])
+
+    def test_execute_task_maps_none_resource_requirement_collection_to_invalid_resource_requirement(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/none-resource-requirement-collection"),
+            ),
+            adapters={TEST_ADAPTER_KEY: NoneResourceRequirementCollectionAdapter()},
+            task_id_factory=lambda: "task-none-resource-requirement-collection",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_requirement")
+        self.assertEqual(
+            envelope["error"]["details"]["registry_error_code"],
+            "invalid_adapter_resource_requirements",
+        )
+
+    def test_execute_task_maps_extra_field_resource_requirement_declaration_to_invalid_resource_requirement(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/extra-field-resource-requirement"),
+            ),
+            adapters={TEST_ADAPTER_KEY: ExtraFieldResourceRequirementDeclarationAdapter()},
+            task_id_factory=lambda: "task-extra-field-resource-requirement",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_requirement")
+        self.assertEqual(
+            envelope["error"]["details"]["registry_error_code"],
+            "invalid_adapter_resource_requirements",
+        )
 
     def test_execute_task_keeps_none_mode_declarations_unreachable_until_registry_baseline_exists(self) -> None:
         with mock.patch(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -12,6 +12,7 @@ from unittest import mock
 import syvert.runtime as runtime_module
 from syvert.adapters.douyin import DouyinAdapter
 from syvert.adapters.xhs import XhsAdapter
+from syvert.registry import baseline_required_resource_requirement_declaration
 from syvert.resource_lifecycle import ResourceRecord
 from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 from syvert.resource_lifecycle_store import default_resource_lifecycle_store
@@ -379,6 +380,28 @@ class InvalidResourceRequirementDeclarationAdapter:
             "resource_dependency_mode": "required",
             "required_capabilities": ("account", "browser_state"),
             "evidence_refs": ("fr-0015:runtime:content-detail-by-url-hybrid:requested-slots",),
+        },
+    )
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
+class NoneModeResourceRequirementDeclarationAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = (
+        {
+            "adapter_key": TEST_ADAPTER_KEY,
+            "capability": "content_detail",
+            "resource_dependency_mode": "none",
+            "required_capabilities": (),
+            "evidence_refs": baseline_required_resource_requirement_declaration(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail",
+            ).evidence_refs,
         },
     )
 
@@ -860,6 +883,29 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             adapters={TEST_ADAPTER_KEY: InvalidResourceRequirementDeclarationAdapter()},
             task_id_factory=lambda: "task-bad-resource-requirement",
         )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(envelope["error"]["code"], "invalid_resource_requirement")
+        self.assertEqual(
+            envelope["error"]["details"]["registry_error_code"],
+            "invalid_adapter_resource_requirements",
+        )
+
+    def test_execute_task_keeps_none_mode_declarations_unreachable_until_registry_baseline_exists(self) -> None:
+        with mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=AssertionError("acquire should not run for none-mode runtime declarations"),
+        ):
+            envelope = execute_task(
+                TaskRequest(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/posts/none-mode-runtime-path"),
+                ),
+                adapters={TEST_ADAPTER_KEY: NoneModeResourceRequirementDeclarationAdapter()},
+                task_id_factory=lambda: "task-none-mode-runtime-path",
+            )
 
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "runtime_contract")

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+import syvert.runtime as runtime_module
 from syvert.runtime import TaskInput, TaskRequest, execute_task, execute_task_with_record
 from syvert.task_record import (
     TaskRecordContractError,
@@ -15,7 +16,9 @@ from syvert.task_record import (
     task_record_from_dict,
     task_record_to_dict,
 )
-from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin, baseline_resource_requirement_declarations
+
+TEST_ADAPTER_KEY = "xhs"
 
 
 class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
@@ -36,16 +39,17 @@ class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
 
 
 class SuccessfulAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request):
         return {
             "raw": {"id": "raw-1"},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-1",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -73,10 +77,11 @@ class SuccessfulAdapter:
 
 
 class PlatformFailureAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request):
         from syvert.runtime import PlatformAdapterError
@@ -89,7 +94,7 @@ class PlatformFailureAdapter:
 
 
 class UnsupportedCapabilityAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"creator_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
@@ -99,16 +104,17 @@ class UnsupportedCapabilityAdapter:
 
 
 class UnserializableSuccessAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request):
         return {
             "raw": {"id": "raw-bad", "bad": object()},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-bad",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -136,16 +142,17 @@ class UnserializableSuccessAdapter:
 
 
 class OffsetTimestampSuccessAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request):
         return {
             "raw": {"id": "raw-offset-1"},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-offset-1",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -176,11 +183,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_round_trips_success_record(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/1"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-1",
         )
 
@@ -196,11 +203,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_missing_required_lifecycle_event(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/2"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-2",
         )
         payload = task_record_to_dict(outcome.task_record)
@@ -211,7 +218,7 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
     def test_accepts_idempotent_terminal_rewrite_and_rejects_conflicting_terminal(self) -> None:
         snapshot = TaskRequestSnapshot(
-            adapter_key="stub",
+            adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
             target_type="url",
             target_value="https://example.com/post/3",
@@ -221,7 +228,7 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         running = start_task_record(accepted, occurred_at="2026-04-17T10:30:01Z")
         envelope = {
             "task_id": "task-record-3",
-            "adapter_key": "stub",
+            "adapter_key": TEST_ADAPTER_KEY,
             "capability": "content_detail_by_url",
             "status": "failed",
             "error": {
@@ -244,11 +251,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_invalid_scalar_types_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/3b"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-3b",
         )
         payload = task_record_to_dict(outcome.task_record)
@@ -260,11 +267,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_terminal_envelope_mismatch_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/3c"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-3c",
         )
         payload = task_record_to_dict(outcome.task_record)
@@ -276,11 +283,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_success_envelope_nested_type_drift_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/3cc"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-3cc",
         )
         payload = task_record_to_dict(outcome.task_record)
@@ -294,11 +301,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_failed_envelope_without_details_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/3cf"),
             ),
-            adapters={"stub": PlatformFailureAdapter()},
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
             task_id_factory=lambda: "task-record-3cf",
         )
         payload = task_record_to_dict(outcome.task_record)
@@ -310,11 +317,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_failed_envelope_with_invalid_category_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/3cg"),
             ),
-            adapters={"stub": PlatformFailureAdapter()},
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
             task_id_factory=lambda: "task-record-3cg",
         )
         payload = task_record_to_dict(outcome.task_record)
@@ -326,11 +333,11 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_untrusted_timeline_during_round_trip_load(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/3d"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-3d",
         )
         payload = task_record_to_dict(outcome.task_record)
@@ -344,7 +351,7 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             create_task_record(
                 "task-record-3e",
                 TaskRequestSnapshot(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     target_type="unsupported",
                     target_value="https://example.com/post/3e",
@@ -357,11 +364,11 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_with_record_keeps_preaccepted_failure_outside_durable_history(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/4"),
             ),
-            adapters={"stub": UnsupportedCapabilityAdapter()},
+            adapters={TEST_ADAPTER_KEY: UnsupportedCapabilityAdapter()},
             task_id_factory=lambda: "task-record-4",
         )
 
@@ -372,11 +379,11 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_with_record_builds_failed_record_for_business_failure(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/5"),
             ),
-            adapters={"stub": PlatformFailureAdapter()},
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
             task_id_factory=lambda: "task-record-5",
         )
 
@@ -385,14 +392,39 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(outcome.task_record.status, "failed")
         self.assertEqual(outcome.task_record.result.envelope["error"]["code"], "platform_broken")
 
+    def test_execute_task_with_record_builds_failed_record_for_unmatched_resource_capabilities(self) -> None:
+        with mock.patch.dict(
+            runtime_module.RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE,
+            {(runtime_module.CONTENT_DETAIL_BY_URL, runtime_module.LEGACY_COLLECTION_MODE): ("account",)},
+            clear=True,
+        ), mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=AssertionError("acquire should not run when matcher is unmatched"),
+        ):
+            outcome = execute_task_with_record(
+                TaskRequest(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/post/5b"),
+                ),
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                task_id_factory=lambda: "task-record-5b",
+            )
+
+        self.assertEqual(outcome.envelope["status"], "failed")
+        self.assertEqual(outcome.envelope["error"]["code"], "resource_unavailable")
+        self.assertIsNotNone(outcome.task_record)
+        self.assertEqual(outcome.task_record.status, "failed")
+        self.assertEqual(outcome.task_record.result.envelope["error"]["code"], "resource_unavailable")
+
     def test_execute_task_envelope_contract_stays_unchanged(self) -> None:
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/6"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-6",
         )
 
@@ -404,20 +436,20 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_preserves_stateless_replay_for_fixed_task_id(self) -> None:
         first = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/6b"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-6b",
         )
         second = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/6b"),
             ),
-            adapters={"stub": SuccessfulAdapter()},
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
             task_id_factory=lambda: "task-record-6b",
         )
 
@@ -427,11 +459,11 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_with_record_fails_closed_when_terminal_envelope_is_not_json_serializable(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/7"),
             ),
-            adapters={"stub": UnserializableSuccessAdapter()},
+            adapters={TEST_ADAPTER_KEY: UnserializableSuccessAdapter()},
             task_id_factory=lambda: "task-record-7",
         )
 
@@ -442,11 +474,11 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_preserves_public_envelope_when_task_record_fails_to_close(self) -> None:
         envelope = execute_task(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/8"),
             ),
-            adapters={"stub": UnserializableSuccessAdapter()},
+            adapters={TEST_ADAPTER_KEY: UnserializableSuccessAdapter()},
             task_id_factory=lambda: "task-record-8",
         )
 
@@ -458,11 +490,11 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_execute_task_with_record_accepts_offset_utc_timestamp_in_success_payload(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/9"),
             ),
-            adapters={"stub": OffsetTimestampSuccessAdapter()},
+            adapters={TEST_ADAPTER_KEY: OffsetTimestampSuccessAdapter()},
             task_id_factory=lambda: "task-record-9",
         )
 

--- a/tests/runtime/test_task_record_store.py
+++ b/tests/runtime/test_task_record_store.py
@@ -15,14 +15,17 @@ from syvert.task_record import (
     start_task_record,
 )
 from syvert.task_record_store import LocalTaskRecordStore, TaskRecordStoreError
-from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin, baseline_resource_requirement_declarations
+
+TEST_ADAPTER_KEY = "xhs"
 
 
 class SuccessfulAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def __init__(self) -> None:
         self.calls = 0
@@ -32,7 +35,7 @@ class SuccessfulAdapter:
         return {
             "raw": {"id": "raw-store-1"},
             "normalized": {
-                "platform": "stub",
+                "platform": TEST_ADAPTER_KEY,
                 "content_id": "content-store-1",
                 "content_type": "unknown",
                 "canonical_url": request.input.url,
@@ -73,10 +76,11 @@ class RunningVisibleAdapter(SuccessfulAdapter):
 
 
 class PlatformFailureAdapter:
-    adapter_key = "stub"
+    adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"content_detail"})
     supported_targets = frozenset({"url"})
     supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
 
     def execute(self, request):
         from syvert.runtime import PlatformAdapterError
@@ -139,11 +143,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             store = LocalTaskRecordStore(Path(temp_dir))
             outcome = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-1"),
                 ),
-                adapters={"stub": SuccessfulAdapter()},
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                 task_id_factory=lambda: "task-store-1",
                 task_record_store=store,
             )
@@ -157,11 +161,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             store = LocalTaskRecordStore(Path(temp_dir))
             outcome = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-2"),
                 ),
-                adapters={"stub": PlatformFailureAdapter()},
+                adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
                 task_id_factory=lambda: "task-store-2",
                 task_record_store=store,
             )
@@ -176,11 +180,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             with mock.patch.dict(os.environ, {"SYVERT_TASK_RECORD_STORE_DIR": temp_dir}, clear=False):
                 outcome = execute_task_with_record(
                     TaskRequest(
-                        adapter_key="stub",
+                        adapter_key=TEST_ADAPTER_KEY,
                         capability="content_detail_by_url",
                         input=TaskInput(url="https://example.com/post/store-default"),
                     ),
-                    adapters={"stub": SuccessfulAdapter()},
+                    adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                     task_id_factory=lambda: "task-store-default",
                 )
 
@@ -193,20 +197,20 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             with mock.patch.dict(os.environ, {"SYVERT_TASK_RECORD_STORE_DIR": temp_dir}, clear=False):
                 first = execute_task(
                     TaskRequest(
-                        adapter_key="stub",
+                        adapter_key=TEST_ADAPTER_KEY,
                         capability="content_detail_by_url",
                         input=TaskInput(url="https://example.com/post/store-stateless"),
                     ),
-                    adapters={"stub": SuccessfulAdapter()},
+                    adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                     task_id_factory=lambda: "task-store-stateless",
                 )
                 second = execute_task(
                     TaskRequest(
-                        adapter_key="stub",
+                        adapter_key=TEST_ADAPTER_KEY,
                         capability="content_detail_by_url",
                         input=TaskInput(url="https://example.com/post/store-stateless"),
                     ),
-                    adapters={"stub": SuccessfulAdapter()},
+                    adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                     task_id_factory=lambda: "task-store-stateless",
                 )
 
@@ -219,11 +223,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         adapter = SuccessfulAdapter()
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/store-3"),
             ),
-            adapters={"stub": adapter},
+            adapters={TEST_ADAPTER_KEY: adapter},
             task_id_factory=lambda: "task-store-3",
             task_record_store=SelectiveFailingStore("accepted"),
         )
@@ -239,11 +243,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         adapter = SuccessfulAdapter()
         outcome = execute_task_with_record(
             TaskRequest(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 input=TaskInput(url="https://example.com/post/store-3b"),
             ),
-            adapters={"stub": adapter},
+            adapters={TEST_ADAPTER_KEY: adapter},
             task_id_factory=lambda: "task-store-3b",
             task_record_store=SelectiveFailingStore("running"),
         )
@@ -260,22 +264,22 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             store = LocalTaskRecordStore(Path(temp_dir))
             first = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-conflict"),
                 ),
-                adapters={"stub": SuccessfulAdapter()},
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                 task_id_factory=lambda: "task-store-conflict",
                 task_record_store=store,
             )
 
             second = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-conflict"),
                 ),
-                adapters={"stub": SuccessfulAdapter()},
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
                 task_id_factory=lambda: "task-store-conflict",
                 task_record_store=store,
             )
@@ -293,11 +297,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
 
             outcome = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-running-visible"),
                 ),
-                adapters={"stub": adapter},
+                adapters={TEST_ADAPTER_KEY: adapter},
                 task_id_factory=lambda: task_id,
                 task_record_store=store,
             )
@@ -312,11 +316,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             store = TerminalFailingLocalStore(Path(temp_dir))
             outcome = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-4"),
                 ),
-                adapters={"stub": adapter},
+                adapters={TEST_ADAPTER_KEY: adapter},
                 task_id_factory=lambda: "task-store-4",
                 task_record_store=store,
             )
@@ -335,11 +339,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             store = BrokenInvalidationLocalStore(Path(temp_dir))
             outcome = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-4b"),
                 ),
-                adapters={"stub": adapter},
+                adapters={TEST_ADAPTER_KEY: adapter},
                 task_id_factory=lambda: "task-store-4b",
                 task_record_store=store,
             )
@@ -350,7 +354,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             with self.assertRaises((TaskRecordStoreError, FileNotFoundError)):
                 store.load("task-store-4b")
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-4b",
@@ -366,11 +370,11 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             store = BrokenInvalidationAndMoveLocalStore(Path(temp_dir))
             outcome = execute_task_with_record(
                 TaskRequest(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     input=TaskInput(url="https://example.com/post/store-4c"),
                 ),
-                adapters={"stub": adapter},
+                adapters={TEST_ADAPTER_KEY: adapter},
                 task_id_factory=lambda: "task-store-4c",
                 task_record_store=store,
             )
@@ -380,7 +384,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             with self.assertRaises(TaskRecordStoreError):
                 store.load("task-store-4c")
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-4c",
@@ -394,7 +398,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-5b",
@@ -412,7 +416,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-5",
@@ -427,7 +431,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-accepted-idempotent",
@@ -455,7 +459,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             accepted = create_task_record(
                 "task-store-accepted-conflict",
                 TaskRequestSnapshot(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     target_type="url",
                     target_value="https://example.com/post/store-accepted-conflict",
@@ -466,7 +470,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             conflicting = create_task_record(
                 "task-store-accepted-conflict",
                 TaskRequestSnapshot(
-                    adapter_key="stub",
+                    adapter_key=TEST_ADAPTER_KEY,
                     capability="content_detail_by_url",
                     target_type="url",
                     target_value="https://example.com/post/store-accepted-conflict-changed",
@@ -484,7 +488,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-running-idempotent",
@@ -507,7 +511,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-6",
@@ -517,7 +521,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             running = start_task_record(accepted, occurred_at="2026-04-17T12:00:01Z")
             envelope = {
                 "task_id": "task-store-6",
-                "adapter_key": "stub",
+                "adapter_key": TEST_ADAPTER_KEY,
                 "capability": "content_detail_by_url",
                 "status": "failed",
                 "error": {
@@ -544,7 +548,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))
             snapshot = TaskRequestSnapshot(
-                adapter_key="stub",
+                adapter_key=TEST_ADAPTER_KEY,
                 capability="content_detail_by_url",
                 target_type="url",
                 target_value="https://example.com/post/store-7",
@@ -554,12 +558,12 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             running = start_task_record(accepted, occurred_at="2026-04-17T12:00:01Z")
             envelope = {
                 "task_id": "task-store-7",
-                "adapter_key": "stub",
+                "adapter_key": TEST_ADAPTER_KEY,
                 "capability": "content_detail_by_url",
                 "status": "success",
                 "raw": {"id": "raw-store-7"},
                 "normalized": {
-                    "platform": "stub",
+                    "platform": TEST_ADAPTER_KEY,
                     "content_id": "content-store-7",
                     "content_type": "unknown",
                     "canonical_url": "https://example.com/post/store-7",

--- a/tests/runtime/test_xhs_adapter.py
+++ b/tests/runtime/test_xhs_adapter.py
@@ -32,6 +32,7 @@ from syvert.adapters.xhs import (
 )
 from tests.runtime.resource_fixtures import (
     ResourceStoreEnvMixin,
+    baseline_resource_requirement_declarations,
     build_managed_resource_bundle,
     seed_default_runtime_resources,
     xhs_account_material,
@@ -1655,6 +1656,7 @@ class XhsAdapterTests(ResourceStoreEnvMixin, unittest.TestCase):
             supported_capabilities = frozenset({"content_detail"})
             supported_targets = frozenset({"url"})
             supported_collection_modes = frozenset({"hybrid"})
+            resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key="xhs")
 
             def execute(self, request: TaskRequest) -> dict[str, Any]:
                 return {


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：让 Core 在进入 acquire 前基于 `#195` 已冻结的 adapter 资源需求声明执行纯粹的资源能力匹配，并把无效声明/输入与能力不满足稳定收口到 `invalid_resource_requirement` / `resource_unavailable`。
- 主要改动：
  - 在 `syvert/runtime.py` 新增 matcher carrier、输入校验、runtime slot projection 与 `match_resource_capabilities(...)`，并在 `execute_task_internal()` 中把 matcher 接到 acquire 前。
  - matcher 对 `required` 声明直接复用 `AdapterRegistry.from_mapping(...)` 的 canonical materialization；对 `none` 声明保留 FR-0014 formal spec 要求的 pure matcher `matched` 语义，同时仍要求 `required_capabilities=[]` 且 `evidence_refs` 只能来自对应 adapter/capability 的 `FR-0015` 批准共享证据。
  - 把 registry 侧资源声明物化错误统一映射为 `invalid_resource_requirement`；合法但不满足声明的情况在进入 adapter 前返回 `resource_unavailable`，同时为 `execute_task_with_record` 产出 failed record。
  - 为 runtime-reaching stub / harness / CLI 测试夹具补齐与 `#195` 一致的 canonical declaration 基线，新增 matcher 单测并补强 evidence 对齐断言。
  - 当前 runtime entrypoint 仍受 `#195` registry baseline 约束：production `resource_requirement_declarations` 若声明 `none` 且尚无 frozen baseline，`execute_task` 继续 fail-closed 为 `invalid_resource_requirement`；本 PR 不回改 `#195` 去打通 production none declaration 路径。

## Issue 摘要

- 实现 `FR-0014` 的 Core 资源能力匹配 contract，只做 declaration demand 与 runtime 当前能力集合之间的 `matched / unmatched` 判断。
- 直接消费 `lookup_resource_requirement(adapter_key, capability_family)` 与 `approved_resource_capability_ids()`，不重新发明 carrier、能力命名或证据词汇。
- 保持当前 `RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE` 作为 acquire requested_slots truth；本回合只增加 declaration-vs-runtime gate，不改写 acquire contract。

## 关联事项

- Issue: #196
- item_key: `CHORE-0142-fr-0014-runtime-closeout`
- item_type: `CHORE`
- release: `v0.5.0`
- sprint: `2026-S18`
- Closing: Fixes #196

## 风险

- 风险级别：`normal`
- 审查关注：
  - matcher 只接受 `content_detail` family 与 `account|proxy` approved capability ids，不能放宽到未批准词汇或 provider/fallback 语义。
  - runtime 现在会对缺声明、坏声明、坏 slot projection fail-closed；需要确认错误口径与 durable task record 语义没有回归。
  - `resource_dependency_mode=none` 目前存在 pure matcher formal semantics 与 production registry baseline 的边界：matcher helper 必须保持 `matched`，runtime entrypoint 仍需对未冻结 declaration fail-closed，不能把两层混淆成 provider/fallback 语义。
  - contract harness / CLI / runtime fixtures 已从无效 `stub` baseline 迁移到 `xhs` canonical declaration truth，需确认没有遗漏正向执行路径。

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_registry tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_executor tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression tests.runtime.test_contract_harness_host tests.runtime.test_contract_harness_automation tests.runtime.test_contract_harness_validation_tool`
  - `python3 -m unittest tests.runtime.test_registry tests.runtime.test_resource_capability_matcher tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_task_record_store tests.runtime.test_cli tests.runtime.test_resource_capability_evidence tests.runtime.test_xhs_adapter tests.runtime.test_douyin_adapter tests.runtime.test_real_adapter_regression`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/governance_gate.py --mode ci --base-sha "$(git merge-base origin/main HEAD)" --head-sha "$(git rev-parse HEAD)" --head-ref issue-196-fr-0014-core`
- 结果摘要：
  - 全量目标回归：`Ran 288 tests in 5.837s`，`OK`
  - 关键 matcher/runtime 回归：`Ran 250 tests in 6.493s`，`OK`
  - docs/workflow/pr_scope/governance guards：全部通过
- 未执行：
  - guardian 审查
  - 受控 `merge_pr`

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
