### PR TITLE
docs(release): 建立 v0.5.0 发布收口 carrier

### DIFF
--- a/docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md
+++ b/docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md
@@ -1,0 +1,43 @@
+# ADR-GOV-0036 Close out v0.5.0 phase and publish anchors in a single governed round
+
+## 关联信息
+
+- Issue：`#215`
+- item_key：`GOV-0036-v0-5-0-phase-and-release-closeout`
+- item_type：`GOV`
+- release：`v0.5.0`
+- sprint：`2026-S18`
+
+## 背景
+
+`v0.5.0` 的 formal spec、runtime implementation、evidence baseline rerun 与顶层定位治理已经全部合入主干：
+
+- `FR-0015` formal spec / follow-up / rerun implementation 已由 PR `#198/#208/#212` 合入主干
+- `FR-0013` formal spec / runtime 已由 PR `#200/#213` 合入主干
+- `FR-0014` formal spec / runtime 已由 PR `#199/#214` 合入主干
+- `GOV-0035` 已由 PR `#207` 合入主干
+
+但当前仓内与 GitHub 仍停留在“版本功能已经完成、正式发布锚点与 closeout 状态尚未统一”的中间态：
+
+- 仓库尚无 `docs/releases/v0.5.0.md` 与 `docs/sprints/2026-S18.md`
+- 仓库尚无 `v0.5.0` tag
+- GitHub 尚无 Release `v0.5.0`
+- GitHub Phase `#188` 与 FR `#189/#190/#191` 仍为 `OPEN`
+- 当前尚无专门承接 `v0.5.0` phase / release 收口的合法治理 Work Item
+
+如果把这些动作拆散处理，会再次制造“主干功能真相已完成，但 release/sprint 索引、发布锚点与 GitHub 状态仍滞后”的分叉。
+
+## 决策
+
+- 使用单一治理 Work Item `#215 / GOV-0036-v0-5-0-phase-and-release-closeout` 承接 `v0.5.0` 的最后一段 phase / release 收口。
+- 本事项采用两个串行阶段，但仍保持同一个 Work Item：
+  - 阶段 A：通过受控 docs PR 建立仓内 carrier，包括 release / sprint 索引、本事项 decision 与 active exec-plan。
+  - 阶段 B：在阶段 A PR 合入主干后，立即创建 `v0.5.0` tag 与 GitHub Release，并以第二个 metadata-only/docs PR 回写 published truth、同步 active exec-plan，并完成 `#188/#189/#190/#191/#215` 的 GitHub closeout。
+- 当前 PR 只允许修改 release / sprint 索引与本事项 decision / exec-plan，不重新打开 `FR-0013`、`FR-0014`、`FR-0015` 或任何 runtime / formal spec 语义。
+- 发布锚点必须后置于阶段 A PR 合入后的主干提交，避免 tag 或 GitHub Release 指向非主干事实。
+
+## 影响
+
+- `v0.5.0` 将沿同一 Work Item 从“功能与 FR closeout 已完成”推进到“仓内 carrier 完成”，再推进到“tag、GitHub Release、Phase / FR 与仓内最终真相全部一致”的正式发布态。
+- 发布动作不会反向污染 `FR-0013` / `FR-0014` / `FR-0015` 的 requirement 或 implementation truth。
+- `docs/releases/v0.5.0.md` 与 `docs/sprints/2026-S18.md` 会先进入受控索引，再在发布锚点建立后切换为完成态索引。

