### PR TITLE
feat(runtime): 实现 FR-0016 最小执行控制

### DIFF
--- a/docs/exec-plans/CHORE-0148-fr-0016-runtime-timeout-retry-concurrency.md
+++ b/docs/exec-plans/CHORE-0148-fr-0016-runtime-timeout-retry-concurrency.md
@@ -1,0 +1,114 @@
+# CHORE-0148 FR-0016 runtime timeout/retry/concurrency 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0148-fr-0016-runtime-timeout-retry-concurrency`
+- Issue：`#224`
+- item_type：`CHORE`
+- release：`v0.6.0`
+- sprint：`2026-S19`
+- 关联 spec：`docs/specs/FR-0016-minimal-execution-controls/`
+- 关联 PR：`#247`
+- 状态：`active`
+
+## 目标
+
+- 在 `FR-0016` 已冻结边界内实现 Core-owned 最小执行控制 runtime：attempt 级 timeout、固定 retry predicate、process-local fail-fast concurrency slot。
+- 保持 CLI / HTTP / adapter 入口只消费同一 Core path，不在入口层或 adapter 私有层维护第二套控制真相。
+- 所有 attempts 共享同一 `task_id` 与同一条 durable `TaskRecord`；attempt/control 事实通过 JSON-safe `runtime_result_refs` 与 `execution_control_events` 投影。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py` Core attempt orchestration
+  - timeout -> `platform/execution_timeout` 与 `details.control_code=execution_timeout`
+  - retryable predicate：`execution_timeout` 或 `platform + details.retryable=true`，且 capability 为 `content_detail_by_url`
+  - process-local concurrency scopes：`global`、`adapter`、`adapter_capability`
+  - pre-accepted concurrency rejection：`invalid_input/concurrency_limit_exceeded` 且不创建 `TaskRecord`
+  - post-accepted retry reacquire rejection：保留上一 attempt 终态 error，仅追加 `ExecutionControlEvent`
+  - `tests/runtime/test_execution_control.py`
+- 本次不纳入：
+  - 分布式调度、队列、取消/暂停/恢复、复杂 retry DSL
+  - HTTP endpoint shape 变更
+  - `FR-0017/#227` observability carrier runtime
+  - `FR-0019/#234` operability gate runner
+
+## 当前停点
+
+- 已通过 `python3 scripts/create_worktree.py --issue 224 --class implementation` 创建 worktree：`/Users/mc/code/worktrees/syvert/issue-224-fr-0016`。
+- 已确认主干基线为 `65657a49536eb7ad83ea1cf666d0a43f233f67fa`，包含 `#230/#231` 的 HTTP / CLI same-path evidence。
+- 已在 Core path 中加入最小 attempt orchestration，保留现有 `TaskRecord` 生命周期：accepted -> running -> 单次 terminal finish。
+- 已新增执行控制回归测试，覆盖 timeout、retry、非 retry、adapter-owned `execution_timeout` 不冒充 Core timeout、pre/post accepted concurrency rejection、accepted persistence 与 resource preparation 不计入 `max_in_flight`、slot release underflow fail-closed、hung adapter timeout fail-closed、hung closeout failure 资源 `INVALID` quarantine 与 slot 延迟释放、timeout grace late disposition hint consumption、malformed late hint fail-closed、timeout closeout quarantine、retry control details 回写、`ExecutionAttemptOutcome.control_code` shape、`ended_at` 晚于资源 release 的可复核时间顺序、FR-0016 carrier 字段与三类 scope。
+
+## FR-0016 concurrency 语义决策
+
+- 本事项同时保持两条 `FR-0016` 边界：`max_in_flight` 只表达同 scope 内处于 adapter execution attempt 阶段的数量；首次并发获取失败必须在 durable accepted 前 fail-fast 为 `invalid_input/concurrency_limit_exceeded`，且不创建 `TaskRecord`。
+- 为消除 admission 检查与真实 execution slot 获取之间的 TOCTOU，Core 使用不计入 `max_in_flight` 的 per-scope admission guard 串行化首次 attempt admission；该 guard 不是 execution slot，不作为 caller-visible in-flight 事实。
+- 首次 execution slot 只在资源准备完成、即将进入 adapter execution 前获取；获取成功后释放 admission guard，并在 attempt closeout 后释放 execution slot。若同 scope 已有真实 execution slot，guard 内 fail-fast 拒绝且不创建 `TaskRecord`。
+- retry 不复用上一 attempt 的 slot；只有上一 attempt 已完成资源 closeout 与 slot release 后才重新获取下一轮 slot。若 retry reacquire 被拒绝，只追加 `retry_concurrency_rejected` control event，不改写上一 attempt 的终态分类。
+- 本事项不提供队列、调度器或跨进程限流能力；admission guard 仅用于本地同步 Core 的 contract-preserving atomicity。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.6.0` 提供 `timeout_retry_concurrency` 的真实 runtime evidence，使后续 `FR-0019/#234` gate matrix 可以消费可复验结果。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0016` implementation Work Item。
+- 阻塞：
+  - `#225` parent closeout 依赖本事项实现与 PR 合入。
+  - `#234` operability gate matrix 的 `timeout_retry_concurrency` 维度依赖本事项 runtime evidence。
+
+## 已验证项
+
+- `python3 -m py_compile syvert/runtime.py tests/runtime/test_execution_control.py`
+  - 结果：通过。
+- `python3 -m unittest tests.runtime.test_execution_control -v`
+  - 结果：通过，`Ran 16 tests`，`OK`。
+- `python3 -m unittest tests.runtime.test_execution_control tests.runtime.test_cli_http_same_path -q`
+  - 结果：通过，`Ran 28 tests`，`OK`。
+- `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_task_record_store tests.runtime.test_version_gate tests.runtime.test_execution_control`
+  - 结果：通过，`Ran 255 tests`，`OK`。
+- `python3 -m unittest discover -s tests`
+  - 结果：通过，`Ran 376 tests`，`OK`。
+- `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
+  - 结果：通过。
+- 子 agent review
+  - 结果：首轮指出 timeout closeout 早于 late result quarantine、runtime refs carrier 字段不足两项阻断；已修复为 timeout closeout 有界确认、hung adapter fail-closed、slot release 后生成 attempt `ended_at`，并补齐 `ExecutionAttemptOutcome` 字段与 `ExecutionControlEvent` refs。
+- PR guardian
+  - 结果：首轮 `REQUEST_CHANGES`，指出 hung adapter timeout path 可能无界阻塞，以及 `ExecutionAttemptOutcome.ended_at` 早于 slot release。
+  - 处理：timeout closeout 改为 bounded quarantine；若 adapter thread 未在 grace 窗口内完成，返回 `runtime_contract/execution_control_state_invalid` 并释放 slot；正常 timeout 完成 closeout 后仍返回 `platform/execution_timeout`；`ExecutionAttemptOutcome.ended_at` 改为在资源 closeout 与 slot release 后生成，并使用 microseconds 精度提供可复核排序。
+  - 结果：二轮 `REQUEST_CHANGES`，指出首次 concurrency slot 持有范围覆盖 admission / TaskRecord / resource preparation，以及 retry exhausted / retry concurrency rejected 未同步写入 failed envelope `error.details`。
+  - 处理：admission 改为只做可用性 fail-fast 检查、不持有 slot；attempt slot 只在 resource preparation 后、adapter execution / timeout closeout 窗口内持有；retry exhausted 与 retry concurrency rejected 同步写入 `error.details.execution_control_event` 与 task-level 控制字段。
+  - 子 agent 复查指出 slot acquire 后移后，resource preparation 后 acquire 失败会泄漏 managed resources，且首次 attempt race 不应投影为 pre-accepted `admission_concurrency_rejected`。
+  - 处理：post-resource-prep acquire 失败先 settle managed resource bundle；首次 attempt slot race 投影为 `runtime_contract/execution_control_state_invalid`，不生成 admission event；retry attempt slot rejection 继续生成 `retry_concurrency_rejected` 并保留上一 attempt 终态 error。
+  - 结果：三轮 `REQUEST_CHANGES`，指出 hung timeout closeout failure 仍将资源释放为 `AVAILABLE`，且 adapter thread still alive 时过早释放 concurrency slot。
+  - 处理：`thread.is_alive()` closeout-failed 路径将 managed resources 置为 `INVALID` quarantine；concurrency slot 移交后台 watcher，等待 adapter thread 实际退出后释放；返回前同 scope admission 继续被拒绝。
+  - 子 agent 复查指出 slot 延迟释放后，若仍生成 `ExecutionAttemptOutcome.ended_at`，会重新违反 `ended_at` 晚于 slot release 的时序契约。
+  - 处理：hung closeout-unproven 路径不生成 `ExecutionAttemptOutcome` / `runtime_result_refs`，只返回 fail-closed envelope；避免在 slot 仍由 watcher 持有时声明 attempt 已结束。
+  - 结果：四轮 `REQUEST_CHANGES`，指出首次普通并发竞争仍可能 accepted 后投影为 `runtime_contract`，以及 timeout grace 内 late result / error 的 resource disposition hint 未被消费。
+  - 处理：新增 admission reservation 计数，普通并发竞争在 accepted 前 fail-fast，且不计入 adapter in-flight；真正 in-flight slot 仍只覆盖 adapter execution / timeout closeout。timeout grace 内若 late result/error 已到达，消费其 `resource_disposition_hint` 后再形成 timeout envelope。
+  - 结果：五轮 `REQUEST_CHANGES`，指出 adapter 自报 `execution_timeout` 会被误判为 Core timeout retry，且非 timeout `ExecutionAttemptOutcome.control_code` 被写为空字符串。
+  - 处理：Core timeout retry 改为依赖 runtime 内部 `core_timeout_outcome` 布尔，不再只看 adapter 可伪造的 error code/details；`ExecutionAttemptOutcome.control_code` 仅在真实 Core timeout outcome 上输出，其他 attempt 省略该字段。
+  - 结果：六轮 `REQUEST_CHANGES`，指出 admission reservation 扩大了并发 gating 窗口，以及 timeout grace 内 malformed late hint 被误分类为 caller `invalid_input`。
+  - 处理：撤销 admission reservation，precheck 仅观察真实 adapter in-flight slot；resource preparation 期间同 scope availability 保持 true。malformed late hint 在 accepted timeout closeout 中改为 `runtime_contract/execution_control_state_invalid`，并将资源 `INVALID` quarantine。
+  - 结果：七轮 `REQUEST_CHANGES`，要求首次 admission 并发判定与实际 slot 保留收敛为同一原子步骤，并要求 slot release underflow fail-closed。
+  - 阶段性处理：首次 execution slot 在 accepted 前原子获取，失败返回 pre-accepted `concurrency_limit_exceeded` 且不创建 `TaskRecord`；retry 仍在前一 attempt 完成后重新获取 slot。`release_execution_concurrency_slot` 对未知/0 计数返回 `runtime_contract/execution_control_state_invalid` shared failed envelope，不向调用方冒出裸异常。
+  - 子 agent 复查指出 formal spec 明确 `max_in_flight` 只表达 adapter execution attempt 阶段，accepted / persistence / resource preparation 不应计入 in-flight。
+  - 处理：将 admission 原子化改为不计入 `max_in_flight` 的 per-scope guard；真实 execution slot 延后到 resource preparation 完成、进入 adapter execution 前获取。新增窗口回归测试证明 accepted persistence 与 resource preparation 期间 `in_flight` 仍为 0，第二个同 scope 请求等待 guard，直到第一个进入 adapter execution 后才 pre-accepted fail-fast 且不创建 `TaskRecord`。
+
+## 未决风险
+
+- timeout 使用 daemon thread 执行 adapter attempt；正常 timeout outcome 形成前会在有界窗口内等待 closeout quarantine，若无法证明完成则 fail-closed 为 `runtime_contract/execution_control_state_invalid`。当前满足本地单进程 runtime 与测试复验，不承诺生产级抢占或跨进程取消。
+- process-local concurrency slot 不提供分布式一致性；这符合 `FR-0016` v0.6.0 边界。
+- `runtime_result_refs` 目前只在失败、多 attempt 或 control event 场景写入，避免单 attempt success 改变既有 CLI/HTTP same-path record equality。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销 `syvert/runtime.py`、`tests/runtime/test_execution_control.py` 与本 exec-plan 的增量。
+- 不回滚 `FR-0016` formal spec，不修改 `FR-0017` / `FR-0019` 下游边界。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `65657a49536eb7ad83ea1cf666d0a43f233f67fa` 为开始实现时的主干基线。
+- `44ecd3a9b2f61838d59ad5ae6dcc89bcaa307182` 为首轮 PR head；后续 guardian blocker 修复提交 SHA 以 PR head 为准。

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+import queue
 import re
+import threading
+import time
 from typing import TYPE_CHECKING, Any, Callable, Mapping
 from uuid import uuid4
 
@@ -48,9 +51,20 @@ DEFAULT_FAILURE_RELEASE_REASON = "adapter_failed_without_disposition_hint"
 DEFAULT_INVALID_HINT_RELEASE_REASON = "invalid_resource_disposition_hint"
 MATCH_STATUS_MATCHED = "matched"
 MATCH_STATUS_UNMATCHED = "unmatched"
+EXECUTION_CONTROL_EVENT_ADMISSION_CONCURRENCY_REJECTED = "admission_concurrency_rejected"
+EXECUTION_CONTROL_EVENT_RETRY_CONCURRENCY_REJECTED = "retry_concurrency_rejected"
+EXECUTION_CONTROL_EVENT_RETRY_EXHAUSTED = "retry_exhausted"
+EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED = "concurrency_limit_exceeded"
+EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT = "execution_timeout"
+EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID = "execution_control_state_invalid"
+EXECUTION_CONTROL_CODE_RETRY_EXHAUSTED = "retry_exhausted"
+EXECUTION_TIMEOUT_CLOSEOUT_GRACE_SECONDS = 0.1
 _ALLOWED_MATCH_STATUSES = frozenset({MATCH_STATUS_MATCHED, MATCH_STATUS_UNMATCHED})
 _ALLOWED_MATCHER_CAPABILITIES = frozenset({CONTENT_DETAIL})
 _APPROVED_RESOURCE_CAPABILITY_IDS = approved_resource_capability_ids()
+_EXECUTION_CONCURRENCY_LOCK = threading.Lock()
+_EXECUTION_CONCURRENCY_IN_FLIGHT: dict[tuple[str, ...], int] = {}
+_EXECUTION_CONCURRENCY_ADMISSION_GUARDS: dict[tuple[str, ...], threading.Lock] = {}
 
 if TYPE_CHECKING:
     from syvert.resource_lifecycle import ResourceBundle
@@ -190,6 +204,25 @@ def default_task_id_factory() -> str:
 class TaskExecutionResult:
     envelope: dict[str, Any]
     task_record: TaskRecord | None
+
+
+@dataclass(frozen=True)
+class ExecutionConcurrencySlot:
+    scope_key: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ExecutionConcurrencyAdmissionGuard:
+    scope_key: tuple[str, ...]
+    lock: threading.Lock
+
+
+@dataclass(frozen=True)
+class AdapterAttemptResult:
+    envelope: dict[str, Any]
+    attempt_outcome_ref: dict[str, Any] | None
+    execution_control_event: dict[str, Any] | None = None
+    core_timeout_outcome: bool = False
 
 
 @dataclass(frozen=True)
@@ -442,9 +475,77 @@ def execute_task_internal(
     if projection_error is not None:
         return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, projection_error), None)
 
+    execution_control_policy = normalized_request.execution_control_policy
+    if execution_control_policy is None:
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                runtime_contract_error("execution_control_state_invalid", "Core 未能物化默认执行控制策略"),
+            ),
+            None,
+        )
+    admission_guard = acquire_execution_concurrency_admission_guard(
+        execution_control_policy.concurrency,
+        adapter_key=adapter_key,
+        capability=capability,
+    )
+    if not is_execution_concurrency_slot_available(
+        execution_control_policy.concurrency,
+        adapter_key=adapter_key,
+        capability=capability,
+    ):
+        release_execution_concurrency_admission_guard(admission_guard)
+        event = build_execution_control_event(
+            task_id,
+            adapter_key,
+            capability,
+            event_type=EXECUTION_CONTROL_EVENT_ADMISSION_CONCURRENCY_REJECTED,
+            attempt_count=0,
+            control_code=EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
+            task_record_ref="none",
+            policy=execution_control_policy,
+        )
+        return TaskExecutionResult(
+            failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                invalid_input_error(
+                    EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
+                    "执行控制并发限制拒绝本次任务提交",
+                    details={
+                        "scope": execution_control_policy.concurrency.scope,
+                        "max_in_flight": execution_control_policy.concurrency.max_in_flight,
+                        "on_limit": execution_control_policy.concurrency.on_limit,
+                        "task_record_ref": "none",
+                        "execution_control_event": event,
+                    },
+                ),
+            ),
+            None,
+        )
+
+    def release_admission_guard_or_failure(stage: str) -> TaskExecutionResult | None:
+        release_error = release_execution_concurrency_admission_guard(admission_guard)
+        if release_error is None:
+            return None
+        release_details = dict(release_error.get("details", {}))
+        release_details["stage"] = stage
+        release_error = dict(release_error)
+        release_error["details"] = release_details
+        return TaskExecutionResult(
+            failure_envelope(task_id, adapter_key, capability, release_error),
+            None,
+        )
+
     try:
         record = create_task_record(task_id, build_task_request_snapshot(normalized_request))
     except TaskRecordContractError as error:
+        release_failure = release_admission_guard_or_failure("create_task_record")
+        if release_failure is not None:
+            return release_failure
         return TaskExecutionResult(
             failure_envelope(
                 task_id,
@@ -463,6 +564,9 @@ def execute_task_internal(
         task_record_store=store,
     )
     if persistence_error is not None:
+        release_failure = release_admission_guard_or_failure("persist_accepted")
+        if release_failure is not None:
+            return release_failure
         return persistence_error
     if persisted_record is not None:
         record = persisted_record
@@ -470,6 +574,9 @@ def execute_task_internal(
     try:
         record = start_task_record(record)
     except TaskRecordContractError as error:
+        release_failure = release_admission_guard_or_failure("start_task_record")
+        if release_failure is not None:
+            return release_failure
         return TaskExecutionResult(
             failure_envelope(
                 task_id,
@@ -488,12 +595,26 @@ def execute_task_internal(
         task_record_store=store,
     )
     if persistence_error is not None:
+        release_failure = release_admission_guard_or_failure("persist_running")
+        if release_failure is not None:
+            return release_failure
         return persistence_error
     if persisted_record is not None:
         record = persisted_record
 
     match_result = match_resource_capabilities(matcher_input)
     if match_result.match_status == MATCH_STATUS_UNMATCHED:
+        release_failure = release_admission_guard_or_failure("resource_capability_match")
+        if release_failure is not None:
+            return finalize_task_execution_result(
+                task_id,
+                adapter_key,
+                capability,
+                record,
+                release_failure.envelope,
+                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
+                task_record_store=store,
+            )
         return finalize_task_execution_result(
             task_id,
             adapter_key,
@@ -518,151 +639,17 @@ def execute_task_internal(
             task_record_store=store,
         )
 
-    requested_slots = resolve_requested_resource_slots(normalized_request)
-    managed_resource_store = None
-    managed_trace_store = None
-    resource_bundle = None
-    if requested_slots is not None:
-        managed_resource_store = resource_lifecycle_store or default_runtime_resource_lifecycle_store()
-        managed_trace_store = resource_trace_store or default_runtime_resource_trace_store(managed_resource_store)
-        acquire_result = acquire_runtime_resource_bundle(
-            task_id=task_id,
-            adapter_key=adapter_key,
-            capability=capability,
-            requested_slots=requested_slots,
-            resource_lifecycle_store=managed_resource_store,
-            resource_trace_store=managed_trace_store,
-        )
-        if isinstance(acquire_result, Mapping):
-            return finalize_task_execution_result(
-                task_id,
-                adapter_key,
-                capability,
-                record,
-                dict(acquire_result),
-                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
-                task_record_store=store,
-            )
-        resource_bundle = acquire_result
-        live_resource_lease, live_resources_by_id, live_lease_error = resolve_host_resource_lease(
-            task_id=task_id,
-            adapter_key=adapter_key,
-            capability=capability,
-            resource_lifecycle_store=managed_resource_store,
-        )
-        if live_lease_error is not None:
-            cleanup_envelope = settle_managed_resource_bundle(
-                lease_id=resource_bundle.lease_id,
-                task_id=task_id,
-                resource_lifecycle_store=managed_resource_store,
-                resource_trace_store=managed_trace_store,
-                default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
-                hint=None,
-            )
-            envelope = cleanup_envelope or failure_envelope(task_id, adapter_key, capability, live_lease_error)
-            return finalize_task_execution_result(
-                task_id,
-                adapter_key,
-                capability,
-                record,
-                envelope,
-                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
-                task_record_store=store,
-            )
-
-        bundle_error = validate_host_resource_bundle(
-            resource_bundle,
-            task_id=task_id,
-            adapter_key=adapter_key,
-            capability=capability,
-            requested_slots=requested_slots,
-            live_resource_lease=live_resource_lease,
-            live_resources_by_id=live_resources_by_id,
-        )
-        if bundle_error is not None:
-            cleanup_envelope = settle_managed_resource_bundle(
-                lease_id=live_resource_lease.lease_id,
-                task_id=task_id,
-                resource_lifecycle_store=managed_resource_store,
-                resource_trace_store=managed_trace_store,
-                default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
-                hint=None,
-            )
-            envelope = cleanup_envelope or failure_envelope(task_id, adapter_key, capability, bundle_error)
-            return finalize_task_execution_result(
-                task_id,
-                adapter_key,
-                capability,
-                record,
-                envelope,
-                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
-                task_record_store=store,
-            )
-
-    adapter_context = AdapterExecutionContext(
-        request=adapter_request,
-        resource_bundle=resource_bundle,
-        execution_control_policy=normalized_request.execution_control_policy,
+    envelope = execute_controlled_adapter_attempts(
+        task_id=task_id,
+        adapter_key=adapter_key,
+        capability=capability,
+        adapter_request=adapter_request,
+        adapter=adapter_declaration.adapter,
+        policy=execution_control_policy,
+        initial_admission_guard=admission_guard,
+        resource_lifecycle_store=resource_lifecycle_store,
+        resource_trace_store=resource_trace_store,
     )
-    disposition_hint: ResourceDispositionHint | None = None
-    default_release_reason = DEFAULT_SUCCESS_RELEASE_REASON
-    try:
-        payload = adapter_declaration.adapter.execute(adapter_context)
-        payload_error = validate_success_payload(payload)
-        if payload_error is not None:
-            envelope = failure_envelope(task_id, adapter_key, capability, payload_error)
-            default_release_reason = DEFAULT_FAILURE_RELEASE_REASON
-        else:
-            disposition_hint, hint_error = extract_internal_resource_disposition_hint(
-                payload.get("resource_disposition_hint"),
-                expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
-            )
-            if hint_error is not None:
-                envelope = failure_envelope(task_id, adapter_key, capability, hint_error)
-                default_release_reason = DEFAULT_INVALID_HINT_RELEASE_REASON
-            else:
-                envelope = {
-                    "task_id": task_id,
-                    "adapter_key": adapter_key,
-                    "capability": capability,
-                    "status": "success",
-                    "raw": payload["raw"],
-                    "normalized": payload["normalized"],
-                }
-    except PlatformAdapterError as error:
-        disposition_hint, hint_error = extract_internal_resource_disposition_hint(
-            error.resource_disposition_hint,
-            expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
-        )
-        if hint_error is not None:
-            envelope = failure_envelope(task_id, adapter_key, capability, hint_error)
-            default_release_reason = DEFAULT_INVALID_HINT_RELEASE_REASON
-        else:
-            envelope = failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error))
-            default_release_reason = DEFAULT_FAILURE_RELEASE_REASON
-    except Exception as error:
-        envelope = failure_envelope(
-            task_id,
-            adapter_key,
-            capability,
-            runtime_contract_error(
-                "adapter_execution_error",
-                str(error) or error.__class__.__name__,
-            ),
-        )
-        default_release_reason = DEFAULT_FAILURE_RELEASE_REASON
-
-    if resource_bundle is not None and managed_resource_store is not None:
-        cleanup_envelope = settle_managed_resource_bundle(
-            lease_id=live_resource_lease.lease_id,
-            task_id=task_id,
-            resource_lifecycle_store=managed_resource_store,
-            resource_trace_store=managed_trace_store,
-            default_reason=default_release_reason,
-            hint=disposition_hint,
-        )
-        if cleanup_envelope is not None:
-            envelope = cleanup_envelope
 
     return finalize_task_execution_result(
         task_id,
@@ -673,6 +660,781 @@ def execute_task_internal(
         preserve_envelope_on_record_error=preserve_envelope_on_record_error,
         task_record_store=store,
     )
+
+
+def execute_controlled_adapter_attempts(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    adapter_request: AdapterTaskRequest,
+    adapter: Any,
+    policy: ExecutionControlPolicy,
+    initial_admission_guard: ExecutionConcurrencyAdmissionGuard,
+    resource_lifecycle_store: "LocalResourceLifecycleStore | None",
+    resource_trace_store: "LocalResourceTraceStore | None",
+) -> dict[str, Any]:
+    attempt_index = 1
+    admission_guard: ExecutionConcurrencyAdmissionGuard | None = initial_admission_guard
+    last_failed_envelope: dict[str, Any] | None = None
+    runtime_result_refs: list[dict[str, Any]] = []
+    execution_control_events: list[dict[str, Any]] = []
+
+    while True:
+        attempt = execute_single_controlled_adapter_attempt(
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            adapter_request=adapter_request,
+            adapter=adapter,
+            policy=policy,
+            attempt_index=attempt_index,
+            admission_guard=admission_guard,
+            resource_lifecycle_store=resource_lifecycle_store,
+            resource_trace_store=resource_trace_store,
+        )
+        admission_guard = None
+        envelope = attempt.envelope
+        if attempt.attempt_outcome_ref is not None:
+            runtime_result_refs.append(attempt.attempt_outcome_ref)
+        if attempt.execution_control_event is not None:
+            execution_control_events.append(attempt.execution_control_event)
+            runtime_result_refs.append(attempt.execution_control_event)
+            if last_failed_envelope is not None:
+                envelope = with_failed_envelope_control_details(
+                    last_failed_envelope,
+                    event=attempt.execution_control_event,
+                    details={
+                        "retry_concurrency_rejected": True,
+                        "attempt_count": attempt_index - 1,
+                        "scope": policy.concurrency.scope,
+                        "max_in_flight": policy.concurrency.max_in_flight,
+                    },
+                )
+            return with_runtime_observability(envelope, runtime_result_refs, execution_control_events)
+        envelope = with_runtime_observability(envelope, runtime_result_refs, execution_control_events)
+        if envelope.get("status") == "success":
+            return envelope
+
+        last_failed_envelope = envelope
+        retryable = is_retryable_attempt_outcome(
+            envelope,
+            capability=capability,
+            core_timeout_outcome=attempt.core_timeout_outcome,
+        )
+        if not retryable:
+            return envelope
+        if attempt_index >= policy.retry.max_attempts:
+            event = build_execution_control_event(
+                task_id,
+                adapter_key,
+                capability,
+                event_type=EXECUTION_CONTROL_EVENT_RETRY_EXHAUSTED,
+                attempt_count=attempt_index,
+                control_code=EXECUTION_CONTROL_CODE_RETRY_EXHAUSTED,
+                task_record_ref=f"task_record:{task_id}",
+                policy=policy,
+            )
+            execution_control_events.append(event)
+            runtime_result_refs.append(event)
+            exhausted_envelope = with_failed_envelope_control_details(
+                last_failed_envelope,
+                event=event,
+                details={
+                    "retry_exhausted": True,
+                    "attempt_count": attempt_index,
+                    "max_attempts": policy.retry.max_attempts,
+                    "last_attempt_outcome_ref": attempt.attempt_outcome_ref,
+                },
+            )
+            return with_runtime_observability(exhausted_envelope, runtime_result_refs, execution_control_events)
+        if policy.retry.backoff_ms:
+            time.sleep(policy.retry.backoff_ms / 1000)
+        admission_guard = acquire_execution_concurrency_admission_guard(
+            policy.concurrency,
+            adapter_key=adapter_key,
+            capability=capability,
+        )
+        if not is_execution_concurrency_slot_available(
+            policy.concurrency,
+            adapter_key=adapter_key,
+            capability=capability,
+        ):
+            release_execution_concurrency_admission_guard(admission_guard)
+            admission_guard = None
+            event = build_execution_control_event(
+                task_id,
+                adapter_key,
+                capability,
+                event_type=EXECUTION_CONTROL_EVENT_RETRY_CONCURRENCY_REJECTED,
+                attempt_count=attempt_index,
+                control_code=EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
+                task_record_ref=f"task_record:{task_id}",
+                policy=policy,
+            )
+            execution_control_events.append(event)
+            runtime_result_refs.append(event)
+            rejected_envelope = with_failed_envelope_control_details(
+                last_failed_envelope,
+                event=event,
+                details={
+                    "retry_concurrency_rejected": True,
+                    "attempt_count": attempt_index,
+                    "scope": policy.concurrency.scope,
+                    "max_in_flight": policy.concurrency.max_in_flight,
+                },
+            )
+            return with_runtime_observability(rejected_envelope, runtime_result_refs, execution_control_events)
+        attempt_index += 1
+
+
+def execute_single_controlled_adapter_attempt(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    adapter_request: AdapterTaskRequest,
+    adapter: Any,
+    policy: ExecutionControlPolicy,
+    attempt_index: int,
+    admission_guard: ExecutionConcurrencyAdmissionGuard,
+    resource_lifecycle_store: "LocalResourceLifecycleStore | None",
+    resource_trace_store: "LocalResourceTraceStore | None",
+) -> AdapterAttemptResult:
+    requested_slots = resolve_requested_resource_slots(
+        CoreTaskRequest(
+            target=InputTarget(
+                adapter_key=adapter_key,
+                capability=capability,
+                target_type=adapter_request.target_type,
+                target_value=adapter_request.target_value,
+            ),
+            policy=CollectionPolicy(collection_mode=adapter_request.collection_mode),
+            execution_control_policy=policy,
+        )
+    )
+    managed_resource_store = None
+    managed_trace_store = None
+    resource_bundle = None
+    live_resource_lease = None
+    disposition_hint: ResourceDispositionHint | None = None
+    default_release_reason = DEFAULT_SUCCESS_RELEASE_REASON
+    started_at = datetime.now(timezone.utc)
+    slot: ExecutionConcurrencySlot | None = None
+    admission_guard_released = False
+    slot_released = False
+
+    def release_attempt_admission_guard() -> dict[str, Any] | None:
+        nonlocal admission_guard_released
+        if admission_guard_released:
+            return None
+        admission_guard_released = True
+        return release_execution_concurrency_admission_guard(admission_guard)
+
+    def finish_attempt(envelope: dict[str, Any], *, core_timeout_outcome: bool = False) -> AdapterAttemptResult:
+        nonlocal slot_released
+        guard_release_error = release_attempt_admission_guard()
+        if guard_release_error is not None:
+            envelope = failure_envelope(task_id, adapter_key, capability, guard_release_error)
+            core_timeout_outcome = False
+        if slot is not None and not slot_released:
+            release_error = release_execution_concurrency_slot(slot)
+            slot_released = True
+            if release_error is not None:
+                envelope = failure_envelope(task_id, adapter_key, capability, release_error)
+                core_timeout_outcome = False
+        ended_at = datetime.now(timezone.utc)
+        return AdapterAttemptResult(
+            envelope,
+            build_attempt_outcome_ref(
+                task_id,
+                adapter_key,
+                capability,
+                attempt_index,
+                envelope,
+                started_at=started_at,
+                ended_at=ended_at,
+                core_timeout_outcome=core_timeout_outcome,
+            ),
+            core_timeout_outcome=core_timeout_outcome,
+        )
+
+    try:
+        if requested_slots is not None:
+            managed_resource_store = resource_lifecycle_store or default_runtime_resource_lifecycle_store()
+            managed_trace_store = resource_trace_store or default_runtime_resource_trace_store(managed_resource_store)
+            acquire_result = acquire_runtime_resource_bundle(
+                task_id=task_id,
+                adapter_key=adapter_key,
+                capability=capability,
+                requested_slots=requested_slots,
+                resource_lifecycle_store=managed_resource_store,
+                resource_trace_store=managed_trace_store,
+            )
+            if isinstance(acquire_result, Mapping):
+                envelope = dict(acquire_result)
+                return finish_attempt(envelope)
+            resource_bundle = acquire_result
+            live_resource_lease, live_resources_by_id, live_lease_error = resolve_host_resource_lease(
+                task_id=task_id,
+                adapter_key=adapter_key,
+                capability=capability,
+                resource_lifecycle_store=managed_resource_store,
+            )
+            if live_lease_error is not None:
+                cleanup_envelope = settle_managed_resource_bundle(
+                    lease_id=resource_bundle.lease_id,
+                    task_id=task_id,
+                    resource_lifecycle_store=managed_resource_store,
+                    resource_trace_store=managed_trace_store,
+                    default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
+                    hint=None,
+                )
+                envelope = cleanup_envelope or failure_envelope(task_id, adapter_key, capability, live_lease_error)
+                return finish_attempt(envelope)
+
+            bundle_error = validate_host_resource_bundle(
+                resource_bundle,
+                task_id=task_id,
+                adapter_key=adapter_key,
+                capability=capability,
+                requested_slots=requested_slots,
+                live_resource_lease=live_resource_lease,
+                live_resources_by_id=live_resources_by_id,
+            )
+            if bundle_error is not None:
+                cleanup_envelope = settle_managed_resource_bundle(
+                    lease_id=live_resource_lease.lease_id,
+                    task_id=task_id,
+                    resource_lifecycle_store=managed_resource_store,
+                    resource_trace_store=managed_trace_store,
+                    default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
+                    hint=None,
+                )
+                envelope = cleanup_envelope or failure_envelope(task_id, adapter_key, capability, bundle_error)
+                return finish_attempt(envelope)
+
+        adapter_context = AdapterExecutionContext(
+            request=adapter_request,
+            resource_bundle=resource_bundle,
+            execution_control_policy=policy,
+        )
+        slot = acquire_execution_concurrency_slot(
+            policy.concurrency,
+            adapter_key=adapter_key,
+            capability=capability,
+        )
+        if slot is None:
+            event = None
+            if attempt_index > 1:
+                event = build_execution_control_event(
+                    task_id,
+                    adapter_key,
+                    capability,
+                    event_type=EXECUTION_CONTROL_EVENT_RETRY_CONCURRENCY_REJECTED,
+                    attempt_count=attempt_index - 1,
+                    control_code=EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
+                    task_record_ref=f"task_record:{task_id}",
+                    policy=policy,
+                )
+            cleanup_envelope = None
+            if resource_bundle is not None and managed_resource_store is not None and live_resource_lease is not None:
+                cleanup_envelope = settle_managed_resource_bundle(
+                    lease_id=live_resource_lease.lease_id,
+                    task_id=task_id,
+                    resource_lifecycle_store=managed_resource_store,
+                    resource_trace_store=managed_trace_store,
+                    default_reason=DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON,
+                    hint=None,
+                )
+            envelope = cleanup_envelope or failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                runtime_contract_error(
+                    EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID,
+                    "execution concurrency slot became unavailable after guarded admission",
+                    details={
+                        "control_code": EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
+                        "scope": policy.concurrency.scope,
+                        "max_in_flight": policy.concurrency.max_in_flight,
+                    },
+                ),
+            )
+            guard_release_error = release_attempt_admission_guard()
+            if guard_release_error is not None:
+                envelope = failure_envelope(task_id, adapter_key, capability, guard_release_error)
+            return AdapterAttemptResult(envelope, None)
+        guard_release_error = release_attempt_admission_guard()
+        if guard_release_error is not None:
+            release_error = release_execution_concurrency_slot(slot)
+            slot_released = True
+            envelope = failure_envelope(task_id, adapter_key, capability, guard_release_error)
+            if release_error is not None:
+                envelope = failure_envelope(task_id, adapter_key, capability, release_error)
+            return finish_attempt(envelope)
+        (
+            envelope,
+            disposition_hint,
+            default_release_reason,
+            slot_release_deferred,
+            core_timeout_outcome,
+        ) = run_adapter_attempt_with_timeout(
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            adapter=adapter,
+            adapter_context=adapter_context,
+            timeout_ms=policy.timeout.timeout_ms,
+            resource_bundle=resource_bundle,
+            slot=slot,
+        )
+        if slot_release_deferred:
+            slot_released = True
+
+        if resource_bundle is not None and managed_resource_store is not None and live_resource_lease is not None:
+            cleanup_envelope = settle_managed_resource_bundle(
+                lease_id=live_resource_lease.lease_id,
+                task_id=task_id,
+                resource_lifecycle_store=managed_resource_store,
+                resource_trace_store=managed_trace_store,
+                default_reason=default_release_reason,
+                hint=disposition_hint,
+            )
+            if cleanup_envelope is not None:
+                envelope = cleanup_envelope
+                core_timeout_outcome = False
+        if slot_release_deferred:
+            return AdapterAttemptResult(envelope, None)
+        return finish_attempt(envelope, core_timeout_outcome=core_timeout_outcome)
+    finally:
+        if not admission_guard_released:
+            release_attempt_admission_guard()
+        if slot is not None and not slot_released:
+            release_execution_concurrency_slot(slot)
+
+
+def run_adapter_attempt_with_timeout(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    adapter: Any,
+    adapter_context: AdapterExecutionContext,
+    timeout_ms: int,
+    resource_bundle: Any,
+    slot: ExecutionConcurrencySlot | None,
+) -> tuple[dict[str, Any], ResourceDispositionHint | None, str, bool, bool]:
+    result_queue: queue.Queue[tuple[str, Any]] = queue.Queue(maxsize=1)
+
+    def invoke_adapter() -> None:
+        try:
+            result_queue.put(("payload", adapter.execute(adapter_context)))
+        except BaseException as error:
+            result_queue.put(("error", error))
+
+    thread = threading.Thread(target=invoke_adapter, daemon=True)
+    thread.start()
+    try:
+        kind, value = result_queue.get(timeout=timeout_ms / 1000)
+    except queue.Empty:
+        thread.join(timeout=EXECUTION_TIMEOUT_CLOSEOUT_GRACE_SECONDS)
+        if thread.is_alive():
+            slot_release_deferred = False
+            if slot is not None:
+                def release_slot_after_adapter_exit() -> None:
+                    thread.join()
+                    release_execution_concurrency_slot(slot)
+
+                threading.Thread(target=release_slot_after_adapter_exit, daemon=True).start()
+                slot_release_deferred = True
+            envelope = failure_envelope(
+                task_id,
+                adapter_key,
+                capability,
+                {
+                    "category": "runtime_contract",
+                    "code": EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID,
+                    "message": "adapter execution timeout closeout could not be proven within bounded quarantine",
+                    "details": {
+                        "control_code": EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT,
+                        "timeout_ms": timeout_ms,
+                        "closeout_grace_seconds": EXECUTION_TIMEOUT_CLOSEOUT_GRACE_SECONDS,
+                        "retryable": False,
+                        "resource_quarantine": "INVALID",
+                    },
+                },
+            )
+            disposition_hint = (
+                ResourceDispositionHint(
+                    lease_id=resource_bundle.lease_id,
+                    target_status_after_release="INVALID",
+                    reason="execution_timeout_closeout_unproven",
+                )
+                if resource_bundle is not None
+                else None
+            )
+            return envelope, disposition_hint, "execution_timeout_closeout_unproven", slot_release_deferred, False
+        envelope = failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            {
+                "category": "platform",
+                "code": EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT,
+                "message": "adapter execution attempt exceeded execution_control_policy timeout",
+                "details": {
+                    "control_code": EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT,
+                    "timeout_ms": timeout_ms,
+                    "retryable": True,
+                },
+            },
+        )
+        late_disposition_hint: ResourceDispositionHint | None = None
+        try:
+            late_kind, late_value = result_queue.get_nowait()
+        except queue.Empty:
+            late_kind = ""
+            late_value = None
+        if late_kind == "payload" and isinstance(late_value, Mapping):
+            late_disposition_hint, hint_error = extract_internal_resource_disposition_hint(
+                late_value.get("resource_disposition_hint"),
+                expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
+            )
+            if hint_error is not None:
+                return (
+                    timeout_closeout_invalid_hint_envelope(task_id, adapter_key, capability, timeout_ms, hint_error),
+                    timeout_closeout_invalid_resource_hint(resource_bundle),
+                    "timeout_closeout_invalid_resource_disposition_hint",
+                    False,
+                    False,
+                )
+        elif late_kind == "error" and isinstance(late_value, PlatformAdapterError):
+            late_disposition_hint, hint_error = extract_internal_resource_disposition_hint(
+                late_value.resource_disposition_hint,
+                expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
+            )
+            if hint_error is not None:
+                return (
+                    timeout_closeout_invalid_hint_envelope(task_id, adapter_key, capability, timeout_ms, hint_error),
+                    timeout_closeout_invalid_resource_hint(resource_bundle),
+                    "timeout_closeout_invalid_resource_disposition_hint",
+                    False,
+                    False,
+                )
+        return envelope, late_disposition_hint, DEFAULT_FAILURE_RELEASE_REASON, False, True
+
+    disposition_hint: ResourceDispositionHint | None = None
+    default_release_reason = DEFAULT_SUCCESS_RELEASE_REASON
+    if kind == "payload":
+        payload = value
+        payload_error = validate_success_payload(payload)
+        if payload_error is not None:
+            return failure_envelope(task_id, adapter_key, capability, payload_error), None, DEFAULT_FAILURE_RELEASE_REASON, False, False
+        disposition_hint, hint_error = extract_internal_resource_disposition_hint(
+            payload.get("resource_disposition_hint"),
+            expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
+        )
+        if hint_error is not None:
+            return failure_envelope(task_id, adapter_key, capability, hint_error), None, DEFAULT_INVALID_HINT_RELEASE_REASON, False, False
+        return (
+            {
+                "task_id": task_id,
+                "adapter_key": adapter_key,
+                "capability": capability,
+                "status": "success",
+                "raw": payload["raw"],
+                "normalized": payload["normalized"],
+            },
+            disposition_hint,
+            default_release_reason,
+            False,
+            False,
+        )
+
+    error = value
+    if isinstance(error, PlatformAdapterError):
+        disposition_hint, hint_error = extract_internal_resource_disposition_hint(
+            error.resource_disposition_hint,
+            expected_lease_id=resource_bundle.lease_id if resource_bundle is not None else None,
+        )
+        if hint_error is not None:
+            return failure_envelope(task_id, adapter_key, capability, hint_error), None, DEFAULT_INVALID_HINT_RELEASE_REASON, False, False
+        return (
+            failure_envelope(task_id, adapter_key, capability, classify_adapter_error(error)),
+            disposition_hint,
+            DEFAULT_FAILURE_RELEASE_REASON,
+            False,
+            False,
+        )
+    return (
+        failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error(
+                "adapter_execution_error",
+                str(error) or error.__class__.__name__,
+            ),
+        ),
+        None,
+        DEFAULT_FAILURE_RELEASE_REASON,
+        False,
+        False,
+    )
+
+
+def timeout_closeout_invalid_hint_envelope(
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    timeout_ms: int,
+    hint_error: Mapping[str, Any],
+) -> dict[str, Any]:
+    return failure_envelope(
+        task_id,
+        adapter_key,
+        capability,
+        runtime_contract_error(
+            EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID,
+            "timeout closeout late resource disposition hint is invalid",
+            details={
+                "control_code": EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT,
+                "timeout_ms": timeout_ms,
+                "closeout_error": dict(hint_error),
+                "resource_quarantine": "INVALID",
+                "retryable": False,
+            },
+        ),
+    )
+
+
+def timeout_closeout_invalid_resource_hint(resource_bundle: Any) -> ResourceDispositionHint | None:
+    if resource_bundle is None:
+        return None
+    return ResourceDispositionHint(
+        lease_id=resource_bundle.lease_id,
+        target_status_after_release="INVALID",
+        reason="timeout_closeout_invalid_resource_disposition_hint",
+    )
+
+
+def acquire_execution_concurrency_admission_guard(
+    policy: ExecutionConcurrencyPolicy,
+    *,
+    adapter_key: str,
+    capability: str,
+) -> ExecutionConcurrencyAdmissionGuard:
+    scope_key = execution_concurrency_scope_key(policy, adapter_key=adapter_key, capability=capability)
+    with _EXECUTION_CONCURRENCY_LOCK:
+        guard_lock = _EXECUTION_CONCURRENCY_ADMISSION_GUARDS.get(scope_key)
+        if guard_lock is None:
+            guard_lock = threading.Lock()
+            _EXECUTION_CONCURRENCY_ADMISSION_GUARDS[scope_key] = guard_lock
+    guard_lock.acquire()
+    return ExecutionConcurrencyAdmissionGuard(scope_key=scope_key, lock=guard_lock)
+
+
+def release_execution_concurrency_admission_guard(
+    guard: ExecutionConcurrencyAdmissionGuard | None,
+) -> dict[str, Any] | None:
+    if guard is None:
+        return None
+    try:
+        guard.lock.release()
+    except RuntimeError:
+        return runtime_contract_error(
+            EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID,
+            "execution concurrency admission guard release underflow",
+            details={
+                "control_code": EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID,
+                "scope_key": list(guard.scope_key),
+            },
+        )
+    return None
+
+
+def acquire_execution_concurrency_slot(
+    policy: ExecutionConcurrencyPolicy,
+    *,
+    adapter_key: str,
+    capability: str,
+) -> ExecutionConcurrencySlot | None:
+    scope_key = execution_concurrency_scope_key(policy, adapter_key=adapter_key, capability=capability)
+    with _EXECUTION_CONCURRENCY_LOCK:
+        in_flight = _EXECUTION_CONCURRENCY_IN_FLIGHT.get(scope_key, 0)
+        if in_flight >= policy.max_in_flight:
+            return None
+        _EXECUTION_CONCURRENCY_IN_FLIGHT[scope_key] = in_flight + 1
+    return ExecutionConcurrencySlot(scope_key=scope_key)
+
+
+def is_execution_concurrency_slot_available(
+    policy: ExecutionConcurrencyPolicy,
+    *,
+    adapter_key: str,
+    capability: str,
+) -> bool:
+    scope_key = execution_concurrency_scope_key(policy, adapter_key=adapter_key, capability=capability)
+    with _EXECUTION_CONCURRENCY_LOCK:
+        return _EXECUTION_CONCURRENCY_IN_FLIGHT.get(scope_key, 0) < policy.max_in_flight
+
+
+def release_execution_concurrency_slot(slot: ExecutionConcurrencySlot | None) -> dict[str, Any] | None:
+    if slot is None:
+        return None
+    with _EXECUTION_CONCURRENCY_LOCK:
+        in_flight = _EXECUTION_CONCURRENCY_IN_FLIGHT.get(slot.scope_key, 0)
+        if in_flight <= 0:
+            return runtime_contract_error(
+                EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID,
+                "execution concurrency slot release underflow",
+                details={
+                    "control_code": EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID,
+                    "scope_key": list(slot.scope_key),
+                    "in_flight": in_flight,
+                },
+            )
+        if in_flight == 1:
+            _EXECUTION_CONCURRENCY_IN_FLIGHT.pop(slot.scope_key, None)
+        else:
+            _EXECUTION_CONCURRENCY_IN_FLIGHT[slot.scope_key] = in_flight - 1
+    return None
+
+
+def execution_concurrency_scope_key(
+    policy: ExecutionConcurrencyPolicy,
+    *,
+    adapter_key: str,
+    capability: str,
+) -> tuple[str, ...]:
+    if policy.scope == "global":
+        return ("global",)
+    if policy.scope == "adapter":
+        return ("adapter", adapter_key)
+    return ("adapter_capability", adapter_key, capability)
+
+
+def is_retryable_attempt_outcome(
+    envelope: Mapping[str, Any],
+    *,
+    capability: str,
+    core_timeout_outcome: bool,
+) -> bool:
+    if capability != CONTENT_DETAIL_BY_URL or envelope.get("status") != "failed":
+        return False
+    error = envelope.get("error")
+    if not isinstance(error, Mapping):
+        return False
+    details = error.get("details")
+    if not isinstance(details, Mapping):
+        details = {}
+    if core_timeout_outcome:
+        return True
+    return error.get("category") == "platform" and details.get("retryable") is True
+
+
+def build_attempt_outcome_ref(
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    attempt_index: int,
+    envelope: Mapping[str, Any],
+    *,
+    started_at: datetime,
+    ended_at: datetime,
+    core_timeout_outcome: bool,
+) -> dict[str, Any]:
+    status = envelope.get("status")
+    if status == "success":
+        outcome = "succeeded"
+        control_code = ""
+    else:
+        error = envelope.get("error") if isinstance(envelope.get("error"), Mapping) else {}
+        details = error.get("details") if isinstance(error.get("details"), Mapping) else {}
+        control_code = str(details.get("control_code") or "") if core_timeout_outcome else ""
+        outcome = "timeout" if core_timeout_outcome else "failed"
+    terminal_envelope = dict(envelope)
+    terminal_envelope.pop("runtime_result_refs", None)
+    terminal_envelope.pop("execution_control_events", None)
+    ref = {
+        "ref_type": "ExecutionAttemptOutcome",
+        "ref_id": f"{task_id}:attempt:{attempt_index}",
+        "task_id": task_id,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "attempt_index": attempt_index,
+        "started_at": started_at.isoformat(timespec="microseconds").replace("+00:00", "Z"),
+        "ended_at": ended_at.isoformat(timespec="microseconds").replace("+00:00", "Z"),
+        "outcome": outcome,
+        "terminal_envelope": terminal_envelope,
+    }
+    if control_code:
+        ref["control_code"] = control_code
+    return ref
+
+
+def build_execution_control_event(
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    *,
+    event_type: str,
+    attempt_count: int,
+    control_code: str,
+    task_record_ref: str,
+    policy: ExecutionControlPolicy,
+) -> dict[str, Any]:
+    return {
+        "ref_type": "ExecutionControlEvent",
+        "ref_id": f"{task_id}:{event_type}:{attempt_count}",
+        "task_id": task_id,
+        "event_type": event_type,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "attempt_count": attempt_count,
+        "control_code": control_code,
+        "task_record_ref": task_record_ref,
+        "policy": {
+            "timeout": {"timeout_ms": policy.timeout.timeout_ms},
+            "retry": {"max_attempts": policy.retry.max_attempts, "backoff_ms": policy.retry.backoff_ms},
+            "concurrency": {
+                "scope": policy.concurrency.scope,
+                "max_in_flight": policy.concurrency.max_in_flight,
+                "on_limit": policy.concurrency.on_limit,
+            },
+        },
+        "occurred_at": datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z"),
+    }
+
+
+def with_runtime_observability(
+    envelope: Mapping[str, Any],
+    runtime_result_refs: list[dict[str, Any]],
+    execution_control_events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    enriched = dict(envelope)
+    if runtime_result_refs and (enriched.get("status") == "failed" or len(runtime_result_refs) > 1 or execution_control_events):
+        enriched["runtime_result_refs"] = list(runtime_result_refs)
+    if execution_control_events:
+        enriched["execution_control_events"] = list(execution_control_events)
+    return enriched
+
+
+def with_failed_envelope_control_details(
+    envelope: Mapping[str, Any],
+    *,
+    event: Mapping[str, Any],
+    details: Mapping[str, Any],
+) -> dict[str, Any]:
+    enriched = dict(envelope)
+    error = dict(enriched.get("error") if isinstance(enriched.get("error"), Mapping) else {})
+    current_details = dict(error.get("details") if isinstance(error.get("details"), Mapping) else {})
+    current_details.update(details)
+    current_details["execution_control_event"] = dict(event)
+    error["details"] = current_details
+    enriched["error"] = error
+    return enriched
 
 
 def finalize_task_execution_result(

--- a/tests/runtime/test_execution_control.py
+++ b/tests/runtime/test_execution_control.py
@@ -1,0 +1,773 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+
+import syvert.runtime as runtime_module
+from syvert.runtime import (
+    ExecutionConcurrencyPolicy,
+    ExecutionControlPolicy,
+    ExecutionRetryPolicy,
+    ExecutionTimeoutPolicy,
+    PlatformAdapterError,
+    TaskInput,
+    TaskRequest,
+    execute_task_with_record,
+)
+from syvert.task_record_store import LocalTaskRecordStore
+from syvert.resource_lifecycle_store import default_resource_lifecycle_store
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin, baseline_resource_requirement_declarations
+
+
+TEST_ADAPTER_KEY = "xhs"
+TEST_CAPABILITY = "content_detail_by_url"
+
+
+def parse_rfc3339_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.astimezone(timezone.utc)
+
+
+def make_policy(
+    *,
+    timeout_ms: int = 30000,
+    max_attempts: int = 1,
+    backoff_ms: int = 0,
+    scope: str = "global",
+    max_in_flight: int = 1,
+) -> ExecutionControlPolicy:
+    return ExecutionControlPolicy(
+        timeout=ExecutionTimeoutPolicy(timeout_ms=timeout_ms),
+        retry=ExecutionRetryPolicy(max_attempts=max_attempts, backoff_ms=backoff_ms),
+        concurrency=ExecutionConcurrencyPolicy(scope=scope, max_in_flight=max_in_flight, on_limit="reject"),
+    )
+
+
+def make_request(policy: ExecutionControlPolicy) -> TaskRequest:
+    return TaskRequest(
+        adapter_key=TEST_ADAPTER_KEY,
+        capability=TEST_CAPABILITY,
+        input=TaskInput(url="https://example.com/posts/execution-control"),
+        execution_control_policy=policy,
+    )
+
+
+class BaseAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(adapter_key=TEST_ADAPTER_KEY)
+
+    def success_payload(self, request):
+        return {
+            "raw": {"id": "raw-control", "url": request.input.url},
+            "normalized": {
+                "platform": TEST_ADAPTER_KEY,
+                "content_id": "content-control",
+                "content_type": "unknown",
+                "canonical_url": request.input.url,
+                "title": "",
+                "body_text": "",
+                "published_at": None,
+                "author": {
+                    "author_id": None,
+                    "display_name": None,
+                    "avatar_url": None,
+                },
+                "stats": {
+                    "like_count": None,
+                    "comment_count": None,
+                    "share_count": None,
+                    "collect_count": None,
+                },
+                "media": {
+                    "cover_url": None,
+                    "video_url": None,
+                    "image_urls": [],
+                },
+            },
+        }
+
+
+class SlowAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self.finished = False
+
+    def execute(self, request):
+        time.sleep(0.05)
+        self.finished = True
+        return self.success_payload(request)
+
+
+class SlowInvalidDispositionAdapter(BaseAdapter):
+    def execute(self, request):
+        time.sleep(0.05)
+        payload = self.success_payload(request)
+        payload["resource_disposition_hint"] = {
+            "lease_id": request.resource_bundle.lease_id,
+            "target_status_after_release": "INVALID",
+            "reason": "late_timeout_invalid_resource",
+        }
+        return payload
+
+
+class SlowMalformedDispositionAdapter(BaseAdapter):
+    def execute(self, request):
+        time.sleep(0.05)
+        payload = self.success_payload(request)
+        payload["resource_disposition_hint"] = {
+            "lease_id": request.resource_bundle.lease_id,
+            "target_status_after_release": "BOGUS",
+            "reason": "late_timeout_bad_hint",
+        }
+        return payload
+
+
+class SuccessAdapter(BaseAdapter):
+    def execute(self, request):
+        return self.success_payload(request)
+
+
+class CorruptingSlotReleaseAdapter(BaseAdapter):
+    def execute(self, request):
+        runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT.clear()
+        return self.success_payload(request)
+
+
+class RetryableThenSuccessAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def execute(self, request):
+        self.calls += 1
+        if self.calls == 1:
+            raise PlatformAdapterError(
+                code="transient_platform",
+                message="try again",
+                details={"retryable": True},
+            )
+        return self.success_payload(request)
+
+
+class SlowThenSuccessAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+        self.events: list[str] = []
+
+    def execute(self, request):
+        self.calls += 1
+        self.events.append(f"start-{self.calls}")
+        if self.calls == 1:
+            time.sleep(0.03)
+            self.events.append("end-1")
+            return self.success_payload(request)
+        self.events.append("end-2")
+        return self.success_payload(request)
+
+
+class HangingAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+        self.started = threading.Event()
+        self.stop = threading.Event()
+
+    def execute(self, request):
+        self.calls += 1
+        self.started.set()
+        self.stop.wait()
+        return self.success_payload(request)
+
+
+class NonRetryablePlatformAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def execute(self, request):
+        self.calls += 1
+        raise PlatformAdapterError(
+            code="hard_platform",
+            message="do not retry",
+            details={"retryable": False},
+        )
+
+
+class AdapterReportedExecutionTimeoutAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def execute(self, request):
+        self.calls += 1
+        raise PlatformAdapterError(
+            code="execution_timeout",
+            message="adapter-owned timeout",
+            details={"control_code": "execution_timeout"},
+        )
+
+
+class RetryableFailureAdapter(BaseAdapter):
+    def execute(self, request):
+        raise PlatformAdapterError(
+            code="transient_platform",
+            message="still broken",
+            details={"retryable": True, "reason": "slot-test"},
+        )
+
+
+class ExecutionControlRuntimeTests(ResourceStoreEnvMixin, unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT.clear()
+        runtime_module._EXECUTION_CONCURRENCY_ADMISSION_GUARDS.clear()
+        self._task_record_store_dir = tempfile.TemporaryDirectory()
+        self._task_record_store_patcher = mock.patch.dict(
+            os.environ,
+            {"SYVERT_TASK_RECORD_STORE_DIR": self._task_record_store_dir.name},
+            clear=False,
+        )
+        self._task_record_store_patcher.start()
+        self.store = LocalTaskRecordStore(Path(self._task_record_store_dir.name))
+
+    def tearDown(self) -> None:
+        runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT.clear()
+        runtime_module._EXECUTION_CONCURRENCY_ADMISSION_GUARDS.clear()
+        self._task_record_store_patcher.stop()
+        self._task_record_store_dir.cleanup()
+        super().tearDown()
+
+    def task_record_files(self) -> list[str]:
+        return sorted(path.name for path in self.store.root.glob("*.json"))
+
+    def test_timeout_attempt_fails_as_platform_execution_timeout(self) -> None:
+        adapter = SlowAdapter()
+        result = execute_task_with_record(
+            make_request(make_policy(timeout_ms=1)),
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-timeout-control",
+            task_record_store=self.store,
+        )
+
+        self.assertTrue(adapter.finished)
+        self.assertIsNotNone(result.task_record)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "platform")
+        self.assertEqual(result.envelope["error"]["code"], "execution_timeout")
+        self.assertEqual(result.envelope["error"]["details"]["control_code"], "execution_timeout")
+        self.assertEqual(result.envelope["runtime_result_refs"][0]["outcome"], "timeout")
+        self.assertEqual(result.envelope["runtime_result_refs"][0]["control_code"], "execution_timeout")
+        self.assertEqual(result.envelope["runtime_result_refs"][0]["adapter_key"], TEST_ADAPTER_KEY)
+        self.assertEqual(result.envelope["runtime_result_refs"][0]["capability"], TEST_CAPABILITY)
+        self.assertIn("started_at", result.envelope["runtime_result_refs"][0])
+        self.assertIn("ended_at", result.envelope["runtime_result_refs"][0])
+        self.assertIn("terminal_envelope", result.envelope["runtime_result_refs"][0])
+        self.assertEqual(result.envelope["execution_control_events"][0]["event_type"], "retry_exhausted")
+        self.assertEqual(result.envelope["runtime_result_refs"][1], result.envelope["execution_control_events"][0])
+        self.assertEqual(
+            result.envelope["error"]["details"]["execution_control_event"],
+            result.envelope["execution_control_events"][0],
+        )
+        self.assertEqual(result.envelope["error"]["details"]["retry_exhausted"], True)
+        self.assertEqual(result.envelope["error"]["details"]["attempt_count"], 1)
+        self.assertEqual(result.envelope["error"]["details"]["max_attempts"], 1)
+        self.assertEqual(
+            result.envelope["error"]["details"]["last_attempt_outcome_ref"],
+            result.envelope["runtime_result_refs"][0],
+        )
+        snapshot = default_resource_lifecycle_store().load_snapshot()
+        released_at = snapshot.leases[-1].released_at
+        self.assertIsNotNone(released_at)
+        self.assertGreater(
+            parse_rfc3339_utc(result.envelope["runtime_result_refs"][0]["ended_at"]),
+            parse_rfc3339_utc(released_at),
+        )
+        self.assertEqual(result.task_record.status, "failed")
+
+    def test_timeout_closeout_consumes_late_resource_disposition_hint(self) -> None:
+        result = execute_task_with_record(
+            make_request(make_policy(timeout_ms=1)),
+            adapters={TEST_ADAPTER_KEY: SlowInvalidDispositionAdapter()},
+            task_id_factory=lambda: "task-timeout-late-hint",
+            task_record_store=self.store,
+        )
+
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["code"], "execution_timeout")
+        snapshot = default_resource_lifecycle_store().load_snapshot()
+        self.assertEqual({lease.target_status_after_release for lease in snapshot.leases}, {"INVALID"})
+        self.assertEqual({lease.release_reason for lease in snapshot.leases}, {"late_timeout_invalid_resource"})
+        self.assertEqual({resource.status for resource in snapshot.resources}, {"INVALID"})
+
+    def test_timeout_closeout_malformed_late_hint_fails_closed_and_quarantines_resources(self) -> None:
+        result = execute_task_with_record(
+            make_request(make_policy(timeout_ms=1)),
+            adapters={TEST_ADAPTER_KEY: SlowMalformedDispositionAdapter()},
+            task_id_factory=lambda: "task-timeout-late-bad-hint",
+            task_record_store=self.store,
+        )
+
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
+        self.assertEqual(result.envelope["error"]["details"]["resource_quarantine"], "INVALID")
+        snapshot = default_resource_lifecycle_store().load_snapshot()
+        self.assertEqual({lease.target_status_after_release for lease in snapshot.leases}, {"INVALID"})
+        self.assertEqual(
+            {lease.release_reason for lease in snapshot.leases},
+            {"timeout_closeout_invalid_resource_disposition_hint"},
+        )
+        self.assertEqual({resource.status for resource in snapshot.resources}, {"INVALID"})
+
+    def test_timeout_closeout_cleanup_failure_is_not_retryable(self) -> None:
+        adapter = SlowThenSuccessAdapter()
+
+        def fail_cleanup(*args, **kwargs):
+            return runtime_module.failure_envelope(
+                "task-timeout-cleanup-failure",
+                TEST_ADAPTER_KEY,
+                TEST_CAPABILITY,
+                runtime_module.runtime_contract_error(
+                    "execution_control_state_invalid",
+                    "resource closeout failed",
+                    details={"retryable": False},
+                ),
+            )
+
+        with mock.patch("syvert.runtime.settle_managed_resource_bundle", side_effect=fail_cleanup):
+            result = execute_task_with_record(
+                make_request(make_policy(timeout_ms=1, max_attempts=2)),
+                adapters={TEST_ADAPTER_KEY: adapter},
+                task_id_factory=lambda: "task-timeout-cleanup-failure",
+                task_record_store=self.store,
+            )
+
+        self.assertEqual(adapter.calls, 1)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
+        self.assertNotIn("execution_control_events", result.envelope)
+
+    def test_timeout_quarantines_late_result_before_retry_reacquires_slot(self) -> None:
+        adapter = SlowThenSuccessAdapter()
+
+        result = execute_task_with_record(
+            make_request(make_policy(timeout_ms=1, max_attempts=2)),
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-timeout-retry-quarantine",
+            task_record_store=self.store,
+        )
+
+        self.assertEqual(result.envelope["status"], "success")
+        self.assertEqual(adapter.events, ["start-1", "end-1", "start-2", "end-2"])
+
+    def test_hung_adapter_timeout_fails_closed_without_permanent_slot_occupancy(self) -> None:
+        adapter = HangingAdapter()
+        started_at = time.monotonic()
+        result = execute_task_with_record(
+            make_request(make_policy(timeout_ms=1, max_attempts=2)),
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-hung-timeout-closeout",
+            task_record_store=self.store,
+        )
+        elapsed = time.monotonic() - started_at
+
+        try:
+            self.assertTrue(adapter.started.is_set())
+            self.assertLess(elapsed, 0.5)
+            self.assertEqual(adapter.calls, 1)
+            self.assertEqual(result.envelope["status"], "failed")
+            self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
+            self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
+            self.assertEqual(result.envelope["error"]["details"]["control_code"], "execution_timeout")
+            self.assertEqual(result.envelope["error"]["details"]["retryable"], False)
+            self.assertEqual(result.envelope["error"]["details"]["resource_quarantine"], "INVALID")
+            self.assertNotIn("runtime_result_refs", result.envelope)
+            self.assertEqual(result.task_record.status, "failed")
+
+            snapshot = default_resource_lifecycle_store().load_snapshot()
+            self.assertEqual({lease.target_status_after_release for lease in snapshot.leases}, {"INVALID"})
+            self.assertEqual({resource.status for resource in snapshot.resources}, {"INVALID"})
+            self.assertEqual(sum(runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT.values()), 1)
+
+            followup = execute_task_with_record(
+                make_request(make_policy(timeout_ms=30000, max_attempts=1)),
+                adapters={TEST_ADAPTER_KEY: SuccessAdapter()},
+                task_id_factory=lambda: "task-after-hung-timeout-closeout",
+                task_record_store=self.store,
+            )
+
+            self.assertIsNone(followup.task_record)
+            self.assertEqual(followup.envelope["error"]["code"], "concurrency_limit_exceeded")
+        finally:
+            adapter.stop.set()
+            for _ in range(100):
+                if not runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT:
+                    break
+                time.sleep(0.01)
+            self.assertEqual(runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT, {})
+
+    def test_retryable_platform_failure_retries_same_task_until_success(self) -> None:
+        adapter = RetryableThenSuccessAdapter()
+
+        result = execute_task_with_record(
+            make_request(make_policy(max_attempts=2)),
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-retry-success",
+            task_record_store=self.store,
+        )
+
+        self.assertEqual(adapter.calls, 2)
+        self.assertEqual(result.envelope["status"], "success")
+        self.assertEqual(result.task_record.task_id, "task-retry-success")
+        self.assertEqual(result.task_record.status, "succeeded")
+        self.assertEqual([ref["attempt_index"] for ref in result.envelope["runtime_result_refs"]], [1, 2])
+        self.assertTrue(all("control_code" not in ref for ref in result.envelope["runtime_result_refs"]))
+
+    def test_non_retryable_platform_failure_does_not_retry(self) -> None:
+        adapter = NonRetryablePlatformAdapter()
+
+        result = execute_task_with_record(
+            make_request(make_policy(max_attempts=3)),
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-no-retry",
+            task_record_store=self.store,
+        )
+
+        self.assertEqual(adapter.calls, 1)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["code"], "hard_platform")
+        self.assertNotIn("execution_control_events", result.envelope)
+        self.assertNotIn("control_code", result.envelope["runtime_result_refs"][0])
+
+    def test_adapter_reported_execution_timeout_does_not_retry_without_retryable_detail(self) -> None:
+        adapter = AdapterReportedExecutionTimeoutAdapter()
+
+        result = execute_task_with_record(
+            make_request(make_policy(max_attempts=2)),
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-adapter-timeout-not-core-timeout",
+            task_record_store=self.store,
+        )
+
+        self.assertEqual(adapter.calls, 1)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["code"], "execution_timeout")
+        self.assertNotIn("execution_control_events", result.envelope)
+        self.assertEqual(result.envelope["runtime_result_refs"][0]["outcome"], "failed")
+        self.assertNotIn("control_code", result.envelope["runtime_result_refs"][0])
+
+    def test_concurrency_slot_release_underflow_fails_closed(self) -> None:
+        result = execute_task_with_record(
+            make_request(make_policy()),
+            adapters={TEST_ADAPTER_KEY: CorruptingSlotReleaseAdapter()},
+            task_id_factory=lambda: "task-slot-release-underflow",
+            task_record_store=self.store,
+        )
+
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
+        self.assertEqual(
+            result.envelope["error"]["details"]["control_code"],
+            "execution_control_state_invalid",
+        )
+        self.assertEqual(result.envelope["runtime_result_refs"][0]["outcome"], "failed")
+        self.assertEqual(result.task_record.status, "failed")
+        self.assertEqual(runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT, {})
+
+    def test_pre_accepted_concurrency_rejection_does_not_create_task_record(self) -> None:
+        policy = make_policy(scope="global", max_in_flight=1)
+        held_slot = runtime_module.acquire_execution_concurrency_slot(
+            policy.concurrency,
+            adapter_key=TEST_ADAPTER_KEY,
+            capability=TEST_CAPABILITY,
+        )
+        try:
+            result = execute_task_with_record(
+                make_request(policy),
+                adapters={TEST_ADAPTER_KEY: RetryableThenSuccessAdapter()},
+                task_id_factory=lambda: "task-pre-accept-rejected",
+                task_record_store=self.store,
+            )
+        finally:
+            runtime_module.release_execution_concurrency_slot(held_slot)
+
+        self.assertIsNone(result.task_record)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "invalid_input")
+        self.assertEqual(result.envelope["error"]["code"], "concurrency_limit_exceeded")
+        self.assertEqual(result.envelope["error"]["details"]["task_record_ref"], "none")
+        self.assertEqual(self.task_record_files(), [])
+
+    def test_resource_preparation_does_not_count_as_execution_in_flight(self) -> None:
+        policy = make_policy(scope="global", max_in_flight=1)
+        first_adapter = HangingAdapter()
+        second_result: dict[str, object] = {}
+        first_result: dict[str, object] = {}
+        resource_prep_entered = threading.Event()
+        allow_resource_prep = threading.Event()
+        second_finished = threading.Event()
+        first_finished = threading.Event()
+        real_acquire_resource_bundle = runtime_module.acquire_runtime_resource_bundle
+
+        def blocking_acquire_resource_bundle(*args, **kwargs):
+            resource_prep_entered.set()
+            self.assertTrue(allow_resource_prep.wait(timeout=1))
+            return real_acquire_resource_bundle(*args, **kwargs)
+
+        def run_first() -> None:
+            first_result["value"] = execute_task_with_record(
+                make_request(policy),
+                adapters={TEST_ADAPTER_KEY: first_adapter},
+                task_id_factory=lambda: "task-resource-prep-first",
+                task_record_store=self.store,
+            )
+            first_finished.set()
+
+        def run_second() -> None:
+            second_result["value"] = execute_task_with_record(
+                make_request(policy),
+                adapters={TEST_ADAPTER_KEY: SuccessAdapter()},
+                task_id_factory=lambda: "task-resource-prep-second",
+                task_record_store=self.store,
+            )
+            second_finished.set()
+
+        with mock.patch("syvert.runtime.acquire_runtime_resource_bundle", side_effect=blocking_acquire_resource_bundle):
+            first_thread = threading.Thread(target=run_first)
+            second_thread = threading.Thread(target=run_second)
+            first_thread.start()
+            try:
+                self.assertTrue(resource_prep_entered.wait(timeout=1))
+                self.assertEqual(runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT, {})
+                self.assertTrue(
+                    runtime_module.is_execution_concurrency_slot_available(
+                        policy.concurrency,
+                        adapter_key=TEST_ADAPTER_KEY,
+                        capability=TEST_CAPABILITY,
+                    )
+                )
+
+                second_thread.start()
+                self.assertFalse(second_finished.wait(timeout=0.05))
+
+                allow_resource_prep.set()
+                self.assertTrue(first_adapter.started.wait(timeout=1))
+                self.assertTrue(second_finished.wait(timeout=1))
+            finally:
+                first_adapter.stop.set()
+                allow_resource_prep.set()
+                first_thread.join(timeout=1)
+                second_thread.join(timeout=1)
+
+        self.assertTrue(first_finished.is_set())
+        self.assertIsNotNone(first_result.get("value"))
+        self.assertIsNotNone(second_result.get("value"))
+        rejected = second_result["value"]
+        self.assertIsNone(rejected.task_record)
+        self.assertEqual(rejected.envelope["error"]["code"], "concurrency_limit_exceeded")
+        self.assertEqual(self.task_record_files(), ["task-resource-prep-first.json"])
+
+    def test_accepted_persistence_does_not_count_as_execution_in_flight(self) -> None:
+        policy = make_policy(scope="global", max_in_flight=1)
+        first_adapter = HangingAdapter()
+        second_result: dict[str, object] = {}
+        first_result: dict[str, object] = {}
+        accepted_persist_entered = threading.Event()
+        allow_accepted_persist = threading.Event()
+        second_finished = threading.Event()
+        first_finished = threading.Event()
+        real_persist_task_record = runtime_module.persist_task_record
+
+        def blocking_persist_task_record(*args, **kwargs):
+            record = args[3]
+            if kwargs.get("stage") == "accepted" and record.task_id == "task-accepted-window-first":
+                accepted_persist_entered.set()
+                self.assertTrue(allow_accepted_persist.wait(timeout=1))
+            return real_persist_task_record(*args, **kwargs)
+
+        def run_first() -> None:
+            first_result["value"] = execute_task_with_record(
+                make_request(policy),
+                adapters={TEST_ADAPTER_KEY: first_adapter},
+                task_id_factory=lambda: "task-accepted-window-first",
+                task_record_store=self.store,
+            )
+            first_finished.set()
+
+        def run_second() -> None:
+            second_result["value"] = execute_task_with_record(
+                make_request(policy),
+                adapters={TEST_ADAPTER_KEY: SuccessAdapter()},
+                task_id_factory=lambda: "task-accepted-window-second",
+                task_record_store=self.store,
+            )
+            second_finished.set()
+
+        with mock.patch("syvert.runtime.persist_task_record", side_effect=blocking_persist_task_record):
+            first_thread = threading.Thread(target=run_first)
+            second_thread = threading.Thread(target=run_second)
+            second_started = False
+            first_thread.start()
+            try:
+                self.assertTrue(accepted_persist_entered.wait(timeout=1))
+                self.assertEqual(runtime_module._EXECUTION_CONCURRENCY_IN_FLIGHT, {})
+
+                second_thread.start()
+                second_started = True
+                self.assertFalse(second_finished.wait(timeout=0.05))
+
+                allow_accepted_persist.set()
+                self.assertTrue(first_adapter.started.wait(timeout=1))
+                self.assertTrue(second_finished.wait(timeout=1))
+            finally:
+                first_adapter.stop.set()
+                allow_accepted_persist.set()
+                first_thread.join(timeout=1)
+                if second_started:
+                    second_thread.join(timeout=1)
+
+        self.assertTrue(first_finished.is_set())
+        self.assertIsNotNone(first_result.get("value"))
+        self.assertIsNotNone(second_result.get("value"))
+        rejected = second_result["value"]
+        self.assertIsNone(rejected.task_record)
+        self.assertEqual(rejected.envelope["error"]["code"], "concurrency_limit_exceeded")
+        self.assertEqual(self.task_record_files(), ["task-accepted-window-first.json"])
+
+    def test_post_accepted_retry_reacquire_rejection_preserves_previous_failure(self) -> None:
+        real_available = runtime_module.is_execution_concurrency_slot_available
+        calls = 0
+
+        def available_once_then_reject(policy, *, adapter_key, capability):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return real_available(policy, adapter_key=adapter_key, capability=capability)
+            return False
+
+        with mock.patch("syvert.runtime.is_execution_concurrency_slot_available", side_effect=available_once_then_reject):
+            result = execute_task_with_record(
+                make_request(make_policy(max_attempts=2)),
+                adapters={TEST_ADAPTER_KEY: RetryableFailureAdapter()},
+                task_id_factory=lambda: "task-retry-slot-rejected",
+                task_record_store=self.store,
+            )
+
+        self.assertIsNotNone(result.task_record)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "platform")
+        self.assertEqual(result.envelope["error"]["code"], "transient_platform")
+        self.assertEqual(result.envelope["execution_control_events"][0]["event_type"], "retry_concurrency_rejected")
+        self.assertEqual(
+            result.envelope["error"]["details"]["execution_control_event"],
+            result.envelope["execution_control_events"][0],
+        )
+        self.assertEqual(result.envelope["error"]["details"]["retry_concurrency_rejected"], True)
+        self.assertEqual(result.envelope["error"]["details"]["attempt_count"], 1)
+        self.assertEqual(result.envelope["runtime_result_refs"][1], result.envelope["execution_control_events"][0])
+        self.assertEqual(result.task_record.status, "failed")
+        snapshot = default_resource_lifecycle_store().load_snapshot()
+        self.assertTrue(all(lease.released_at is not None for lease in snapshot.leases))
+        self.assertEqual({resource.status for resource in snapshot.resources}, {"AVAILABLE"})
+
+    def test_retry_slot_accounting_invariant_failure_fails_closed(self) -> None:
+        real_acquire = runtime_module.acquire_execution_concurrency_slot
+        calls = 0
+
+        def acquire_once_then_invalid(policy, *, adapter_key, capability):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return real_acquire(policy, adapter_key=adapter_key, capability=capability)
+            return None
+
+        with mock.patch("syvert.runtime.acquire_execution_concurrency_slot", side_effect=acquire_once_then_invalid):
+            result = execute_task_with_record(
+                make_request(make_policy(max_attempts=2)),
+                adapters={TEST_ADAPTER_KEY: RetryableFailureAdapter()},
+                task_id_factory=lambda: "task-retry-slot-invariant-invalid",
+                task_record_store=self.store,
+            )
+
+        self.assertIsNotNone(result.task_record)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
+        self.assertNotIn("execution_control_events", result.envelope)
+        self.assertEqual(result.task_record.status, "failed")
+
+    def test_concurrency_scope_keys_are_enforced_independently(self) -> None:
+        global_policy = make_policy(scope="global")
+        global_slot = runtime_module.acquire_execution_concurrency_slot(
+            global_policy.concurrency,
+            adapter_key="xhs",
+            capability=TEST_CAPABILITY,
+        )
+        try:
+            self.assertIsNone(
+                runtime_module.acquire_execution_concurrency_slot(
+                    global_policy.concurrency,
+                    adapter_key="douyin",
+                    capability=TEST_CAPABILITY,
+                )
+            )
+        finally:
+            runtime_module.release_execution_concurrency_slot(global_slot)
+
+        adapter_policy = make_policy(scope="adapter")
+        adapter_slot = runtime_module.acquire_execution_concurrency_slot(
+            adapter_policy.concurrency,
+            adapter_key="xhs",
+            capability=TEST_CAPABILITY,
+        )
+        try:
+            self.assertIsNone(
+                runtime_module.acquire_execution_concurrency_slot(
+                    adapter_policy.concurrency,
+                    adapter_key="xhs",
+                    capability="other",
+                )
+            )
+            douyin_slot = runtime_module.acquire_execution_concurrency_slot(
+                adapter_policy.concurrency,
+                adapter_key="douyin",
+                capability=TEST_CAPABILITY,
+            )
+            self.assertIsNotNone(douyin_slot)
+            runtime_module.release_execution_concurrency_slot(douyin_slot)
+        finally:
+            runtime_module.release_execution_concurrency_slot(adapter_slot)
+
+        adapter_capability_policy = make_policy(scope="adapter_capability")
+        capability_slot = runtime_module.acquire_execution_concurrency_slot(
+            adapter_capability_policy.concurrency,
+            adapter_key="xhs",
+            capability=TEST_CAPABILITY,
+        )
+        try:
+            self.assertIsNone(
+                runtime_module.acquire_execution_concurrency_slot(
+                    adapter_capability_policy.concurrency,
+                    adapter_key="xhs",
+                    capability=TEST_CAPABILITY,
+                )
+            )
+            other_capability_slot = runtime_module.acquire_execution_concurrency_slot(
+                adapter_capability_policy.concurrency,
+                adapter_key="xhs",
+                capability="other_capability",
+            )
+            self.assertIsNotNone(other_capability_slot)
+            runtime_module.release_execution_concurrency_slot(other_capability_slot)
+        finally:
+            runtime_module.release_execution_concurrency_slot(capability_slot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：实现 `FR-0016` 的 Core-owned 最小执行控制 runtime，为 `v0.6.0` 的 timeout / retry / concurrency gate matrix 提供可复验运行时证据。
- 主要改动：
  - 在 Core `execute_task_with_record` 路径内加入 attempt 级 timeout、固定 retry predicate、process-local admission guard 与 execution concurrency slot。
  - admission guard 不计入 `max_in_flight`，只串行化首次 attempt admission；真实 execution slot 仅覆盖 adapter execution / timeout closeout，只有确认 execution slot 真实不可用时才返回 pre-accepted `concurrency_limit_exceeded` 且不创建 `TaskRecord`。
  - 通过 `runtime_result_refs` / `execution_control_events` 投影可证明完成的 `ExecutionAttemptOutcome` 与 `ExecutionControlEvent`。
  - 新增 `tests/runtime/test_execution_control.py`，覆盖 Core timeout、adapter-owned timeout 不冒充 Core timeout、hung adapter fail-closed、late resource disposition hint、malformed late hint fail-closed、timeout cleanup failure 非 retry、retry、非 retry、pre/post accepted concurrency rejection、accepted/resource-prep 窗口不计入 `max_in_flight`、retry invariant fail-closed、retry control details 回写、`ExecutionAttemptOutcome.control_code` shape、`ended_at` 顺序证据与三类 scope。

## Issue 摘要

`#224` 要求在 `FR-0016` 边界内实现 Core 侧超时、基础重试与并发限制，并将结果写入同一路径任务记录；不实现 HTTP API、不做分布式调度、不扩展资源 provider 选择。

