### PR TITLE
docs(release): 同步 v0.5.0 发布完成真相

### DIFF
--- a/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
@@ -140,5 +140,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `caef0abc3071d554e599fbae473b3348868a2bf0`
-- 说明：该 checkpoint 对应阶段 A release carrier 已合入主干，且 `v0.5.0` tag / GitHub Release 已建立；当前阶段 B 仅回写仓内最终发布真相与 GitHub closeout metadata。
+- `f05556581cbba094c702c659e0ac994903fbd87d`
+- 说明：最近一次真实 checkpoint 对应 `FR-0014` runtime implementation 已合入主干、`v0.5.0` 已具备 formal spec / implementation / evidence baseline 的发布前主干基线。阶段 A carrier 合入、`v0.5.0` tag / GitHub Release 建立，以及当前阶段 B metadata-only 回写都属于该 checkpoint 之后的发布收口动作，不单独改写 checkpoint head 真相。

--- a/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S18`
 - 关联 spec：无（发布/治理收口事项）
 - 关联 decision：`docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
-- 关联 PR：`#216`
+- 关联 PR：`#216`、阶段 B published-truth follow-up（当前分支待创建）
 - 状态：`active`
 - active 收口事项：`GOV-0036-v0-5-0-phase-and-release-closeout`
 
@@ -36,31 +36,33 @@
 
 - `origin/main@f05556581cbba094c702c659e0ac994903fbd87d` 已包含 `v0.5.0` 所需的全部 formal spec、runtime、evidence rerun 与顶层定位治理：PR `#198/#199/#200/#207/#208/#212/#213/#214`。
 - `#192/#193/#194/#195/#196/#205/#206/#211` 均已关闭，`v0.5.0` 的 formal spec、implementation 与 evidence 基线已经完成。
-- `#188/#189/#190/#191` 仍为 `OPEN`，仓库尚无 `docs/releases/v0.5.0.md`、`docs/sprints/2026-S18.md`、`v0.5.0` tag 与 GitHub Release `v0.5.0`。
+- 阶段 A docs carrier 已由 PR `#216` 合入主干，merge commit 为 `caef0abc3071d554e599fbae473b3348868a2bf0`。
+- `v0.5.0` tag 与 GitHub Release `v0.5.0` 已建立。
+- `#188/#189/#190/#191` 仍为 `OPEN`，当前仅剩 GitHub closeout 对账与关闭动作。
 - `#215` 已建立为承接 `v0.5.0` phase / release closeout 的合法治理 Work Item。
-- 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-215-v0-5-0`，当前分支为 `issue-215-v0-5-0`。
-- 当前回合先进入阶段 A：建立 release / sprint / decision / exec-plan carrier，不提前宣称正式发布完成真相。
+- 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-215-v0-5-0`，当前分支为 `issue-215-v0-5-0-phase-b`。
+- 当前执行现场已进入阶段 B published-truth follow-up：phase A carrier 已合入主干，`v0.5.0` tag 与 GitHub Release 已建立，当前分支只负责把仓内索引与 active exec-plan 回写到正式发布完成真相。
 
 ## 下一步动作
 
-- 在当前分支建立 `v0.5.0` 的 release / sprint / decision / exec-plan carrier。
-- 通过受控 docs PR 合入阶段 A closeout carrier。
-- 阶段 A 合入后在主干建立 `v0.5.0` tag 与 GitHub Release。
-- 继续同一 Work Item 的阶段 B metadata-only/docs PR，回写正式发布完成真相。
+- 在当前分支把 release / sprint 索引与 active exec-plan 同步到正式发布完成真相。
+- 通过受控 docs PR 合入阶段 B metadata-only/docs follow-up。
 - 完成 `#188/#189/#190/#191/#215` 的 GitHub closeout 对账与关闭。
 
 ## 当前 checkpoint 推进的 release 目标
 