--- a/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
@@ -1,0 +1,111 @@
+# GOV-0036-v0.5.0-phase-and-release-closeout 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0036-v0-5-0-phase-and-release-closeout`
+- Issue：`#215`
+- item_type：`GOV`
+- release：`v0.5.0`
+- sprint：`2026-S18`
+- 关联 spec：无（发布/治理收口事项）
+- 关联 decision：`docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
+- 关联 PR：待创建
+- 状态：`active`
+- active 收口事项：`GOV-0036-v0-5-0-phase-and-release-closeout`
+
+## 目标
+
+- 在不引入新 runtime、formal spec 或测试语义的前提下，通过合法 Work Item `#215` 完成 `v0.5.0` 的 phase / release 发布收口。
+- 把 `docs/releases/v0.5.0.md`、`docs/sprints/2026-S18.md`、Git tag、GitHub Release 与 GitHub issue 真相收口到同一条版本 closeout 证据链。
+
+## 范围
+
+- 本次纳入：
+  - `docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md`
+  - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
+  - `docs/releases/v0.5.0.md`
+  - `docs/sprints/2026-S18.md`
+  - GitHub `#188/#189/#190/#191/#215` 的 issue 正文、关闭语义与最终评论对齐
+  - git tag `v0.5.0`
+  - GitHub Release `v0.5.0`
+- 本次不纳入：
+  - 任何新的 runtime / adapter / test 实现
+  - `FR-0013` / `FR-0014` / `FR-0015` formal spec 语义改写
+  - `v0.6.0` 规划或跨版本治理重构
+
+## 当前停点
+
+- `origin/main@f05556581cbba094c702c659e0ac994903fbd87d` 已包含 `v0.5.0` 所需的全部 formal spec、runtime、evidence rerun 与顶层定位治理：PR `#198/#199/#200/#207/#208/#212/#213/#214`。
+- `#192/#193/#194/#195/#196/#205/#206/#211` 均已关闭，`v0.5.0` 的 formal spec、implementation 与 evidence 基线已经完成。
+- `#188/#189/#190/#191` 仍为 `OPEN`，仓库尚无 `docs/releases/v0.5.0.md`、`docs/sprints/2026-S18.md`、`v0.5.0` tag 与 GitHub Release `v0.5.0`。
+- `#215` 已建立为承接 `v0.5.0` phase / release closeout 的合法治理 Work Item。
+- 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-215-v0-5-0`，当前分支为 `issue-215-v0-5-0`。
+- 当前回合先进入阶段 A：建立 release / sprint / decision / exec-plan carrier，不提前宣称正式发布完成真相。
+
+## 下一步动作
+
+- 在当前分支建立 `v0.5.0` 的 release / sprint / decision / exec-plan carrier。
+- 通过受控 docs PR 合入阶段 A closeout carrier。
+- 阶段 A 合入后在主干建立 `v0.5.0` tag 与 GitHub Release。
+- 继续同一 Work Item 的阶段 B metadata-only/docs PR，回写正式发布完成真相。
+- 完成 `#188/#189/#190/#191/#215` 的 GitHub closeout 对账与关闭。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.5.0` 建立正式发布前的仓内 closeout carrier，使后续 tag / GitHub Release 与 GitHub closeout 有单一落点可以对齐。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`v0.5.0` 的 phase / release 发布 closeout Work Item。
+- 阻塞：
+  - 阶段 A 不能误写成已发布完成态；当前主干还没有 `v0.5.0` tag / GitHub Release。
+  - 阶段 B 必须基于阶段 A 已合入的主干提交建立发布锚点，不能让 tag 指向非主干事实。
+
+## 已验证项
+
+- `GH_TOKEN=\"$GH_TOKEN\" gh issue view 188 --json state`
+  - 结果：`#188` 为 `OPEN`
+- `GH_TOKEN=\"$GH_TOKEN\" gh issue view 189 --json state`
+  - 结果：`#189` 为 `OPEN`
+- `GH_TOKEN=\"$GH_TOKEN\" gh issue view 190 --json state`
+  - 结果：`#190` 为 `OPEN`
+- `GH_TOKEN=\"$GH_TOKEN\" gh issue view 191 --json state`
+  - 结果：`#191` 为 `OPEN`
+- `GH_TOKEN=\"$GH_TOKEN\" gh release view v0.5.0`
+  - 结果：当前不存在 `v0.5.0` GitHub Release
+- `git tag --list 'v0.5.0'`
+  - 结果：当前未找到 `v0.5.0`
+
+## closeout 证据
+
+- 功能完成证据：
+  - `FR-0015` formal spec / follow-up / implementation 已由 PR `#198/#208/#212` 合入主干
+  - `FR-0013` formal spec / runtime 已由 PR `#200/#213` 合入主干
+  - `FR-0014` formal spec / runtime 已由 PR `#199/#214` 合入主干
+  - `GOV-0035` 顶层定位治理已由 PR `#207` 合入主干
+- 当前发布前基线：
+  - `origin/main@f05556581cbba094c702c659e0ac994903fbd87d`
+
+## 剩余 closeout 动作
+
+- 合入阶段 A docs carrier PR
+- 建立 `v0.5.0` tag 与 GitHub Release
+- 合入阶段 B metadata-only/docs PR
+- 回写并关闭 `#188/#189/#190/#191/#215`
+
+## 未决风险
+
+- 若阶段 A 合入后没有立即建立 tag / GitHub Release，仓内 release/sprint 索引仍会滞后于正式发布态。
+- 若只建立 tag 而不回写 published truth 与 GitHub issue closeout metadata，`v0.5.0` 会再次出现“发布锚点已存在，但仓内/issue 真相仍停在前一跳”的分叉。
+
+## 回滚方式
+
+- 仓内回滚：如需回滚，使用独立 revert PR 撤销本事项对 release / sprint 索引、decision 与 exec-plan 的增量修改。
+- 仓外回滚：
+  - 若阶段 A PR 未合入，恢复 `#215` 正文并停止发布动作
+  - 若 tag / GitHub Release 已建立但主干事实有误，先修正主干与 GitHub truth，再按独立治理回合决定是否删除 / 重建发布锚点
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `f05556581cbba094c702c659e0ac994903fbd87d`
+- 说明：该 checkpoint 对应 `v0.5.0` 的 formal spec、implementation、evidence 与治理前置都已合入主干，但尚未建立正式发布锚点。