## 关联事项

- Issue: #224
- item_key: `CHORE-0148-fr-0016-runtime-timeout-retry-concurrency`
- item_type: `CHORE`
- release: `v0.6.0`
- sprint: `2026-S19`
- Closing: Fixes #224

## 风险

- 风险级别：`normal`
- 审查关注：timeout closeout 必须有界；正常 Core timeout 在 closeout 可证明完成后返回 `platform/execution_timeout`；adapter-owned timeout 不自动重试；无法证明 closeout 的 hung adapter fail-closed 为 `runtime_contract/execution_control_state_invalid`，资源 `INVALID` quarantine，slot 等 adapter thread 退出后释放；pre-accepted concurrency rejection 不得创建 TaskRecord；post-accepted retry reacquire rejection 不得改写上一 attempt 的终态 error。

## 验证

- 已执行：
  - `python3 -m py_compile syvert/runtime.py tests/runtime/test_execution_control.py`
  - `python3 -m unittest tests.runtime.test_execution_control -v` (`Ran 16 tests`, `OK`)
  - `python3 -m unittest tests.runtime.test_execution_control tests.runtime.test_cli_http_same_path -q` (`Ran 28 tests`, `OK`)
  - `python3 -m unittest tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_task_record_store tests.runtime.test_version_gate tests.runtime.test_execution_control` (`Ran 255 tests`, `OK`)
  - `python3 -m unittest discover -s tests` (`Ran 376 tests`, `OK`)
  - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
- 未执行：无。

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销 `syvert/runtime.py`、`tests/runtime/test_execution_control.py` 与 `docs/exec-plans/CHORE-0148-fr-0016-runtime-timeout-retry-concurrency.md` 的增量。