-- 为 `v0.5.0` 建立正式发布前的仓内 closeout carrier，使后续 tag / GitHub Release 与 GitHub closeout 有单一落点可以对齐。
+- 为 `v0.5.0` 完成“从功能收口到正式发布”的最后一段链路，使 release/sprint 索引、发布锚点与 GitHub closeout 进入一致完成态。
 
 ## 当前事项在 sprint 中的角色 / 阻塞
 
 - 角色：`v0.5.0` 的 phase / release 发布 closeout Work Item。
 - 阻塞：
-  - 阶段 A 不能误写成已发布完成态；当前主干还没有 `v0.5.0` tag / GitHub Release。
-  - 阶段 B 必须基于阶段 A 已合入的主干提交建立发布锚点，不能让 tag 指向非主干事实。
+- 阶段 B 需要把 `#216/caef0ab...` 与最终 published truth 严格区分，不能误写成仓内最终发布真相已经由阶段 A 单独完成。
+- active `exec-plan` 需要把阶段 A 的历史基线与阶段 B 当前验证结果按 phase 隔离，避免 review 输入混写。
 
 ## 已验证项
+
+### 阶段 A 基线验证
 
 - `GH_TOKEN=\"$GH_TOKEN\" gh issue view 188 --json state`
   - 结果：`#188` 为 `OPEN`
@@ -74,6 +76,37 @@
   - 结果：当前不存在 `v0.5.0` GitHub Release
 - `git tag --list 'v0.5.0'`
   - 结果：当前未找到 `v0.5.0`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过
+- `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
+  - 结果：通过
+- `python3 scripts/governance_gate.py --mode ci --base-sha \"$(git merge-base origin/main HEAD)\" --head-sha \"$(git rev-parse HEAD)\" --head-ref issue-215-v0-5-0`
+  - 结果：通过
+- `GH_TOKEN=\"$GH_TOKEN\" python3 scripts/open_pr.py --class docs --issue 215 --item-key GOV-0036-v0-5-0-phase-and-release-closeout --item-type GOV --release v0.5.0 --sprint 2026-S18 --title 'docs(release): 建立 v0.5.0 发布收口 carrier' --base main --closing fixes --dry-run`
+  - 结果：通过
+- `GH_TOKEN=\"$GH_TOKEN\" python3 scripts/open_pr.py --class docs --issue 215 --item-key GOV-0036-v0-5-0-phase-and-release-closeout --item-type GOV --release v0.5.0 --sprint 2026-S18 --title 'docs(release): 建立 v0.5.0 发布收口 carrier' --base main --closing fixes`
+  - 结果：已创建 PR `#216`
+- guardian review（绑定 PR `#216` 最新受审 head）
+  - 结果：`APPROVE`
+- `GH_TOKEN=\"$GH_TOKEN\" gh pr view 216 --json state,mergedAt`
+  - 结果：PR `#216` 已 `MERGED`，merge commit 为 `caef0abc3071d554e599fbae473b3348868a2bf0`
+
+### 阶段 B 当前验证
+
+- `git -C /Users/mc/dev/syvert pull --ff-only origin main`
+  - 结果：本地主仓库 `main` 已 fast-forward 到 `caef0abc3071d554e599fbae473b3348868a2bf0`
+- `git -C /Users/mc/dev/syvert tag -a v0.5.0 -m 'v0.5.0' caef0abc3071d554e599fbae473b3348868a2bf0`
+  - 结果：已在阶段 A merge commit 上创建 annotated tag `v0.5.0`
+- `git -C /Users/mc/dev/syvert push origin v0.5.0`
+  - 结果：已推送 tag `v0.5.0`
+- `GH_TOKEN=\"$GH_TOKEN\" gh release create v0.5.0 --repo MC-and-his-Agents/Syvert --title 'v0.5.0' --notes-file /tmp/v0.5.0-release.md`
+  - 结果：已创建 GitHub Release `v0.5.0`
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：当前阶段 B 变更已通过
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：当前阶段 B 变更已通过
 
 ## closeout 证据
 
@@ -84,11 +117,12 @@
   - `GOV-0035` 顶层定位治理已由 PR `#207` 合入主干
 - 当前发布前基线：
   - `origin/main@f05556581cbba094c702c659e0ac994903fbd87d`