--- a/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
@@ -25,13 +25,12 @@
   - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
   - `docs/releases/v0.5.0.md`
   - `docs/sprints/2026-S18.md`
-  - GitHub `#188/#189/#190/#191/#215` 的 issue 正文、关闭语义与最终评论对齐
-  - git tag `v0.5.0`
-  - GitHub Release `v0.5.0`
 - 本次不纳入：
   - 任何新的 runtime / adapter / test 实现
   - `FR-0013` / `FR-0014` / `FR-0015` formal spec 语义改写
   - `v0.6.0` 规划或跨版本治理重构
+  - 阶段 B 的 tag / GitHub Release 建立
+  - GitHub `#188/#189/#190/#191/#215` 的最终 closeout 对账与关闭
 
 ## 当前停点
 

--- a/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S18`
 - 关联 spec：无（发布/治理收口事项）
 - 关联 decision：`docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
-- 关联 PR：待创建
+- 关联 PR：`#216`
 - 状态：`active`
 - active 收口事项：`GOV-0036-v0-5-0-phase-and-release-closeout`
 

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,78 @@
+# Release v0.5.0
+
+## 目标
+
+- 在真实参考适配器压力下收敛资源能力抽象，使 Core 能以最小共享语义表达 adapter 资源需求、能力匹配与证据基线。
+
+## 明确不在范围
+
+- 不引入 provider 选择、排序、偏好或 fallback 语义
+- 不把 Playwright、CDP、Chromium 等技术实现名称带入共享 contract
+- 不扩张 `account`、`proxy` 之外的共享资源能力词汇
+- 不提前进入 `v0.6.0` 的运维性、HTTP API 或 richer execution control 范围
+
+## 目标判据
+
+- `FR-0013` formal spec 与 runtime 已冻结并落地 adapter 资源需求声明 carrier、lookup surface 与 fail-closed 校验
+- `FR-0014` formal spec 与 runtime 已冻结并落地 Core 资源能力匹配 surface、`matched/unmatched` 结论与错误口径边界
+- `FR-0015` formal spec、evidence registry traceability 与 machine-readable baseline 已冻结并落地，且 `FR-0013/FR-0014` 只消费同一份批准词汇与 evidence refs
+- 双参考适配器当前共享能力词汇仍只允许 `account`、`proxy`
+- GitHub Phase / FR、release / sprint 索引、tag 与 GitHub Release 保持一致
+
+## 纳入事项
+
+- `FR-0013-adapter-resource-requirement-declaration`：`v0.5.0` adapter 资源需求声明 contract，对应 Issue `#189`
+- `CHORE-0138-fr-0013-formal-spec-closeout`：`FR-0013` formal spec 收口 Work Item，对应 Issue `#192`
+- `CHORE-0141-fr-0013-runtime-closeout`：`FR-0013` runtime implementation，对应 Issue `#195`
+- `FR-0014-core-resource-capability-matching`：`v0.5.0` Core 资源能力匹配 contract，对应 Issue `#190`
+- `CHORE-0139-fr-0014-formal-spec-closeout`：`FR-0014` formal spec 收口 Work Item，对应 Issue `#193`
+- `CHORE-0142-fr-0014-runtime-closeout`：`FR-0014` Core matcher implementation，对应 Issue `#196`
+- `FR-0015-dual-reference-resource-capability-evidence`：`v0.5.0` 双参考适配器资源能力证据 contract，对应 Issue `#191`
+- `CHORE-0140-fr-0015-formal-spec-closeout`：`FR-0015` formal spec 收口 Work Item，对应 Issue `#194`
+- `CHORE-0144-fr-0015-evidence-registry-reconciliation`：`FR-0015` formal evidence registry traceability follow-up，对应 Issue `#206`
+- `CHORE-0146-fr-0015-evidence-closeout-rerun`：`FR-0015` machine-readable evidence baseline rerun，对应 Issue `#211`
+- `GOV-0035-top-level-positioning-alignment`：收敛仓库顶层定位叙事，对应 Issue `#205`
+- `GOV-0036-v0-5-0-phase-and-release-closeout`：`v0.5.0` phase 与发布收口，对应 Issue `#215`
+
+## 相关前提
+
+- `#188` 已作为 `v0.5.0` 阶段事项建立并冻结资源能力抽象收敛目标
+- `v0.4.0` 已正式发布，并冻结最小资源生命周期、任务级资源追踪与 Core 注入资源包三条上游 contract
+
+## 关联工件
+
+- roadmap：`docs/roadmap-v0-to-v1.md`
+- sprint：
+  - `docs/sprints/2026-S18.md`
+- spec：
+  - `docs/specs/FR-0013-adapter-resource-requirement-declaration/`
+  - `docs/specs/FR-0014-core-resource-capability-matching/`
+  - `docs/specs/FR-0015-dual-reference-resource-capability-evidence/`
+- exec-plan：
+  - `docs/exec-plans/FR-0013-adapter-resource-requirement-declaration.md`
+  - `docs/exec-plans/CHORE-0138-fr-0013-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0141-fr-0013-runtime-closeout.md`
+  - `docs/exec-plans/FR-0014-core-resource-capability-matching.md`
+  - `docs/exec-plans/CHORE-0139-fr-0014-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md`
+  - `docs/exec-plans/FR-0015-dual-reference-resource-capability-evidence.md`
+  - `docs/exec-plans/CHORE-0140-fr-0015-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0144-fr-0015-evidence-registry-reconciliation.md`
+  - `docs/exec-plans/CHORE-0146-fr-0015-evidence-closeout-rerun.md`
+  - `docs/exec-plans/GOV-0035-top-level-positioning-alignment.md`
+  - `docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md`
+- decision：
+  - `docs/decisions/ADR-GOV-0035-top-level-positioning-alignment.md`
+  - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
+
+## 当前 closeout 基线真相
+
+- `FR-0015` formal spec 已由 PR `#198` 合入主干。
+- `FR-0014` formal spec 已由 PR `#199` 合入主干。
+- `FR-0013` formal spec 已由 PR `#200` 合入主干。
+- `GOV-0035` 顶层定位治理已由 PR `#207` 合入主干。
+- `FR-0015` formal evidence registry traceability follow-up 已由 PR `#208` 合入主干。
+- `FR-0015` 的历史 implementation PR `#204` 已由 hotfix PR `#210` 回退；当前正式有效的 machine-readable evidence baseline 已由 rerun PR `#212` 合入主干。
+- `FR-0013` runtime implementation 已由 PR `#213` 合入主干。
+- `FR-0014` runtime implementation 已由 PR `#214` 合入主干，merge commit `f05556581cbba094c702c659e0ac994903fbd87d` 是当前 `v0.5.0` 发布前主干基线。
+- 当前主干已经满足 `v0.5.0` 的 formal spec、implementation 与 evidence baseline 收口目标，但仓库尚无 `docs/releases/v0.5.0.md`、`docs/sprints/2026-S18.md`、`v0.5.0` tag、GitHub Release `v0.5.0`，且 GitHub Phase `#188` 与 FR `#189/#190/#191` 仍待最终 closeout。

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -75,4 +75,4 @@
 - `FR-0015` 的历史 implementation PR `#204` 已由 hotfix PR `#210` 回退；当前正式有效的 machine-readable evidence baseline 已由 rerun PR `#212` 合入主干。
 - `FR-0013` runtime implementation 已由 PR `#213` 合入主干。
 - `FR-0014` runtime implementation 已由 PR `#214` 合入主干，merge commit `f05556581cbba094c702c659e0ac994903fbd87d` 是当前 `v0.5.0` 发布前主干基线。