+- 发布锚点证据：
+  - `v0.5.0` tag 已创建并推送
+  - GitHub Release `v0.5.0` 已创建
 
 ## 剩余 closeout 动作
 
-- 合入阶段 A docs carrier PR
-- 建立 `v0.5.0` tag 与 GitHub Release
 - 合入阶段 B metadata-only/docs PR
 - 回写并关闭 `#188/#189/#190/#191/#215`
 
@@ -106,5 +140,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `f05556581cbba094c702c659e0ac994903fbd87d`
-- 说明：该 checkpoint 对应 `v0.5.0` 的 formal spec、implementation、evidence 与治理前置都已合入主干，但尚未建立正式发布锚点。
+- `caef0abc3071d554e599fbae473b3348868a2bf0`
+- 说明：该 checkpoint 对应阶段 A release carrier 已合入主干，且 `v0.5.0` tag / GitHub Release 已建立；当前阶段 B 仅回写仓内最终发布真相与 GitHub closeout metadata。

--- a/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S18`
 - 关联 spec：无（发布/治理收口事项）
 - 关联 decision：`docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
-- 关联 PR：`#216`、阶段 B published-truth follow-up（当前分支待创建）
+- 关联 PR：`#216`、`#217`
 - 状态：`active`
 - active 收口事项：`GOV-0036-v0-5-0-phase-and-release-closeout`
 
@@ -40,8 +40,8 @@
 - `v0.5.0` tag 与 GitHub Release `v0.5.0` 已建立。
 - `#188/#189/#190/#191` 仍为 `OPEN`，当前仅剩 GitHub closeout 对账与关闭动作。
 - `#215` 已建立为承接 `v0.5.0` phase / release closeout 的合法治理 Work Item。
-- 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-215-v0-5-0`，当前分支为 `issue-215-v0-5-0-phase-b`。
-- 当前执行现场已进入阶段 B published-truth follow-up：phase A carrier 已合入主干，`v0.5.0` tag 与 GitHub Release 已建立，当前分支只负责把仓内索引与 active exec-plan 回写到正式发布完成真相。
+- 当前执行现场为独立 worktree：`/Users/mc/code/worktrees/syvert/issue-215-v0-5-0`，当前分支为 `issue-215-v0-5-0`。
+- 当前执行现场已进入阶段 B published-truth follow-up：phase A carrier 已合入主干，`v0.5.0` tag 与 GitHub Release 已建立，当前 PR `#217` 只负责把仓内索引与 active exec-plan 回写到 published truth，并为后续 GitHub closeout 对账提供一致基线。
 
 ## 下一步动作
 

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -65,7 +65,7 @@
   - `docs/decisions/ADR-GOV-0035-top-level-positioning-alignment.md`
   - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
 
-## 当前 closeout 基线真相
+## 当前发布完成真相
 
 - `FR-0015` formal spec 已由 PR `#198` 合入主干。
 - `FR-0014` formal spec 已由 PR `#199` 合入主干。
@@ -74,5 +74,8 @@
 - `FR-0015` formal evidence registry traceability follow-up 已由 PR `#208` 合入主干。
 - `FR-0015` 的历史 implementation PR `#204` 已由 hotfix PR `#210` 回退；当前正式有效的 machine-readable evidence baseline 已由 rerun PR `#212` 合入主干。
 - `FR-0013` runtime implementation 已由 PR `#213` 合入主干。
-- `FR-0014` runtime implementation 已由 PR `#214` 合入主干，merge commit `f05556581cbba094c702c659e0ac994903fbd87d` 是当前 `v0.5.0` 发布前主干基线。
-- 当前主干已经满足 `v0.5.0` 的 formal spec、implementation 与 evidence baseline 收口目标；在阶段 A 合入前的主干基线中，尚无 `docs/releases/v0.5.0.md`、`docs/sprints/2026-S18.md`、`v0.5.0` tag 与 GitHub Release `v0.5.0`，且 GitHub Phase `#188` 与 FR `#189/#190/#191` 仍待最终 closeout。
+- `FR-0014` runtime implementation 已由 PR `#214` 合入主干。
+- `v0.5.0` 的阶段 A 发布 carrier 已由 PR `#216` 合入主干，merge commit `caef0abc3071d554e599fbae473b3348868a2bf0` 作为正式发布锚点建立前的仓内基线。
+- `v0.5.0` 已发布为 tag `v0.5.0`，tag 锚点为主干提交 `caef0abc3071d554e599fbae473b3348868a2bf0`。
+- GitHub Release `v0.5.0` 已创建，正式发布锚点已经建立。
+- 仓内 release/sprint 索引已同步到正式发布完成真相；`GOV-0036` 当前仅剩 `#188/#189/#190/#191/#215` 的 GitHub closeout 对账与关闭动作。

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -65,7 +65,7 @@
   - `docs/decisions/ADR-GOV-0035-top-level-positioning-alignment.md`
   - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
 
-## 当前发布完成真相
+## 当前发布与 closeout 状态
 
 - `FR-0015` formal spec 已由 PR `#198` 合入主干。
 - `FR-0014` formal spec 已由 PR `#199` 合入主干。
@@ -78,4 +78,4 @@
 - `v0.5.0` 的阶段 A 发布 carrier 已由 PR `#216` 合入主干，merge commit `caef0abc3071d554e599fbae473b3348868a2bf0` 作为正式发布锚点建立前的仓内基线。
 - `v0.5.0` 已发布为 tag `v0.5.0`，tag 锚点为主干提交 `caef0abc3071d554e599fbae473b3348868a2bf0`。
 - GitHub Release `v0.5.0` 已创建，正式发布锚点已经建立。
-- 仓内 release/sprint 索引已同步到正式发布完成真相；`GOV-0036` 当前仅剩 `#188/#189/#190/#191/#215` 的 GitHub closeout 对账与关闭动作。
+- 当前 release/sprint 索引回写的是 published truth，不等同于 closeout 已完成；`GOV-0036` 仍待 `#188/#189/#190/#191/#215` 的 GitHub 对账与关闭动作完成后才算正式收口。

--- a/docs/sprints/2026-S18.md
+++ b/docs/sprints/2026-S18.md
@@ -65,7 +65,9 @@
   - `docs/decisions/ADR-GOV-0035-top-level-positioning-alignment.md`
   - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
 
-## 当前 closeout 基线真相
+## 当前发布完成真相
 
 - `FR-0013`、`FR-0014`、`FR-0015` 的 formal spec、runtime 与 evidence baseline 已在当前 sprint 合入主干。
-- `2026-S18` 的功能性交付目标已经完成；当前仅剩 `GOV-0036` 负责把 release / sprint 索引、发布锚点与 GitHub closeout 收口到正式发布态。
+- `GOV-0035` 已收口顶层定位叙事，避免 `v0.5.0` 抽象收敛被旧“采集底座”叙事误导。
+- `2026-S18` 的版本交付目标已经完成，`v0.5.0` 已发布为 tag `v0.5.0` 并建立 GitHub Release。
+- 当前 sprint 索引已进入发布完成态；`GOV-0036` 仅剩 GitHub closeout 对账与关闭动作。

--- a/docs/sprints/2026-S18.md
+++ b/docs/sprints/2026-S18.md
@@ -65,9 +65,9 @@
   - `docs/decisions/ADR-GOV-0035-top-level-positioning-alignment.md`
   - `docs/decisions/ADR-GOV-0036-v0-5-0-phase-and-release-closeout.md`
 
-## 当前发布完成真相
+## 当前发布与 closeout 状态
 
 - `FR-0013`、`FR-0014`、`FR-0015` 的 formal spec、runtime 与 evidence baseline 已在当前 sprint 合入主干。
 - `GOV-0035` 已收口顶层定位叙事，避免 `v0.5.0` 抽象收敛被旧“采集底座”叙事误导。