-- 当前主干已经满足 `v0.5.0` 的 formal spec、implementation 与 evidence baseline 收口目标，但仓库尚无 `docs/releases/v0.5.0.md`、`docs/sprints/2026-S18.md`、`v0.5.0` tag、GitHub Release `v0.5.0`，且 GitHub Phase `#188` 与 FR `#189/#190/#191` 仍待最终 closeout。
+- 当前主干已经满足 `v0.5.0` 的 formal spec、implementation 与 evidence baseline 收口目标；在阶段 A 合入前的主干基线中，尚无 `docs/releases/v0.5.0.md`、`docs/sprints/2026-S18.md`、`v0.5.0` tag 与 GitHub Release `v0.5.0`，且 GitHub Phase `#188` 与 FR `#189/#190/#191` 仍待最终 closeout。

--- a/docs/sprints/2026-S18.md
+++ b/docs/sprints/2026-S18.md
@@ -1,0 +1,71 @@
+# Sprint 2026-S18
+
+## release
+
+- `v0.5.0`
+
+## 本轮目标
+
+- 为 `v0.5.0` 收口资源能力抽象：冻结 adapter 资源需求声明、Core 资源能力匹配与双参考证据基线，并完成 phase / release 发布闭环。
+
+## 入口事项
+
+- `FR-0013-adapter-resource-requirement-declaration`：`v0.5.0` adapter 资源需求声明，对应 Issue `#189`
+- `CHORE-0138-fr-0013-formal-spec-closeout`：`FR-0013` formal spec 收口 Work Item，对应 Issue `#192`
+- `CHORE-0141-fr-0013-runtime-closeout`：`FR-0013` runtime implementation，对应 Issue `#195`
+- `FR-0014-core-resource-capability-matching`：`v0.5.0` Core 资源能力匹配，对应 Issue `#190`
+- `CHORE-0139-fr-0014-formal-spec-closeout`：`FR-0014` formal spec 收口 Work Item，对应 Issue `#193`
+- `CHORE-0142-fr-0014-runtime-closeout`：`FR-0014` runtime implementation，对应 Issue `#196`
+- `FR-0015-dual-reference-resource-capability-evidence`：`v0.5.0` 双参考资源能力证据，对应 Issue `#191`
+- `CHORE-0140-fr-0015-formal-spec-closeout`：`FR-0015` formal spec 收口 Work Item，对应 Issue `#194`
+- `CHORE-0144-fr-0015-evidence-registry-reconciliation`：`FR-0015` formal evidence registry 追溯入口，对应 Issue `#206`
+- `CHORE-0146-fr-0015-evidence-closeout-rerun`：`FR-0015` machine-readable evidence baseline rerun，对应 Issue `#211`
+- `GOV-0035-top-level-positioning-alignment`：收敛仓库顶层定位文档，对应 Issue `#205`
+- `GOV-0036-v0-5-0-phase-and-release-closeout`：`v0.5.0` phase 与发布收口，对应 Issue `#215`
+
+## 进入前依赖
+
+- `#188/#189/#190/#191` 的 GitHub 事项树已建立
+- `docs/roadmap-v0-to-v1.md` 已定义 `v0.5.0` 的目标、约束与成功标准
+- `v0.4.0` 已正式发布，且最小资源系统 contract 已在主干冻结
+
+## 目标判据
+
+- `FR-0013` formal spec 与 runtime 已按同一份共享能力词汇和 evidence baseline 收口
+- `FR-0014` formal spec 与 runtime 已按同一份 declaration carrier 和 approved capability vocabulary 收口
+- `FR-0015` formal spec、traceability follow-up 与 machine-readable evidence baseline 已完成收口
+- `v0.5.0` 的 phase / release closeout 已把 release/sprint 索引、tag、GitHub Release 与 GitHub issue 状态收成一致
+
+## 协作入口
+
+- GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口
+- 相关 Issue / PR：`#188`、`#189`、`#190`、`#191`、`#192`、`#193`、`#194`、`#195`、`#196`、`#205`、`#206`、`#211`、`#215`、`#198`、`#199`、`#200`、`#207`、`#208`、`#210`、`#212`、`#213`、`#214`
+
+## 关联工件
+
+- release：`docs/releases/v0.5.0.md`
+- spec：
+  - `docs/specs/FR-0013-adapter-resource-requirement-declaration/`
+  - `docs/specs/FR-0014-core-resource-capability-matching/`
+  - `docs/specs/FR-0015-dual-reference-resource-capability-evidence/`
+- exec-plan：
+  - `docs/exec-plans/FR-0013-adapter-resource-requirement-declaration.md`
+  - `docs/exec-plans/CHORE-0138-fr-0013-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0141-fr-0013-runtime-closeout.md`
+  - `docs/exec-plans/FR-0014-core-resource-capability-matching.md`
+  - `docs/exec-plans/CHORE-0139-fr-0014-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0142-fr-0014-runtime-closeout.md`
+  - `docs/exec-plans/FR-0015-dual-reference-resource-capability-evidence.md`
+  - `docs/exec-plans/CHORE-0140-fr-0015-formal-spec-closeout.md`
+  - `docs/exec-plans/CHORE-0144-fr-0015-evidence-registry-reconciliation.md`
+  - `docs/exec-plans/CHORE-0146-fr-0015-evidence-closeout-rerun.md`
+  - `docs/exec-plans/GOV-0035-top-level-positioning-alignment.md`
+  - `docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md`
+- decision：
+  - `docs/decisions/ADR-GOV-0035-top-level-positioning-alignment.md`
+  - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
+
+## 当前 closeout 基线真相
+
+- `FR-0013`、`FR-0014`、`FR-0015` 的 formal spec、runtime 与 evidence baseline 已在当前 sprint 合入主干。
+- `2026-S18` 的功能性交付目标已经完成；当前仅剩 `GOV-0036` 负责把 release / sprint 索引、发布锚点与 GitHub closeout 收口到正式发布态。


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：为 `v0.5.0` 建立 phase / release closeout 的仓内 carrier，使后续 tag、GitHub Release 与 GitHub closeout 有单一落点可以对齐。
- 主要改动：
  - 新增 `docs/releases/v0.5.0.md` 与 `docs/sprints/2026-S18.md`，把 `v0.5.0` 的目标、范围、成功判据、事项索引与当前发布前基线沉淀到仓内索引层。
  - 新增 `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`，明确 `v0.5.0` 采用两阶段发布收口：阶段 A 建立 carrier，阶段 B 在主干上建立 tag / GitHub Release 后回写 published truth。
  - 新增 `docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md`，绑定当前 worktree / branch / checkpoint、closeout 证据、阶段边界与后续动作。
  - 当前 PR 只建立发布前 carrier，不宣称 `v0.5.0` 已正式发布；tag、GitHub Release 以及 `#188/#189/#190/#191` 的关闭动作留在阶段 B。

## Issue 摘要

- 使用单一治理 Work Item `#215` 承接 `v0.5.0` 的最后一段 phase / release 收口。
- 在 `#198/#199/#200/#207/#208/#212/#213/#214` 已合入主干的基础上，先让 release/sprint/decision/exec-plan 进入受控状态，再建立发布锚点并回写 published truth。
- 避免再次出现“主干功能真相已完成，但 release/sprint 索引、tag、GitHub Release 与 GitHub issue 状态仍滞后”的分叉。

## 关联事项

- Issue: #215
- item_key: `GOV-0036-v0-5-0-phase-and-release-closeout`
- item_type: `GOV`
- release: `v0.5.0`
- sprint: `2026-S18`
- Closing: Fixes #215

## 风险

- 风险级别：`lightweight`
- 审查关注：
  - 阶段 A 只能建立 carrier，不能把当前 PR 表述成已经建立 `v0.5.0` tag / GitHub Release 的最终发布态。
  - `docs/releases/v0.5.0.md` 与 `docs/sprints/2026-S18.md` 需要如实反映“formal spec、implementation 与 evidence 已完成，但发布锚点和 GitHub closeout 仍待阶段 B”的边界。
  - 决策与 exec-plan 必须明确两阶段模型，避免后续 tag 指向非主干 carrier 或 published-truth 回写缺少合法入口。

## 验证

- 已执行：
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/governance_gate.py --mode ci --base-sha "$(git merge-base origin/main HEAD)" --head-sha "$(git rev-parse HEAD)" --head-ref issue-215-v0-5-0`
  - `GH_TOKEN="$GH_TOKEN" python3 scripts/open_pr.py --class docs --issue 215 --item-key GOV-0036-v0-5-0-phase-and-release-closeout --item-type GOV --release v0.5.0 --sprint 2026-S18 --title 'docs(release): 建立 v0.5.0 发布收口 carrier' --base main --closing fixes --dry-run`
- 未执行：
  - guardian 审查
  - 受控 merge
  - `v0.5.0` tag / GitHub Release 创建

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