-- `2026-S18` 的版本交付目标已经完成，`v0.5.0` 已发布为 tag `v0.5.0` 并建立 GitHub Release。
-- 当前 sprint 索引已进入发布完成态；`GOV-0036` 仅剩 GitHub closeout 对账与关闭动作。
+- `v0.5.0` 已建立 tag `v0.5.0` 与 GitHub Release，发布锚点已经存在。
+- 当前 sprint 索引已回写 published truth；正式 closeout 仍待 `#188/#189/#190/#191/#215` 完成 GitHub 对账与关闭后才算收口完成。


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：把 `v0.5.0` 的 release / sprint / exec-plan 从阶段 A 发布前基线回写到正式发布完成真相，并为 GitHub closeout 提供最终仓内锚点。
- 主要改动：
  - 更新 `docs/releases/v0.5.0.md`，把 `v0.5.0` 的发布完成真相回写为：阶段 A carrier 已由 PR `#216` 合入、tag `v0.5.0` 已建立、GitHub Release `v0.5.0` 已创建。
  - 更新 `docs/sprints/2026-S18.md`，把 sprint 索引切换到发布完成态，并明确当前仅剩 `#188/#189/#190/#191/#215` 的 GitHub closeout 对账。
  - 更新 `docs/exec-plans/GOV-0036-v0-5-0-phase-and-release-closeout.md`，把当前执行现场切换到阶段 B published-truth follow-up，补齐阶段 A merge、tag / release 建立与阶段 B 当前验证记录。
  - 当前 PR 不再建立新的发布锚点；tag 与 GitHub Release 已经在阶段 A merge commit `caef0abc3071d554e599fbae473b3348868a2bf0` 上建立，本 PR 只回写最终元数据真相。

## Issue 摘要

- `v0.5.0` 的 formal spec、runtime、evidence 与治理前置已经全部合入主干。
- 阶段 A PR `#216` 已建立 release/sprint/decision/exec-plan carrier，并作为正式发布锚点的仓内前置。
- 当前阶段 B 负责把 published truth 回写到仓内索引，并为 `#188/#189/#190/#191/#215` 的 GitHub closeout 提供最终依据。

## 关联事项

- Issue: #215
- item_key: `GOV-0036-v0-5-0-phase-and-release-closeout`
- item_type: `GOV`
- release: `v0.5.0`
- sprint: `2026-S18`
- Closing: Fixes #215

## 风险

- 风险级别：`lightweight`
- 审查关注：
  - 需要严格区分阶段 A 的发布前 carrier 与阶段 B 的 published truth，不能把 `#216` 单独误写成已经完成全部发布收口。
  - active exec-plan 需要同时保留阶段 A 历史基线与阶段 B 当前验证，但两者不能混写成同一时点的当前真相。
  - 当前 PR 只回写仓内元数据，不得重新打开 tag / GitHub Release 建立动作，也不得越界到 runtime / formal spec 语义。

## 验证

- 已执行：
  - `git -C /Users/mc/dev/syvert pull --ff-only origin main`
  - `git -C /Users/mc/dev/syvert tag -a v0.5.0 -m 'v0.5.0' caef0abc3071d554e599fbae473b3348868a2bf0`
  - `git -C /Users/mc/dev/syvert push origin v0.5.0`
  - `GH_TOKEN="$GH_TOKEN" gh release create v0.5.0 --repo MC-and-his-Agents/Syvert --title 'v0.5.0' --notes-file /tmp/v0.5.0-release.md`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/governance_gate.py --mode ci --base-sha "$(git merge-base origin/main HEAD)" --head-sha "$(git rev-parse HEAD)" --head-ref issue-215-v0-5-0`
  - `GH_TOKEN="$GH_TOKEN" python3 scripts/open_pr.py --class docs --issue 215 --item-key GOV-0036-v0-5-0-phase-and-release-closeout --item-type GOV --release v0.5.0 --sprint 2026-S18 --title 'docs(release): 同步 v0.5.0 发布完成真相' --base main --closing fixes --dry-run`
- 未执行：
  - guardian 审查
  - 受控 merge
  - `#188/#189/#190/#191/#215` 的最终 closeout 评论与关闭动作

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。
