### PR TITLE
feat(runtime): 实现 FR-0017 失败可观测性

### DIFF
--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -40,6 +40,7 @@
 - 已按本地 reviewer 复核补齐 `ExecutionAttemptOutcome.terminal_envelope` 与 FR-0017 carrier 去重边界、`observability_write_failed` metric allowlist 边界，以及 execution-control runtime_contract 的真实 phase 投影。
 - 已按 guardian 第五轮审查补齐 success/lifecycle structured logs 与 minimal metrics、post-accepted failed signal 的 durable `task_record_ref` 重投影、retry-then-success 中间失败 signal 顶层持久化，以及 observability 同 ID identical replay / conflict fail-closed 约束。
 - 已按 guardian 第六轮审查补齐 repeated identical retry failure 的 per-attempt signal identity，以及 failed terminal path 的 attempt lifecycle log/metric 保留。
+- 已按 guardian 第七轮审查收敛 FR-0017 注入边界、`envelope_ref` occurrence identity，以及 durable observability carrier 枚举校验。
 
 ## 下一步动作
 
@@ -72,6 +73,7 @@
   - 本地 reviewer 复核修复后结果：通过，`Ran 13 tests`，`OK`。
 - guardian 第五轮 review-sync 后结果：通过，`Ran 13 tests`，`OK`。
   - guardian 第六轮 review-sync 后结果：通过，`Ran 14 tests`，`OK`。
+  - guardian 第七轮 review-sync 后结果：通过，`Ran 15 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
   - 初始结果：通过，`Ran 161 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
@@ -82,23 +84,27 @@
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability tests.runtime.test_task_record`
   - guardian 第五轮 review-sync 后结果：通过，`Ran 190 tests`，`OK`。
   - guardian 第六轮 review-sync 后结果：通过，`Ran 191 tests`，`OK`。
+  - guardian 第七轮 review-sync 后结果：通过，`Ran 193 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - 本地 reviewer 复核修复后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第五轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第六轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第七轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
   - guardian 第五轮 review-sync 后结果：通过。
   - guardian 第六轮 review-sync 后结果：通过。
+  - guardian 第七轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
   - guardian 第五轮 review-sync 后结果：通过。
   - guardian 第六轮 review-sync 后结果：通过。
+  - guardian 第七轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -139,6 +145,11 @@
 - 已处理阻断项：
   - `RuntimeFailureSignal.signal_id`、`task_failed` log id 与 failed metric id 纳入 `attempt_index`，同一 task 中重复相同 retryable failure 会保留不同 occurrence 的 signal，不触发同 ID 不同 payload 冲突。
   - failed path 的 `with_failure_observability` 保留已有 `attempt_started` / `attempt_finished` structured logs 与 `attempt_started_total` / `execution_duration_ms` metrics，确保失败终态 durable carrier 不丢 attempt lifecycle evidence。
+- PR `#249` 第七次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `failure_envelope(...)` 重新收敛为纯 shared failed envelope helper，不再无条件注入 FR-0017 carrier；runtime 主路径通过 `pre_accepted_failure_envelope`、`with_runtime_observability` 与 `finalize_task_execution_result` 显式投影 observability。
+  - `RuntimeFailureSignal.envelope_ref` 增加 attempt occurrence 维度，与 repeated identical failures 的 per-attempt `signal_id` 对齐。
+  - `TaskRecord` durable observability carrier 校验固定枚举与语义：`failure_phase`、`event_type`、`level`、`metric_name`、metric unit/value、上下文绑定和失败日志 signal 引用。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -36,11 +36,11 @@
 - 当前主干基线为 `3c57ec6ce6437b0e810645b104fd85d6bf1235ba`，已包含 `FR-0016` closeout。
 - 已在 runtime helper 层为 failed envelope 投影最小 failure signal、structured log event 与 metric sample。
 - 已扩展 `TaskRecord` JSON-safe durable fields：`runtime_failure_signals`、`runtime_structured_log_events`、`runtime_execution_metric_samples`。
-- guardian 初审要求补齐 pre-accepted failure、admission concurrency control ref、retry scheduling、persistence phase 与 resource trace refs 五类 FR-0017 关联 truth；当前修复已落到同一 Core path。
+- guardian 多轮审查要求补齐 pre-accepted failure、admission concurrency control ref、retry scheduling、persistence phase、resource trace refs、success envelope 边界与 observability write failure 保留语义；当前修复已落到同一 Core path。
 
 ## 下一步动作
 
-- 推送 guardian review-sync 修复提交。
+- 推送第四轮 guardian review-sync 修复提交。
 - 重跑 CI、guardian、merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
@@ -64,15 +64,21 @@
   - guardian review-sync 后结果：通过，`Ran 8 tests`，`OK`。
   - guardian 第二轮 review-sync 后结果：通过，`Ran 9 tests`，`OK`。
   - guardian 第三轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
+  - guardian 第四轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
   - 初始结果：通过，`Ran 161 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
   - guardian 第二轮 review-sync 后结果：通过，`Ran 165 tests`，`OK`。
   - guardian 第三轮 review-sync 后结果：通过，`Ran 167 tests`，`OK`。
+  - guardian 第四轮 review-sync 后结果：通过，`Ran 167 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
+  - guardian 第四轮 review-sync 后结果：通过。
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - guardian 第四轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -93,6 +99,11 @@
   - failed observability 默认 `task_record_ref=none`；进入 accepted/running/attempt 后由 runtime/finalize 明确补 `task_record:{task_id}`。
   - failed terminal persistence / completion observability 写入失败时保留原业务 failed envelope，并追加 `observability_write_failed` structured log / metric。
   - retry-then-success 的 `retry_scheduled` log/metric 只持久化到 `TaskRecord` 顶层 carrier，success result envelope 不新增 FR-0017 字段。
+- PR `#249` 第四次 guardian 结论：`REQUEST_CHANGES`，本地结果已写入 guardian cache，但 GitHub comment 因 GraphQL 配额耗尽未完成发布。
+- 已处理阻断项：
+  - retry-then-success 的内部 `_runtime_structured_log_events` / `_runtime_execution_metric_samples` 仅作为 `TaskRecord` 顶层持久化输入，`execute_task` / `execute_task_with_record` 公共 success envelope 返回前剥离私有字段。
+  - failure observability 重建时保留 `retry_scheduled` 与 `observability_write_failed` lifecycle carrier，避免 completion-time observability write failure 被后续投影覆盖。
+  - admission guard release failure 按 durable accepted 边界设置 `task_record_ref`：accepted 前为 `none`，accepted 后为 `task_record:{task_id}`。
 
 ## 未决风险
 
@@ -111,4 +122,5 @@
 - guardian review-sync 可恢复 checkpoint：`9a1239e70f1ff76580ee3a0775815d9a7cdf5ffd`。
 - guardian 第二轮 review-sync 可恢复 checkpoint：`3b2883728374972d02637d1e0e61a63306bbd549`。
 - guardian 第三轮 review-sync 可恢复 checkpoint：`288c26667e98a74e38feea26a777885fb093f98c`。
+- guardian 第四轮 review-sync 可恢复 checkpoint：`9ba4cf56f7837d24307227ec1db12101cba6fe66`。
 - 本次追加 checkpoint 元数据属于 `metadata-only review sync`，不推进新的 runtime / formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -1,0 +1,85 @@
+# CHORE-0151 FR-0017 failure/log/metrics runtime 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0151-fr-0017-failure-logs-metrics-runtime`
+- Issue：`#227`
+- item_type：`CHORE`
+- release：`v0.6.0`
+- sprint：`2026-S19`
+- 父 FR：`#220`
+- 关联 spec：`docs/specs/FR-0017-runtime-failure-observability/`
+- 状态：`active`
+
+## 目标
+
+- 在 `FR-0017` 边界内实现最小 runtime observability carrier：`RuntimeFailureSignal`、`RuntimeStructuredLogEvent`、`RuntimeExecutionMetricSample`。
+- 失败分类从 shared failed envelope 投影，不新增第二套错误 taxonomy，不改写 success `raw` / `normalized` payload。
+- 将 carrier 落到同一 Core path 与 durable `TaskRecord` truth，供 CLI / HTTP / review / gate 后续消费。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py`
+  - `syvert/task_record.py`
+  - `tests/runtime/test_runtime_observability.py`
+  - `docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md`
+- 本次不纳入：
+  - 外部日志后端、metrics backend、dashboard、OpenTelemetry / Prometheus 集成
+  - adapter 私有平台 taxonomy
+  - success envelope contract 改写
+  - `FR-0019/#234` gate matrix
+
+## 当前停点
+
+- 已通过 `python3 scripts/create_worktree.py --issue 227 --class implementation` 创建 worktree：`/Users/mc/code/worktrees/syvert/issue-227-fr-0017`。
+- 当前主干基线为 `3c57ec6ce6437b0e810645b104fd85d6bf1235ba`，已包含 `FR-0016` closeout。
+- 已在 runtime helper 层为 failed envelope 投影最小 failure signal、structured log event 与 metric sample。
+- 已扩展 `TaskRecord` JSON-safe durable fields：`runtime_failure_signals`、`runtime_structured_log_events`、`runtime_execution_metric_samples`。
+- 当前实现保持 success envelope 不新增 observability 字段。
+
+## 下一步动作
+
+- 跑完整本地验证矩阵。
+- 创建 PR，绑定 `#227` / `CHORE-0151-fr-0017-failure-logs-metrics-runtime`。
+- 通过 CI、guardian、merge gate 后 squash merge。
+- 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.6.0` 提供 `failure_log_metrics` 维度 runtime evidence，使后续 `FR-0019/#234` gate matrix 可以消费可复验 observability carrier。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`FR-0017` implementation Work Item。
+- 阻塞：
+  - `#228` parent closeout 依赖本事项实现与 PR 合入。
+  - `#234` operability gate matrix 的 `failure_log_metrics` 维度依赖本事项 runtime evidence。
+
+## 已验证项
+
+- `python3 -m py_compile syvert/runtime.py syvert/task_record.py tests/runtime/test_runtime_observability.py`
+  - 结果：通过。
+- `python3 -m unittest tests.runtime.test_runtime_observability -v`
+  - 结果：通过，`Ran 5 tests`，`OK`。
+- `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
+  - 结果：通过，`Ran 161 tests`，`OK`。
+- `python3 -m unittest discover -s tests`
+  - 结果：通过，`Ran 376 tests`，`OK`。
+- `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
+  - 结果：通过。
+
+## 未决风险
+
+- 当前 metrics / logs 是 JSON-safe local carrier，不是持久化指标后端。
+- 当前 structured log event 使用最小事件集合；更完整的 retry lifecycle、duration metrics 或 observability-write failure 注入测试可在后续 gate / closeout 中扩展。
+- `TaskRecord` 新字段保持 additive；旧记录缺字段时按空数组解析。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销 `syvert/runtime.py`、`syvert/task_record.py`、`tests/runtime/test_runtime_observability.py` 与本 exec-plan 的增量。
+- 不回滚 `FR-0017` formal spec，不修改 `FR-0016` / `FR-0018` / `FR-0019` 边界。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `3c57ec6ce6437b0e810645b104fd85d6bf1235ba` 为开始实现时的主干基线。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -38,10 +38,12 @@
 - 已扩展 `TaskRecord` JSON-safe durable fields：`runtime_failure_signals`、`runtime_structured_log_events`、`runtime_execution_metric_samples`。
 - guardian 多轮审查要求补齐 pre-accepted failure、admission concurrency control ref、retry scheduling、persistence phase、resource trace refs、success envelope 边界与 observability write failure 保留语义；当前修复已落到同一 Core path。
 - 已按本地 reviewer 复核补齐 `ExecutionAttemptOutcome.terminal_envelope` 与 FR-0017 carrier 去重边界、`observability_write_failed` metric allowlist 边界，以及 execution-control runtime_contract 的真实 phase 投影。
+- 已按 guardian 第五轮审查补齐 success/lifecycle structured logs 与 minimal metrics、post-accepted failed signal 的 durable `task_record_ref` 重投影、retry-then-success 中间失败 signal 顶层持久化，以及 observability 同 ID identical replay / conflict fail-closed 约束。
 
 ## 下一步动作
 
 - 推送第四轮 guardian review-sync 修复提交。
+- 推送第五轮 guardian review-sync 修复提交。
 - 重跑 CI、guardian、merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
@@ -67,6 +69,7 @@
   - guardian 第三轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
   - 本地 reviewer 复核修复后结果：通过，`Ran 13 tests`，`OK`。
+  - guardian 第五轮 review-sync 后结果：通过，`Ran 13 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
   - 初始结果：通过，`Ran 161 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
@@ -74,17 +77,22 @@
   - guardian 第三轮 review-sync 后结果：通过，`Ran 167 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 167 tests`，`OK`。
   - 本地 reviewer 复核修复后结果：通过，`Ran 169 tests`，`OK`。
+- `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability tests.runtime.test_task_record`
+  - guardian 第五轮 review-sync 后结果：通过，`Ran 190 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - 本地 reviewer 复核修复后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第五轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
+  - guardian 第五轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
+  - guardian 第五轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -115,6 +123,12 @@
   - `ExecutionAttemptOutcome.terminal_envelope` 剥离 `runtime_failure_signal`、`runtime_structured_log_events`、`runtime_execution_metric_samples` 与内部私有 observability 字段，避免 attempt 快照和 canonical failed envelope 出现重复不一致 carrier。
   - `observability_write_failed` 仅作为 `RuntimeStructuredLogEvent` 暴露，不再生成未被 FR-0017 metric allowlist 批准的 `observability_write_failed_total`；该日志回指原业务 `RuntimeFailureSignal.signal_id` 并保留 resource trace refs。
   - 默认 execution-control policy 物化失败投影为 `failure_phase=pre_execution`；guarded admission 后 slot 消失投影为 `failure_phase=concurrency_rejected`，不再兜底成 `adapter_execution`。
+- PR `#249` 第五次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `TaskRecord` 顶层持久化 `task_accepted`、`task_running`、`attempt_started`、`attempt_finished`、`task_succeeded` lifecycle structured logs，以及 `task_started_total`、`attempt_started_total`、`task_succeeded_total`、`execution_duration_ms` minimal metrics；success envelope 仍不新增 FR-0017 公共字段。
+  - `finalize_task_execution_result` 在 post-accepted failed envelope 补入 durable `task_record_ref` 后重投影 failure signal/log/metric，避免 `error.details.task_record_ref` 与 `RuntimeFailureSignal.task_record_ref` 漂移。
+  - retry-then-success 会把中间失败的 `RuntimeFailureSignal` 持久化到 `TaskRecord.runtime_failure_signals` 顶层，使 `retry_scheduled.failure_signal_id` 有可追溯目标，同时不污染 success result envelope。
+  - `TaskRecord` 校验同一 `signal_id` / `event_id` / `metric_id` 的 identical replay；store reconciliation 只允许 terminal incoming observability 作为无冲突 superset 合入，冲突性同 ID payload fail-closed。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -101,4 +101,5 @@
 
 - `3c57ec6ce6437b0e810645b104fd85d6bf1235ba` 为开始实现时的主干基线。
 - guardian review-sync 可恢复 checkpoint：`9a1239e70f1ff76580ee3a0775815d9a7cdf5ffd`。
+- guardian 第二轮 review-sync 可恢复 checkpoint：`3b2883728374972d02637d1e0e61a63306bbd549`。
 - 本次追加 checkpoint 元数据属于 `metadata-only review sync`，不推进新的 runtime / formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -43,10 +43,11 @@
 - 已按 guardian 第七轮审查收敛 FR-0017 注入边界、`envelope_ref` occurrence identity，以及 durable observability carrier 枚举校验。
 - 已按 guardian 第八轮审查补齐 record lifecycle fail-closed 分支的 FR-0017 carrier，并收紧 failed log / metric 必填引用和错误元数据校验。
 - 已按 guardian 第九轮审查收窄 `retry_scheduled.runtime_result_refs` 至直接前因，并修正 terminal observability reconciliation 的 append-only superset 约束。
+- 已按 guardian 第十轮审查补齐 terminal-to-terminal observability superset 升级路径，并校验 durable observability refs 的 `ResourceTraceEvent` / `ExecutionAttemptOutcome` / `ExecutionControlEvent` 形状。
 
 ## 下一步动作
 
-- 推送第九轮 guardian review-sync 修复提交。
+- 推送第十轮 guardian review-sync 修复提交。
 - 等待 CI 重新全绿后重跑 guardian 与 merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
@@ -88,6 +89,7 @@
   - guardian 第七轮 review-sync 后结果：通过，`Ran 193 tests`，`OK`。
   - guardian 第八轮 review-sync 后结果：通过，`Ran 195 tests`，`OK`。
   - guardian 第九轮 review-sync 后结果：通过，`Ran 196 tests`，`OK`。
+  - guardian 第十轮 review-sync 后结果：通过，`Ran 197 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
@@ -97,6 +99,7 @@
   - guardian 第七轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第八轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第九轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第十轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
@@ -106,6 +109,7 @@
   - guardian 第七轮 review-sync 后结果：通过。
   - guardian 第八轮 review-sync 后结果：通过。
   - guardian 第九轮 review-sync 后结果：通过。
+  - guardian 第十轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
@@ -114,6 +118,7 @@
   - guardian 第七轮 review-sync 后结果：通过。
   - guardian 第八轮 review-sync 后结果：通过。
   - guardian 第九轮 review-sync 后结果：通过。
+  - guardian 第十轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -168,6 +173,10 @@
 - 已处理阻断项：
   - `retry_scheduled` structured log 的 `runtime_result_refs` 从累计 execution history 收窄为触发本次 retry 的直接 `ExecutionAttemptOutcome`，避免第二次及后续 retry 混入更早 attempt / control refs。
   - `LocalTaskRecordStore` terminal reconciliation 在同 ID 无冲突之外，进一步要求 incoming terminal observability 是 candidate durable observability 的 superset；较小子集不再能覆盖既有 lifecycle / metric truth。
+- PR `#249` 第十次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `LocalTaskRecordStore` 已对 existing terminal -> incoming terminal 的合法 observability superset 回写走同一 merge 逻辑，允许 legacy terminal record 无损升级新增顶层 carrier。
+  - `TaskRecord` durable validation 已校验 `RuntimeFailureSignal` / `RuntimeStructuredLogEvent` 中 `resource_trace_refs` 的 `ResourceTraceEvent` 形状，以及 `runtime_result_refs` 的 `ExecutionAttemptOutcome` / `ExecutionControlEvent` 形状、上下文绑定与时间字段。
 
 ## 未决风险
 
@@ -189,4 +198,5 @@
 - guardian 第四轮 review-sync 可恢复 checkpoint：`9ba4cf56f7837d24307227ec1db12101cba6fe66`。
 - guardian 第七轮 review-sync 可恢复 checkpoint：`8eb978c55a91143cb0c9fb975fe93bd8528b55c7`。
 - guardian 第八轮 review-sync 可恢复 checkpoint：`7339885287f2bb55b858fba96e5ad61302c04842`。
-- guardian 第九轮 review-sync 待提交；本轮不推进 formal spec 语义。
+- guardian 第九轮 review-sync 可恢复 checkpoint：`a0e0d2ccd9c4e91cd844d7bf89ca70075328172f`。
+- guardian 第十轮 review-sync 待提交；本轮不推进 formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -63,10 +63,12 @@
   - 初始结果：通过，`Ran 5 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 8 tests`，`OK`。
   - guardian 第二轮 review-sync 后结果：通过，`Ran 9 tests`，`OK`。
+  - guardian 第三轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
   - 初始结果：通过，`Ran 161 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
   - guardian 第二轮 review-sync 后结果：通过，`Ran 165 tests`，`OK`。
+  - guardian 第三轮 review-sync 后结果：通过，`Ran 167 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
@@ -85,6 +87,12 @@
 - 已处理阻断项：
   - failed envelope 再投影时只保留 `retry_scheduled` lifecycle carrier，并重建唯一一组 failure signal/log/metric，避免同一失败出现重复且不一致的 observability truth。
   - retry 成功路径只保留既有 `runtime_result_refs` 执行控制证据，不把 `runtime_failure_signal`、`runtime_structured_log_events` 或 `runtime_execution_metric_samples` 写入 success envelope。
+- PR `#249` 第三次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `failure_phase` 改为按明确 stage / event / error code 投影，避免用宽泛 error category 伪造阶段。
+  - failed observability 默认 `task_record_ref=none`；进入 accepted/running/attempt 后由 runtime/finalize 明确补 `task_record:{task_id}`。
+  - failed terminal persistence / completion observability 写入失败时保留原业务 failed envelope，并追加 `observability_write_failed` structured log / metric。
+  - retry-then-success 的 `retry_scheduled` log/metric 只持久化到 `TaskRecord` 顶层 carrier，success result envelope 不新增 FR-0017 字段。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -94,3 +94,5 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - `3c57ec6ce6437b0e810645b104fd85d6bf1235ba` 为开始实现时的主干基线。
+- guardian review-sync 可恢复 checkpoint：`9a1239e70f1ff76580ee3a0775815d9a7cdf5ffd`。
+- 本次追加 checkpoint 元数据属于 `metadata-only review sync`，不推进新的 runtime / formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -62,9 +62,11 @@
 - `python3 -m unittest tests.runtime.test_runtime_observability -v`
   - 初始结果：通过，`Ran 5 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 8 tests`，`OK`。
+  - guardian 第二轮 review-sync 后结果：通过，`Ran 9 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
   - 初始结果：通过，`Ran 161 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
+  - guardian 第二轮 review-sync 后结果：通过，`Ran 165 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
@@ -79,6 +81,10 @@
   - retry predicate 命中且预算允许时生成 `retry_scheduled` structured log 与 `retry_scheduled_total` metric，不新增 FR-0016 control event。
   - persistence / completion 写入失败投影 `failure_phase=persistence`。
   - 已 acquire 资源后的 failed envelope 注入 FR-0011 `resource_trace_refs`，并同步到 failure signal / structured log。
+- PR `#249` 第二次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - failed envelope 再投影时只保留 `retry_scheduled` lifecycle carrier，并重建唯一一组 failure signal/log/metric，避免同一失败出现重复且不一致的 observability truth。
+  - retry 成功路径只保留既有 `runtime_result_refs` 执行控制证据，不把 `runtime_failure_signal`、`runtime_structured_log_events` 或 `runtime_execution_metric_samples` 写入 success envelope。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -42,10 +42,11 @@
 - 已按 guardian 第六轮审查补齐 repeated identical retry failure 的 per-attempt signal identity，以及 failed terminal path 的 attempt lifecycle log/metric 保留。
 - 已按 guardian 第七轮审查收敛 FR-0017 注入边界、`envelope_ref` occurrence identity，以及 durable observability carrier 枚举校验。
 - 已按 guardian 第八轮审查补齐 record lifecycle fail-closed 分支的 FR-0017 carrier，并收紧 failed log / metric 必填引用和错误元数据校验。
+- 已按 guardian 第九轮审查收窄 `retry_scheduled.runtime_result_refs` 至直接前因，并修正 terminal observability reconciliation 的 append-only superset 约束。
 
 ## 下一步动作
 
-- 推送第八轮 guardian review-sync 修复提交。
+- 推送第九轮 guardian review-sync 修复提交。
 - 等待 CI 重新全绿后重跑 guardian 与 merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
@@ -86,6 +87,7 @@
   - guardian 第六轮 review-sync 后结果：通过，`Ran 191 tests`，`OK`。
   - guardian 第七轮 review-sync 后结果：通过，`Ran 193 tests`，`OK`。
   - guardian 第八轮 review-sync 后结果：通过，`Ran 195 tests`，`OK`。
+  - guardian 第九轮 review-sync 后结果：通过，`Ran 196 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
@@ -94,6 +96,7 @@
   - guardian 第六轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第七轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第八轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第九轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
@@ -102,6 +105,7 @@
   - guardian 第六轮 review-sync 后结果：通过。
   - guardian 第七轮 review-sync 后结果：通过。
   - guardian 第八轮 review-sync 后结果：通过。
+  - guardian 第九轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
@@ -109,6 +113,7 @@
   - guardian 第六轮 review-sync 后结果：通过。
   - guardian 第七轮 review-sync 后结果：通过。
   - guardian 第八轮 review-sync 后结果：通过。
+  - guardian 第九轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -159,6 +164,10 @@
   - record lifecycle fail-closed 分支统一注入 FR-0017 runtime observability：`create_task_record` 前失败走 pre-accepted carrier；`start_task_record` / running persistence 后失败走 durable `TaskRecord` completion finalize；success envelope 收口为 JSON-safe terminal record 失败时，转为 `runtime_contract/envelope_not_json_serializable` 并绑定 durable `task_record_ref`。
   - `TaskRecord` durable validation 明确拒绝 failed structured log 缺失或悬空 `failure_signal_id`，覆盖 `admission_concurrency_rejected`、`retry_concurrency_rejected`、`task_failed`、`timeout_triggered`、`retry_scheduled`、`observability_write_failed`。
   - `TaskRecord` durable validation 明确拒绝 failed metrics 缺失 `error_category/error_code/failure_phase`，覆盖 `task_failed_total`、`timeout_total`、`admission_concurrency_rejected_total`、`retry_concurrency_rejected_total`。
+- PR `#249` 第九次 guardian 结论：`REQUEST_CHANGES`；GitHub review comment 因 GraphQL quota exhausted 未发布，本地 JSON evidence 为 `/tmp/syvert-guardian-249-7339885.json`。
+- 已处理阻断项：
+  - `retry_scheduled` structured log 的 `runtime_result_refs` 从累计 execution history 收窄为触发本次 retry 的直接 `ExecutionAttemptOutcome`，避免第二次及后续 retry 混入更早 attempt / control refs。
+  - `LocalTaskRecordStore` terminal reconciliation 在同 ID 无冲突之外，进一步要求 incoming terminal observability 是 candidate durable observability 的 superset；较小子集不再能覆盖既有 lifecycle / metric truth。
 
 ## 未决风险
 
@@ -179,4 +188,5 @@
 - guardian 第三轮 review-sync 可恢复 checkpoint：`288c26667e98a74e38feea26a777885fb093f98c`。
 - guardian 第四轮 review-sync 可恢复 checkpoint：`9ba4cf56f7837d24307227ec1db12101cba6fe66`。
 - guardian 第七轮 review-sync 可恢复 checkpoint：`8eb978c55a91143cb0c9fb975fe93bd8528b55c7`。
-- guardian 第八轮 review-sync 待提交；本轮不推进 formal spec 语义。
+- guardian 第八轮 review-sync 可恢复 checkpoint：`7339885287f2bb55b858fba96e5ad61302c04842`。
+- guardian 第九轮 review-sync 待提交；本轮不推进 formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -36,13 +36,12 @@
 - 当前主干基线为 `3c57ec6ce6437b0e810645b104fd85d6bf1235ba`，已包含 `FR-0016` closeout。
 - 已在 runtime helper 层为 failed envelope 投影最小 failure signal、structured log event 与 metric sample。
 - 已扩展 `TaskRecord` JSON-safe durable fields：`runtime_failure_signals`、`runtime_structured_log_events`、`runtime_execution_metric_samples`。
-- 当前实现保持 success envelope 不新增 observability 字段。
+- guardian 初审要求补齐 pre-accepted failure、admission concurrency control ref、retry scheduling、persistence phase 与 resource trace refs 五类 FR-0017 关联 truth；当前修复已落到同一 Core path。
 
 ## 下一步动作
 
-- 跑完整本地验证矩阵。
-- 创建 PR，绑定 `#227` / `CHORE-0151-fr-0017-failure-logs-metrics-runtime`。
-- 通过 CI、guardian、merge gate 后 squash merge。
+- 推送 guardian review-sync 修复提交。
+- 重跑 CI、guardian、merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -61,18 +60,30 @@
 - `python3 -m py_compile syvert/runtime.py syvert/task_record.py tests/runtime/test_runtime_observability.py`
   - 结果：通过。
 - `python3 -m unittest tests.runtime.test_runtime_observability -v`
-  - 结果：通过，`Ran 5 tests`，`OK`。
+  - 初始结果：通过，`Ran 5 tests`，`OK`。
+  - guardian review-sync 后结果：通过，`Ran 8 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
-  - 结果：通过，`Ran 161 tests`，`OK`。
+  - 初始结果：通过，`Ran 161 tests`，`OK`。
+  - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
 
+## guardian review-sync
+
+- PR `#249` 初次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - pre-accepted failure 统一投影 `task_record_ref=none` 与 `stage=pre_admission`。
+  - admission concurrency rejection 的 `ExecutionControlEvent` 同步进入 `runtime_result_refs`。
+  - retry predicate 命中且预算允许时生成 `retry_scheduled` structured log 与 `retry_scheduled_total` metric，不新增 FR-0016 control event。
+  - persistence / completion 写入失败投影 `failure_phase=persistence`。
+  - 已 acquire 资源后的 failed envelope 注入 FR-0011 `resource_trace_refs`，并同步到 failure signal / structured log。
+
 ## 未决风险
 
 - 当前 metrics / logs 是 JSON-safe local carrier，不是持久化指标后端。
-- 当前 structured log event 使用最小事件集合；更完整的 retry lifecycle、duration metrics 或 observability-write failure 注入测试可在后续 gate / closeout 中扩展。
+- 当前 structured log event 使用最小事件集合；更完整的 duration metrics 或 observability-write failure 注入测试可在后续 gate / closeout 中扩展。
 - `TaskRecord` 新字段保持 additive；旧记录缺字段时按空数组解析。
 
 ## 回滚方式

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -41,12 +41,12 @@
 - 已按 guardian 第五轮审查补齐 success/lifecycle structured logs 与 minimal metrics、post-accepted failed signal 的 durable `task_record_ref` 重投影、retry-then-success 中间失败 signal 顶层持久化，以及 observability 同 ID identical replay / conflict fail-closed 约束。
 - 已按 guardian 第六轮审查补齐 repeated identical retry failure 的 per-attempt signal identity，以及 failed terminal path 的 attempt lifecycle log/metric 保留。
 - 已按 guardian 第七轮审查收敛 FR-0017 注入边界、`envelope_ref` occurrence identity，以及 durable observability carrier 枚举校验。
+- 已按 guardian 第八轮审查补齐 record lifecycle fail-closed 分支的 FR-0017 carrier，并收紧 failed log / metric 必填引用和错误元数据校验。
 
 ## 下一步动作
 
-- 推送第四轮 guardian review-sync 修复提交。
-- 推送第五轮 guardian review-sync 修复提交。
-- 重跑 CI、guardian、merge gate。
+- 推送第八轮 guardian review-sync 修复提交。
+- 等待 CI 重新全绿后重跑 guardian 与 merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -85,6 +85,7 @@
   - guardian 第五轮 review-sync 后结果：通过，`Ran 190 tests`，`OK`。
   - guardian 第六轮 review-sync 后结果：通过，`Ran 191 tests`，`OK`。
   - guardian 第七轮 review-sync 后结果：通过，`Ran 193 tests`，`OK`。
+  - guardian 第八轮 review-sync 后结果：通过，`Ran 195 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
@@ -92,6 +93,7 @@
   - guardian 第五轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第六轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第七轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第八轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
@@ -99,12 +101,14 @@
   - guardian 第五轮 review-sync 后结果：通过。
   - guardian 第六轮 review-sync 后结果：通过。
   - guardian 第七轮 review-sync 后结果：通过。
+  - guardian 第八轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
   - guardian 第五轮 review-sync 后结果：通过。
   - guardian 第六轮 review-sync 后结果：通过。
   - guardian 第七轮 review-sync 后结果：通过。
+  - guardian 第八轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -150,6 +154,11 @@
   - `failure_envelope(...)` 重新收敛为纯 shared failed envelope helper，不再无条件注入 FR-0017 carrier；runtime 主路径通过 `pre_accepted_failure_envelope`、`with_runtime_observability` 与 `finalize_task_execution_result` 显式投影 observability。
   - `RuntimeFailureSignal.envelope_ref` 增加 attempt occurrence 维度，与 repeated identical failures 的 per-attempt `signal_id` 对齐。
   - `TaskRecord` durable observability carrier 校验固定枚举与语义：`failure_phase`、`event_type`、`level`、`metric_name`、metric unit/value、上下文绑定和失败日志 signal 引用。
+- PR `#249` 第八次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - record lifecycle fail-closed 分支统一注入 FR-0017 runtime observability：`create_task_record` 前失败走 pre-accepted carrier；`start_task_record` / running persistence 后失败走 durable `TaskRecord` completion finalize；success envelope 收口为 JSON-safe terminal record 失败时，转为 `runtime_contract/envelope_not_json_serializable` 并绑定 durable `task_record_ref`。
+  - `TaskRecord` durable validation 明确拒绝 failed structured log 缺失或悬空 `failure_signal_id`，覆盖 `admission_concurrency_rejected`、`retry_concurrency_rejected`、`task_failed`、`timeout_triggered`、`retry_scheduled`、`observability_write_failed`。
+  - `TaskRecord` durable validation 明确拒绝 failed metrics 缺失 `error_category/error_code/failure_phase`，覆盖 `task_failed_total`、`timeout_total`、`admission_concurrency_rejected_total`、`retry_concurrency_rejected_total`。
 
 ## 未决风险
 
@@ -169,4 +178,5 @@
 - guardian 第二轮 review-sync 可恢复 checkpoint：`3b2883728374972d02637d1e0e61a63306bbd549`。
 - guardian 第三轮 review-sync 可恢复 checkpoint：`288c26667e98a74e38feea26a777885fb093f98c`。
 - guardian 第四轮 review-sync 可恢复 checkpoint：`9ba4cf56f7837d24307227ec1db12101cba6fe66`。
-- 本次追加 checkpoint 元数据属于 `metadata-only review sync`，不推进新的 runtime / formal spec 语义。
+- guardian 第七轮 review-sync 可恢复 checkpoint：`8eb978c55a91143cb0c9fb975fe93bd8528b55c7`。
+- guardian 第八轮 review-sync 待提交；本轮不推进 formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -46,10 +46,11 @@
 - 已按 guardian 第十轮审查补齐 terminal-to-terminal observability superset 升级路径，并校验 durable observability refs 的 `ResourceTraceEvent` / `ExecutionAttemptOutcome` / `ExecutionControlEvent` 形状。
 - 已按 guardian 第十一轮审查补齐 post-accepted persistence failure 的 durable `task_record_ref` 绑定，以及 retry reacquire TOCTOU 分支的 `retry_concurrency_rejected` event 回传。
 - 已按 guardian 第十二轮审查收敛 failure phase 推断：post-accepted adapter-attempt `invalid_input` 不再伪装成 admission，timeout closeout/control-state `runtime_contract` 不再计入正常 timeout observability。
+- 已按 guardian 第十三轮审查修复 retry-concurrency rejection 外层归并：当前 attempt 若已有 cleanup/runtime-contract failure，不再被上一 attempt 的业务失败覆盖。
 
 ## 下一步动作
 
-- 推送第十二轮 guardian review-sync 修复提交。
+- 推送第十三轮 guardian review-sync 修复提交。
 - 等待 CI 重新全绿后重跑 guardian 与 merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
@@ -94,6 +95,7 @@
   - guardian 第十轮 review-sync 后结果：通过，`Ran 197 tests`，`OK`。
   - guardian 第十一轮 review-sync 后结果：通过，`Ran 197 tests`，`OK`。
   - guardian 第十二轮 review-sync 后结果：通过，`Ran 198 tests`，`OK`。
+  - guardian 第十三轮 review-sync 后结果：通过，`Ran 199 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
@@ -106,6 +108,7 @@
   - guardian 第十轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第十一轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第十二轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第十三轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
@@ -118,6 +121,7 @@
   - guardian 第十轮 review-sync 后结果：通过。
   - guardian 第十一轮 review-sync 后结果：通过。
   - guardian 第十二轮 review-sync 后结果：通过。
+  - guardian 第十三轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
@@ -129,6 +133,7 @@
   - guardian 第十轮 review-sync 后结果：通过。
   - guardian 第十一轮 review-sync 后结果：通过。
   - guardian 第十二轮 review-sync 后结果：通过。
+  - guardian 第十三轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -195,6 +200,10 @@
 - 已处理阻断项：
   - `infer_failure_phase` 不再用 `error.category=invalid_input/unsupported` 兜底成 admission；已 accepted/running 的 adapter-attempt 失败默认保持 `adapter_execution`，pre-admission 仍由显式 `details.stage=pre_admission` 表达。
   - timeout observability 只对正常 `platform/execution_timeout` 且 `details.control_code=execution_timeout` 投影 `timeout` / `timeout_triggered` / `timeout_total`；timeout closeout/control-state 的 `runtime_contract/execution_control_state_invalid` 保持普通 task failure 观测。
+- PR `#249` 第十三次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `execute_controlled_adapter_attempts` 只在当前 envelope 是合成的 guarded-admission retry concurrency wrapper 时，才用上一 attempt 的 failed envelope 追加 control details。
+  - 当第二次 retry reacquire slot 丢失且资源 cleanup 返回真实 runtime-contract failure 时，最终 envelope 保留当前 cleanup failure，同时仍携带 `retry_concurrency_rejected` control event / refs。
 
 ## 未决风险
 
@@ -219,4 +228,5 @@
 - guardian 第九轮 review-sync 可恢复 checkpoint：`a0e0d2ccd9c4e91cd844d7bf89ca70075328172f`。
 - guardian 第十轮 review-sync 可恢复 checkpoint：`6ffeb01aedad08f9c9fb12a2f89a77fd379275c4`。
 - guardian 第十一轮 review-sync 可恢复 checkpoint：`5b2f207da7390776b3bdd094b7995461642dc20d`。
-- guardian 第十二轮 review-sync 待提交；本轮不推进 formal spec 语义。
+- guardian 第十二轮 review-sync 可恢复 checkpoint：`d48ef1c0595ae49e15b807d5854b46aa202d0619`。
+- guardian 第十三轮 review-sync 待提交；本轮不推进 formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -39,6 +39,7 @@
 - guardian 多轮审查要求补齐 pre-accepted failure、admission concurrency control ref、retry scheduling、persistence phase、resource trace refs、success envelope 边界与 observability write failure 保留语义；当前修复已落到同一 Core path。
 - 已按本地 reviewer 复核补齐 `ExecutionAttemptOutcome.terminal_envelope` 与 FR-0017 carrier 去重边界、`observability_write_failed` metric allowlist 边界，以及 execution-control runtime_contract 的真实 phase 投影。
 - 已按 guardian 第五轮审查补齐 success/lifecycle structured logs 与 minimal metrics、post-accepted failed signal 的 durable `task_record_ref` 重投影、retry-then-success 中间失败 signal 顶层持久化，以及 observability 同 ID identical replay / conflict fail-closed 约束。
+- 已按 guardian 第六轮审查补齐 repeated identical retry failure 的 per-attempt signal identity，以及 failed terminal path 的 attempt lifecycle log/metric 保留。
 
 ## 下一步动作
 
@@ -69,7 +70,8 @@
   - guardian 第三轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
   - 本地 reviewer 复核修复后结果：通过，`Ran 13 tests`，`OK`。
-  - guardian 第五轮 review-sync 后结果：通过，`Ran 13 tests`，`OK`。
+- guardian 第五轮 review-sync 后结果：通过，`Ran 13 tests`，`OK`。
+  - guardian 第六轮 review-sync 后结果：通过，`Ran 14 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
   - 初始结果：通过，`Ran 161 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
@@ -79,20 +81,24 @@
   - 本地 reviewer 复核修复后结果：通过，`Ran 169 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability tests.runtime.test_task_record`
   - guardian 第五轮 review-sync 后结果：通过，`Ran 190 tests`，`OK`。
+  - guardian 第六轮 review-sync 后结果：通过，`Ran 191 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - 本地 reviewer 复核修复后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第五轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第六轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
   - guardian 第五轮 review-sync 后结果：通过。
+  - guardian 第六轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
   - guardian 第五轮 review-sync 后结果：通过。
+  - guardian 第六轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -129,6 +135,10 @@
   - `finalize_task_execution_result` 在 post-accepted failed envelope 补入 durable `task_record_ref` 后重投影 failure signal/log/metric，避免 `error.details.task_record_ref` 与 `RuntimeFailureSignal.task_record_ref` 漂移。
   - retry-then-success 会把中间失败的 `RuntimeFailureSignal` 持久化到 `TaskRecord.runtime_failure_signals` 顶层，使 `retry_scheduled.failure_signal_id` 有可追溯目标，同时不污染 success result envelope。
   - `TaskRecord` 校验同一 `signal_id` / `event_id` / `metric_id` 的 identical replay；store reconciliation 只允许 terminal incoming observability 作为无冲突 superset 合入，冲突性同 ID payload fail-closed。
+- PR `#249` 第六次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `RuntimeFailureSignal.signal_id`、`task_failed` log id 与 failed metric id 纳入 `attempt_index`，同一 task 中重复相同 retryable failure 会保留不同 occurrence 的 signal，不触发同 ID 不同 payload 冲突。
+  - failed path 的 `with_failure_observability` 保留已有 `attempt_started` / `attempt_finished` structured logs 与 `attempt_started_total` / `execution_duration_ms` metrics，确保失败终态 durable carrier 不丢 attempt lifecycle evidence。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -37,6 +37,7 @@
 - 已在 runtime helper 层为 failed envelope 投影最小 failure signal、structured log event 与 metric sample。
 - 已扩展 `TaskRecord` JSON-safe durable fields：`runtime_failure_signals`、`runtime_structured_log_events`、`runtime_execution_metric_samples`。
 - guardian 多轮审查要求补齐 pre-accepted failure、admission concurrency control ref、retry scheduling、persistence phase、resource trace refs、success envelope 边界与 observability write failure 保留语义；当前修复已落到同一 Core path。
+- 已按本地 reviewer 复核补齐 `ExecutionAttemptOutcome.terminal_envelope` 与 FR-0017 carrier 去重边界、`observability_write_failed` metric allowlist 边界，以及 execution-control runtime_contract 的真实 phase 投影。
 
 ## 下一步动作
 
@@ -65,20 +66,25 @@
   - guardian 第二轮 review-sync 后结果：通过，`Ran 9 tests`，`OK`。
   - guardian 第三轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 11 tests`，`OK`。
+  - 本地 reviewer 复核修复后结果：通过，`Ran 13 tests`，`OK`。
 - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability`
   - 初始结果：通过，`Ran 161 tests`，`OK`。
   - guardian review-sync 后结果：通过，`Ran 164 tests`，`OK`。
   - guardian 第二轮 review-sync 后结果：通过，`Ran 165 tests`，`OK`。
   - guardian 第三轮 review-sync 后结果：通过，`Ran 167 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 167 tests`，`OK`。
+  - 本地 reviewer 复核修复后结果：通过，`Ran 169 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - 本地 reviewer 复核修复后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
+  - 本地 reviewer 复核修复后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
+  - 本地 reviewer 复核修复后结果：通过。
 
 ## guardian review-sync
 
@@ -104,6 +110,11 @@
   - retry-then-success 的内部 `_runtime_structured_log_events` / `_runtime_execution_metric_samples` 仅作为 `TaskRecord` 顶层持久化输入，`execute_task` / `execute_task_with_record` 公共 success envelope 返回前剥离私有字段。
   - failure observability 重建时保留 `retry_scheduled` 与 `observability_write_failed` lifecycle carrier，避免 completion-time observability write failure 被后续投影覆盖。
   - admission guard release failure 按 durable accepted 边界设置 `task_record_ref`：accepted 前为 `none`，accepted 后为 `task_record:{task_id}`。
+- PR `#249` 第四轮后本地 reviewer 复核发现 3 个潜在阻断点。
+- 已处理复核项：
+  - `ExecutionAttemptOutcome.terminal_envelope` 剥离 `runtime_failure_signal`、`runtime_structured_log_events`、`runtime_execution_metric_samples` 与内部私有 observability 字段，避免 attempt 快照和 canonical failed envelope 出现重复不一致 carrier。
+  - `observability_write_failed` 仅作为 `RuntimeStructuredLogEvent` 暴露，不再生成未被 FR-0017 metric allowlist 批准的 `observability_write_failed_total`；该日志回指原业务 `RuntimeFailureSignal.signal_id` 并保留 resource trace refs。
+  - 默认 execution-control policy 物化失败投影为 `failure_phase=pre_execution`；guarded admission 后 slot 消失投影为 `failure_phase=concurrency_rejected`，不再兜底成 `adapter_execution`。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -45,10 +45,11 @@
 - 已按 guardian 第九轮审查收窄 `retry_scheduled.runtime_result_refs` 至直接前因，并修正 terminal observability reconciliation 的 append-only superset 约束。
 - 已按 guardian 第十轮审查补齐 terminal-to-terminal observability superset 升级路径，并校验 durable observability refs 的 `ResourceTraceEvent` / `ExecutionAttemptOutcome` / `ExecutionControlEvent` 形状。
 - 已按 guardian 第十一轮审查补齐 post-accepted persistence failure 的 durable `task_record_ref` 绑定，以及 retry reacquire TOCTOU 分支的 `retry_concurrency_rejected` event 回传。
+- 已按 guardian 第十二轮审查收敛 failure phase 推断：post-accepted adapter-attempt `invalid_input` 不再伪装成 admission，timeout closeout/control-state `runtime_contract` 不再计入正常 timeout observability。
 
 ## 下一步动作
 
-- 推送第十一轮 guardian review-sync 修复提交。
+- 推送第十二轮 guardian review-sync 修复提交。
 - 等待 CI 重新全绿后重跑 guardian 与 merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
@@ -92,6 +93,7 @@
   - guardian 第九轮 review-sync 后结果：通过，`Ran 196 tests`，`OK`。
   - guardian 第十轮 review-sync 后结果：通过，`Ran 197 tests`，`OK`。
   - guardian 第十一轮 review-sync 后结果：通过，`Ran 197 tests`，`OK`。
+  - guardian 第十二轮 review-sync 后结果：通过，`Ran 198 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
@@ -103,6 +105,7 @@
   - guardian 第九轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第十轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第十一轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第十二轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
@@ -114,6 +117,7 @@
   - guardian 第九轮 review-sync 后结果：通过。
   - guardian 第十轮 review-sync 后结果：通过。
   - guardian 第十一轮 review-sync 后结果：通过。
+  - guardian 第十二轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
@@ -124,6 +128,7 @@
   - guardian 第九轮 review-sync 后结果：通过。
   - guardian 第十轮 review-sync 后结果：通过。
   - guardian 第十一轮 review-sync 后结果：通过。
+  - guardian 第十二轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -186,6 +191,10 @@
 - 已处理阻断项：
   - `persist_task_record` 的 post-accepted `running` / `completion` conflict 与 persistence failure 分支会把 durable `task_record_ref` 写回 failed envelope details，再投影到 `RuntimeFailureSignal.task_record_ref`，避免退化为 `none`。
   - retry 重新获取并发 slot 的 guarded admission TOCTOU 分支会把已构造的 `retry_concurrency_rejected` `ExecutionControlEvent` 传回上层，使最终 failed envelope 保留 `runtime_result_refs`、`execution_control_events`、结构化日志与指标。
+- PR `#249` 第十二次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `infer_failure_phase` 不再用 `error.category=invalid_input/unsupported` 兜底成 admission；已 accepted/running 的 adapter-attempt 失败默认保持 `adapter_execution`，pre-admission 仍由显式 `details.stage=pre_admission` 表达。
+  - timeout observability 只对正常 `platform/execution_timeout` 且 `details.control_code=execution_timeout` 投影 `timeout` / `timeout_triggered` / `timeout_total`；timeout closeout/control-state 的 `runtime_contract/execution_control_state_invalid` 保持普通 task failure 观测。
 
 ## 未决风险
 
@@ -209,4 +218,5 @@
 - guardian 第八轮 review-sync 可恢复 checkpoint：`7339885287f2bb55b858fba96e5ad61302c04842`。
 - guardian 第九轮 review-sync 可恢复 checkpoint：`a0e0d2ccd9c4e91cd844d7bf89ca70075328172f`。
 - guardian 第十轮 review-sync 可恢复 checkpoint：`6ffeb01aedad08f9c9fb12a2f89a77fd379275c4`。
-- guardian 第十一轮 review-sync 待提交；本轮不推进 formal spec 语义。
+- guardian 第十一轮 review-sync 可恢复 checkpoint：`5b2f207da7390776b3bdd094b7995461642dc20d`。
+- guardian 第十二轮 review-sync 待提交；本轮不推进 formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -44,10 +44,11 @@
 - 已按 guardian 第八轮审查补齐 record lifecycle fail-closed 分支的 FR-0017 carrier，并收紧 failed log / metric 必填引用和错误元数据校验。
 - 已按 guardian 第九轮审查收窄 `retry_scheduled.runtime_result_refs` 至直接前因，并修正 terminal observability reconciliation 的 append-only superset 约束。
 - 已按 guardian 第十轮审查补齐 terminal-to-terminal observability superset 升级路径，并校验 durable observability refs 的 `ResourceTraceEvent` / `ExecutionAttemptOutcome` / `ExecutionControlEvent` 形状。
+- 已按 guardian 第十一轮审查补齐 post-accepted persistence failure 的 durable `task_record_ref` 绑定，以及 retry reacquire TOCTOU 分支的 `retry_concurrency_rejected` event 回传。
 
 ## 下一步动作
 
-- 推送第十轮 guardian review-sync 修复提交。
+- 推送第十一轮 guardian review-sync 修复提交。
 - 等待 CI 重新全绿后重跑 guardian 与 merge gate。
 - 合入后同步 `#227` issue / Project 状态，并进入 `#228` parent closeout。
 
@@ -90,6 +91,7 @@
   - guardian 第八轮 review-sync 后结果：通过，`Ran 195 tests`，`OK`。
   - guardian 第九轮 review-sync 后结果：通过，`Ran 196 tests`，`OK`。
   - guardian 第十轮 review-sync 后结果：通过，`Ran 197 tests`，`OK`。
+  - guardian 第十一轮 review-sync 后结果：通过，`Ran 197 tests`，`OK`。
 - `python3 -m unittest discover -s tests`
   - 结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第四轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
@@ -100,6 +102,7 @@
   - guardian 第八轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第九轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
   - guardian 第十轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
+  - guardian 第十一轮 review-sync 后结果：通过，`Ran 376 tests`，`OK`。
 - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
   - 结果：通过。
   - guardian 第四轮 review-sync 后结果：通过。
@@ -110,6 +113,7 @@
   - guardian 第八轮 review-sync 后结果：通过。
   - guardian 第九轮 review-sync 后结果：通过。
   - guardian 第十轮 review-sync 后结果：通过。
+  - guardian 第十一轮 review-sync 后结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - guardian 第四轮 review-sync 后结果：通过。
   - 本地 reviewer 复核修复后结果：通过。
@@ -119,6 +123,7 @@
   - guardian 第八轮 review-sync 后结果：通过。
   - guardian 第九轮 review-sync 后结果：通过。
   - guardian 第十轮 review-sync 后结果：通过。
+  - guardian 第十一轮 review-sync 后结果：通过。
 
 ## guardian review-sync
 
@@ -177,6 +182,10 @@
 - 已处理阻断项：
   - `LocalTaskRecordStore` 已对 existing terminal -> incoming terminal 的合法 observability superset 回写走同一 merge 逻辑，允许 legacy terminal record 无损升级新增顶层 carrier。
   - `TaskRecord` durable validation 已校验 `RuntimeFailureSignal` / `RuntimeStructuredLogEvent` 中 `resource_trace_refs` 的 `ResourceTraceEvent` 形状，以及 `runtime_result_refs` 的 `ExecutionAttemptOutcome` / `ExecutionControlEvent` 形状、上下文绑定与时间字段。
+- PR `#249` 第十一次 guardian 结论：`REQUEST_CHANGES`。
+- 已处理阻断项：
+  - `persist_task_record` 的 post-accepted `running` / `completion` conflict 与 persistence failure 分支会把 durable `task_record_ref` 写回 failed envelope details，再投影到 `RuntimeFailureSignal.task_record_ref`，避免退化为 `none`。
+  - retry 重新获取并发 slot 的 guarded admission TOCTOU 分支会把已构造的 `retry_concurrency_rejected` `ExecutionControlEvent` 传回上层，使最终 failed envelope 保留 `runtime_result_refs`、`execution_control_events`、结构化日志与指标。
 
 ## 未决风险
 
@@ -199,4 +208,5 @@
 - guardian 第七轮 review-sync 可恢复 checkpoint：`8eb978c55a91143cb0c9fb975fe93bd8528b55c7`。
 - guardian 第八轮 review-sync 可恢复 checkpoint：`7339885287f2bb55b858fba96e5ad61302c04842`。
 - guardian 第九轮 review-sync 可恢复 checkpoint：`a0e0d2ccd9c4e91cd844d7bf89ca70075328172f`。
-- guardian 第十轮 review-sync 待提交；本轮不推进 formal spec 语义。
+- guardian 第十轮 review-sync 可恢复 checkpoint：`6ffeb01aedad08f9c9fb12a2f89a77fd379275c4`。
+- guardian 第十一轮 review-sync 待提交；本轮不推进 formal spec 语义。

--- a/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
+++ b/docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md
@@ -110,4 +110,5 @@
 - `3c57ec6ce6437b0e810645b104fd85d6bf1235ba` 为开始实现时的主干基线。
 - guardian review-sync 可恢复 checkpoint：`9a1239e70f1ff76580ee3a0775815d9a7cdf5ffd`。
 - guardian 第二轮 review-sync 可恢复 checkpoint：`3b2883728374972d02637d1e0e61a63306bbd549`。
+- guardian 第三轮 review-sync 可恢复 checkpoint：`288c26667e98a74e38feea26a777885fb093f98c`。
 - 本次追加 checkpoint 元数据属于 `metadata-only review sync`，不推进新的 runtime / formal spec 语义。

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -303,14 +303,14 @@ def execute_task_internal(
     adapter_key, capability = extract_request_context(request)
     task_id, task_id_error = resolve_task_id(task_id_factory)
     if task_id_error is not None:
-        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, task_id_error), None)
+        return TaskExecutionResult(pre_accepted_failure_envelope(task_id, adapter_key, capability, task_id_error), None)
 
     normalized_request, contract_error = normalize_request(request)
     if contract_error is not None:
-        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, contract_error), None)
+        return TaskExecutionResult(pre_accepted_failure_envelope(task_id, adapter_key, capability, contract_error), None)
     if normalized_request is None:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -323,10 +323,13 @@ def execute_task_internal(
     capability = normalized_request.target.capability
     capability_family, capability_family_error = resolve_capability_family(capability)
     if capability_family_error is not None:
-        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, capability_family_error), None)
+        return TaskExecutionResult(
+            pre_accepted_failure_envelope(task_id, adapter_key, capability, capability_family_error),
+            None,
+        )
     if capability_family is None:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -337,7 +340,10 @@ def execute_task_internal(
 
     projection_axis_error = validate_projection_axes_for_current_runtime(normalized_request)
     if projection_axis_error is not None:
-        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, projection_axis_error), None)
+        return TaskExecutionResult(
+            pre_accepted_failure_envelope(task_id, adapter_key, capability, projection_axis_error),
+            None,
+        )
 
     try:
         registry = AdapterRegistry.from_mapping(adapters)
@@ -349,7 +355,7 @@ def execute_task_internal(
         )
         if requested_resource_requirement_error is not None:
             return TaskExecutionResult(
-                failure_envelope(
+                pre_accepted_failure_envelope(
                     task_id,
                     adapter_key,
                     capability,
@@ -358,7 +364,7 @@ def execute_task_internal(
                 None,
             )
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -374,7 +380,7 @@ def execute_task_internal(
     adapter_declaration = registry.lookup(adapter_key)
     if adapter_declaration is None:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -386,7 +392,7 @@ def execute_task_internal(
     supported_capabilities = adapter_declaration.supported_capabilities
     if capability_family not in supported_capabilities:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -405,7 +411,7 @@ def execute_task_internal(
     supported_targets = adapter_declaration.supported_targets
     if normalized_request.target.target_type not in supported_targets:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -421,7 +427,7 @@ def execute_task_internal(
     supported_collection_modes = adapter_declaration.supported_collection_modes
     if normalized_request.policy.collection_mode not in supported_collection_modes:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -437,7 +443,7 @@ def execute_task_internal(
     resource_requirement_declaration = registry.lookup_resource_requirement(adapter_key, capability_family)
     if resource_requirement_declaration is None:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -462,7 +468,7 @@ def execute_task_internal(
         )
     except ResourceCapabilityMatcherContractError as error:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -473,12 +479,15 @@ def execute_task_internal(
 
     adapter_request, projection_error = project_to_adapter_request(normalized_request, capability_family)
     if projection_error is not None:
-        return TaskExecutionResult(failure_envelope(task_id, adapter_key, capability, projection_error), None)
+        return TaskExecutionResult(
+            pre_accepted_failure_envelope(task_id, adapter_key, capability, projection_error),
+            None,
+        )
 
     execution_control_policy = normalized_request.execution_control_policy
     if execution_control_policy is None:
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -507,23 +516,24 @@ def execute_task_internal(
             task_record_ref="none",
             policy=execution_control_policy,
         )
-        return TaskExecutionResult(
-            failure_envelope(
-                task_id,
-                adapter_key,
-                capability,
-                invalid_input_error(
-                    EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
-                    "执行控制并发限制拒绝本次任务提交",
-                    details={
-                        "scope": execution_control_policy.concurrency.scope,
-                        "max_in_flight": execution_control_policy.concurrency.max_in_flight,
-                        "on_limit": execution_control_policy.concurrency.on_limit,
-                        "task_record_ref": "none",
-                        "execution_control_event": event,
-                    },
-                ),
+        envelope = pre_accepted_failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            invalid_input_error(
+                EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
+                "执行控制并发限制拒绝本次任务提交",
+                details={
+                    "scope": execution_control_policy.concurrency.scope,
+                    "max_in_flight": execution_control_policy.concurrency.max_in_flight,
+                    "on_limit": execution_control_policy.concurrency.on_limit,
+                    "task_record_ref": "none",
+                    "execution_control_event": event,
+                },
             ),
+        )
+        return TaskExecutionResult(
+            with_runtime_observability(envelope, [event], [event]),
             None,
         )
 
@@ -679,6 +689,8 @@ def execute_controlled_adapter_attempts(
     last_failed_envelope: dict[str, Any] | None = None
     runtime_result_refs: list[dict[str, Any]] = []
     execution_control_events: list[dict[str, Any]] = []
+    structured_log_events: list[dict[str, Any]] = []
+    metric_samples: list[dict[str, Any]] = []
 
     while True:
         attempt = execute_single_controlled_adapter_attempt(
@@ -711,8 +723,20 @@ def execute_controlled_adapter_attempts(
                         "max_in_flight": policy.concurrency.max_in_flight,
                     },
                 )
-            return with_runtime_observability(envelope, runtime_result_refs, execution_control_events)
-        envelope = with_runtime_observability(envelope, runtime_result_refs, execution_control_events)
+            return with_runtime_observability(
+                envelope,
+                runtime_result_refs,
+                execution_control_events,
+                structured_log_events,
+                metric_samples,
+            )
+        envelope = with_runtime_observability(
+            envelope,
+            runtime_result_refs,
+            execution_control_events,
+            structured_log_events,
+            metric_samples,
+        )
         if envelope.get("status") == "success":
             return envelope
 
@@ -747,7 +771,33 @@ def execute_controlled_adapter_attempts(
                     "last_attempt_outcome_ref": attempt.attempt_outcome_ref,
                 },
             )
-            return with_runtime_observability(exhausted_envelope, runtime_result_refs, execution_control_events)
+            return with_runtime_observability(
+                exhausted_envelope,
+                runtime_result_refs,
+                execution_control_events,
+                structured_log_events,
+                metric_samples,
+            )
+        retry_log_event, retry_metric_sample = build_retry_scheduled_observability(
+            task_id=task_id,
+            adapter_key=adapter_key,
+            capability=capability,
+            attempt_index=attempt_index,
+            next_attempt_index=attempt_index + 1,
+            failure_signal_id=str(envelope.get("runtime_failure_signal", {}).get("signal_id", "")),
+            error_category=str(envelope.get("runtime_failure_signal", {}).get("error_category", "")),
+            error_code=str(envelope.get("runtime_failure_signal", {}).get("error_code", "")),
+            failure_phase=str(envelope.get("runtime_failure_signal", {}).get("failure_phase", "")),
+            resource_trace_refs=list(
+                envelope.get("runtime_failure_signal", {}).get("resource_trace_refs", [])
+                if isinstance(envelope.get("runtime_failure_signal", {}).get("resource_trace_refs"), list)
+                else []
+            ),
+            runtime_result_refs=runtime_result_refs,
+            policy=policy,
+        )
+        structured_log_events.append(retry_log_event)
+        metric_samples.append(retry_metric_sample)
         if policy.retry.backoff_ms:
             time.sleep(policy.retry.backoff_ms / 1000)
         admission_guard = acquire_execution_concurrency_admission_guard(
@@ -784,7 +834,13 @@ def execute_controlled_adapter_attempts(
                     "max_in_flight": policy.concurrency.max_in_flight,
                 },
             )
-            return with_runtime_observability(rejected_envelope, runtime_result_refs, execution_control_events)
+            return with_runtime_observability(
+                rejected_envelope,
+                runtime_result_refs,
+                execution_control_events,
+                structured_log_events,
+                metric_samples,
+            )
         attempt_index += 1
 
 
@@ -833,6 +889,9 @@ def execute_single_controlled_adapter_attempt(
 
     def finish_attempt(envelope: dict[str, Any], *, core_timeout_outcome: bool = False) -> AdapterAttemptResult:
         nonlocal slot_released
+        trace_refs = resource_trace_refs_for_bundle(resource_bundle)
+        if trace_refs:
+            envelope = with_failed_envelope_resource_trace_refs(envelope, trace_refs)
         guard_release_error = release_attempt_admission_guard()
         if guard_release_error is not None:
             envelope = failure_envelope(task_id, adapter_key, capability, guard_release_error)
@@ -1412,15 +1471,130 @@ def with_runtime_observability(
     envelope: Mapping[str, Any],
     runtime_result_refs: list[dict[str, Any]],
     execution_control_events: list[dict[str, Any]],
+    structured_log_events: list[dict[str, Any]] | None = None,
+    metric_samples: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     enriched = dict(envelope)
     if runtime_result_refs and (enriched.get("status") == "failed" or len(runtime_result_refs) > 1 or execution_control_events):
         enriched["runtime_result_refs"] = list(runtime_result_refs)
     if execution_control_events:
         enriched["execution_control_events"] = list(execution_control_events)
+    if structured_log_events:
+        enriched["runtime_structured_log_events"] = list(structured_log_events)
+    if metric_samples:
+        enriched["runtime_execution_metric_samples"] = list(metric_samples)
     if enriched.get("status") == "failed":
         enriched = with_failure_observability(enriched)
     return enriched
+
+
+def pre_accepted_failure_envelope(
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    error: Mapping[str, Any],
+) -> dict[str, Any]:
+    return failure_envelope(
+        task_id,
+        adapter_key,
+        capability,
+        with_error_details(error, {"task_record_ref": "none", "stage": "pre_admission"}),
+    )
+
+
+def with_error_details(error: Mapping[str, Any], details: Mapping[str, Any]) -> dict[str, Any]:
+    enriched = dict(error)
+    current_details = dict(enriched.get("details") if isinstance(enriched.get("details"), Mapping) else {})
+    current_details.update(details)
+    enriched["details"] = current_details
+    return enriched
+
+
+def with_failed_envelope_resource_trace_refs(envelope: Mapping[str, Any], refs: list[dict[str, Any]]) -> dict[str, Any]:
+    if envelope.get("status") != "failed" or not refs:
+        return dict(envelope)
+    enriched = dict(envelope)
+    error = dict(enriched.get("error") if isinstance(enriched.get("error"), Mapping) else {})
+    current_details = dict(error.get("details") if isinstance(error.get("details"), Mapping) else {})
+    current_details.setdefault("resource_trace_refs", refs)
+    error["details"] = current_details
+    enriched["error"] = error
+    return enriched
+
+
+def resource_trace_refs_for_bundle(resource_bundle: Any) -> list[dict[str, Any]]:
+    if resource_bundle is None:
+        return []
+    lease_id = getattr(resource_bundle, "lease_id", "")
+    bundle_id = getattr(resource_bundle, "bundle_id", "")
+    refs: list[dict[str, Any]] = []
+    for slot_name in ("account", "proxy"):
+        resource = getattr(resource_bundle, slot_name, None)
+        resource_id = getattr(resource, "resource_id", "")
+        resource_type = getattr(resource, "resource_type", slot_name)
+        if not lease_id or not bundle_id or not resource_id:
+            continue
+        refs.append(
+            {
+                "event_id": f"acquired:{lease_id}:{resource_id}",
+                "ref_type": "ResourceTraceEvent",
+                "lease_id": lease_id,
+                "bundle_id": bundle_id,
+                "resource_id": resource_id,
+                "resource_type": resource_type,
+            }
+        )
+    return refs
+
+
+def build_retry_scheduled_observability(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    attempt_index: int,
+    next_attempt_index: int,
+    failure_signal_id: str,
+    error_category: str,
+    error_code: str,
+    failure_phase: str,
+    resource_trace_refs: list[dict[str, Any]],
+    runtime_result_refs: list[dict[str, Any]],
+    policy: ExecutionControlPolicy,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    occurred_at = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    log_event = {
+        "event_id": f"runtime_log:{task_id}:retry_scheduled:{attempt_index}:{next_attempt_index}",
+        "task_id": task_id,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "event_type": "retry_scheduled",
+        "level": "info",
+        "attempt_index": attempt_index,
+        "failure_signal_id": failure_signal_id,
+        "resource_trace_refs": list(resource_trace_refs),
+        "runtime_result_refs": list(runtime_result_refs),
+        "message": f"retry scheduled after attempt {attempt_index}",
+        "occurred_at": occurred_at,
+    }
+    metric_sample = {
+        "metric_id": f"runtime_metric:{task_id}:retry_scheduled_total:{attempt_index}:{next_attempt_index}",
+        "task_id": task_id,
+        "metric_name": "retry_scheduled_total",
+        "metric_value": 1,
+        "unit": "count",
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "error_category": error_category,
+        "error_code": error_code,
+        "failure_phase": failure_phase,
+        "attempt_index": attempt_index,
+        "policy": {
+            "retry": {"max_attempts": policy.retry.max_attempts, "backoff_ms": policy.retry.backoff_ms},
+        },
+        "occurred_at": occurred_at,
+    }
+    return log_event, metric_sample
 
 
 def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
@@ -1490,8 +1664,18 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "occurred_at": occurred_at,
     }
     enriched["runtime_failure_signal"] = failure_signal
-    enriched["runtime_structured_log_events"] = [log_event]
-    enriched["runtime_execution_metric_samples"] = [metric_sample]
+    existing_log_events = list(
+        enriched.get("runtime_structured_log_events")
+        if isinstance(enriched.get("runtime_structured_log_events"), list)
+        else []
+    )
+    existing_metric_samples = list(
+        enriched.get("runtime_execution_metric_samples")
+        if isinstance(enriched.get("runtime_execution_metric_samples"), list)
+        else []
+    )
+    enriched["runtime_structured_log_events"] = [*existing_log_events, log_event]
+    enriched["runtime_execution_metric_samples"] = [*existing_metric_samples, metric_sample]
     return enriched
 
 
@@ -1511,6 +1695,10 @@ def infer_failure_phase(*, error_category: str, error_code: str, details: Mappin
         return "timeout"
     if error_code in {"resource_unavailable", "invalid_resource_requirement"}:
         return "resource_acquire"
+    if error_code in {"envelope_not_json_serializable", "task_record_conflict", "task_record_persistence_failed"}:
+        return "persistence"
+    if details.get("stage") in {"accepted", "running", "completion", "persist_accepted", "persist_running"}:
+        return "persistence"
     if error_category == "invalid_input":
         return "admission"
     if error_category == "runtime_contract":

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1517,6 +1517,8 @@ def with_runtime_observability(
         enriched["runtime_result_refs"] = list(runtime_result_refs)
     if execution_control_events:
         enriched["execution_control_events"] = list(execution_control_events)
+    if failure_signals:
+        enriched["_runtime_failure_signals"] = list(failure_signals)
     if structured_log_events:
         enriched["runtime_structured_log_events"] = list(structured_log_events)
     if metric_samples:
@@ -1551,12 +1553,12 @@ def pre_accepted_failure_envelope(
     current_details["task_record_ref"] = "none"
     current_details.setdefault("stage", "pre_admission")
     enriched_error["details"] = current_details
-    return failure_envelope(
+    return with_failure_observability(failure_envelope(
         task_id,
         adapter_key,
         capability,
         enriched_error,
-    )
+    ))
 
 
 def with_failed_envelope_resource_trace_refs(envelope: Mapping[str, Any], refs: list[dict[str, Any]]) -> dict[str, Any]:
@@ -1807,7 +1809,7 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     metric_name = infer_failure_metric_name(event_type=event_type, failure_phase=failure_phase)
     attempt_index = infer_attempt_index(runtime_result_refs)
     signal_id = f"runtime_failure_signal:{task_id}:{error_category}:{error_code}:{failure_phase}:{attempt_index}"
-    envelope_ref = f"failed_envelope:{task_id}:{error_category}:{error_code}"
+    envelope_ref = f"failed_envelope:{task_id}:{error_category}:{error_code}:{attempt_index}"
     existing_failure_signal = (
         enriched.get("runtime_failure_signal") if isinstance(enriched.get("runtime_failure_signal"), Mapping) else {}
     )
@@ -2087,7 +2089,7 @@ def persist_task_record(
         return task_record_store.write(record), None
     except TaskRecordConflictError as error:
         return None, TaskExecutionResult(
-            failure_envelope(
+            with_failure_observability(failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -2096,7 +2098,7 @@ def persist_task_record(
                     "共享任务记录写入与既有 durable truth 冲突",
                     details={"stage": stage, "reason": str(error)},
                 ),
-            ),
+            )),
             None,
         )
     except (TaskRecordContractError, TaskRecordStoreError, OSError) as error:
@@ -2136,7 +2138,7 @@ def _fail_closed_task_record_persistence(
     except Exception as invalidation_error:
         invalidation_details["invalidation_reason"] = str(invalidation_error)
     return None, TaskExecutionResult(
-        failure_envelope(
+        with_failure_observability(failure_envelope(
             task_id,
             adapter_key,
             capability,
@@ -2145,7 +2147,7 @@ def _fail_closed_task_record_persistence(
                 "共享任务记录无法可靠写入本地稳定存储",
                 details={"stage": stage, "reason": str(error), **invalidation_details},
             ),
-        ),
+        )),
         None,
     )
 
@@ -2878,7 +2880,7 @@ def failure_envelope(task_id: str, adapter_key: str, capability: str, error: Map
     details = error.get("details", {})
     if not isinstance(details, Mapping):
         details = {}
-    envelope = {
+    return {
         "task_id": task_id,
         "adapter_key": adapter_key,
         "capability": capability,
@@ -2890,7 +2892,6 @@ def failure_envelope(task_id: str, adapter_key: str, capability: str, error: Map
             "details": dict(details),
         },
     }
-    return with_failure_observability(envelope)
 
 
 def runtime_contract_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -745,7 +745,7 @@ def execute_controlled_adapter_attempts(
         if attempt.execution_control_event is not None:
             execution_control_events.append(attempt.execution_control_event)
             runtime_result_refs.append(attempt.execution_control_event)
-            if last_failed_envelope is not None:
+            if last_failed_envelope is not None and is_synthetic_retry_concurrency_rejection(envelope):
                 envelope = with_failed_envelope_control_details(
                     last_failed_envelope,
                     event=attempt.execution_control_event,
@@ -2033,6 +2033,17 @@ def with_failed_envelope_control_details(
     error["details"] = current_details
     enriched["error"] = error
     return enriched
+
+
+def is_synthetic_retry_concurrency_rejection(envelope: Mapping[str, Any]) -> bool:
+    error = envelope.get("error") if isinstance(envelope.get("error"), Mapping) else {}
+    details = error.get("details") if isinstance(error.get("details"), Mapping) else {}
+    return (
+        error.get("category") == "runtime_contract"
+        and error.get("code") == EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID
+        and details.get("control_context") == "guarded_admission"
+        and details.get("control_code") == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED
+    )
 
 
 def finalize_task_execution_result(

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -697,6 +697,7 @@ def execute_controlled_adapter_attempts(
     last_failed_envelope: dict[str, Any] | None = None
     runtime_result_refs: list[dict[str, Any]] = []
     execution_control_events: list[dict[str, Any]] = []
+    failure_signals: list[dict[str, Any]] = []
     structured_log_events: list[dict[str, Any]] = []
     metric_samples: list[dict[str, Any]] = []
 
@@ -717,6 +718,9 @@ def execute_controlled_adapter_attempts(
         envelope = attempt.envelope
         if attempt.attempt_outcome_ref is not None:
             runtime_result_refs.append(attempt.attempt_outcome_ref)
+            attempt_log_events, attempt_metric_samples = build_attempt_lifecycle_observability(attempt.attempt_outcome_ref)
+            structured_log_events.extend(attempt_log_events)
+            metric_samples.extend(attempt_metric_samples)
         if attempt.execution_control_event is not None:
             execution_control_events.append(attempt.execution_control_event)
             runtime_result_refs.append(attempt.execution_control_event)
@@ -735,6 +739,7 @@ def execute_controlled_adapter_attempts(
                 envelope,
                 runtime_result_refs,
                 execution_control_events,
+                failure_signals,
                 structured_log_events,
                 metric_samples,
             )
@@ -742,6 +747,7 @@ def execute_controlled_adapter_attempts(
             envelope,
             runtime_result_refs,
             execution_control_events,
+            failure_signals,
             structured_log_events,
             metric_samples,
         )
@@ -749,6 +755,9 @@ def execute_controlled_adapter_attempts(
             return envelope
 
         last_failed_envelope = envelope
+        failure_signal = envelope.get("runtime_failure_signal")
+        if isinstance(failure_signal, Mapping):
+            failure_signals.append(dict(failure_signal))
         retryable = is_retryable_attempt_outcome(
             envelope,
             capability=capability,
@@ -783,6 +792,7 @@ def execute_controlled_adapter_attempts(
                 exhausted_envelope,
                 runtime_result_refs,
                 execution_control_events,
+                failure_signals,
                 structured_log_events,
                 metric_samples,
             )
@@ -846,6 +856,7 @@ def execute_controlled_adapter_attempts(
                 rejected_envelope,
                 runtime_result_refs,
                 execution_control_events,
+                failure_signals,
                 structured_log_events,
                 metric_samples,
             )
@@ -1429,6 +1440,7 @@ def build_attempt_outcome_ref(
     terminal_envelope.pop("runtime_failure_signal", None)
     terminal_envelope.pop("runtime_structured_log_events", None)
     terminal_envelope.pop("runtime_execution_metric_samples", None)
+    terminal_envelope.pop("_runtime_failure_signals", None)
     terminal_envelope.pop("_runtime_structured_log_events", None)
     terminal_envelope.pop("_runtime_execution_metric_samples", None)
     ref = {
@@ -1486,6 +1498,7 @@ def with_runtime_observability(
     envelope: Mapping[str, Any],
     runtime_result_refs: list[dict[str, Any]],
     execution_control_events: list[dict[str, Any]],
+    failure_signals: list[dict[str, Any]] | None = None,
     structured_log_events: list[dict[str, Any]] | None = None,
     metric_samples: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -1493,6 +1506,8 @@ def with_runtime_observability(
     if enriched.get("status") == "success":
         if runtime_result_refs and (len(runtime_result_refs) > 1 or execution_control_events):
             enriched["runtime_result_refs"] = list(runtime_result_refs)
+        if failure_signals:
+            enriched["_runtime_failure_signals"] = list(failure_signals)
         if structured_log_events:
             enriched["_runtime_structured_log_events"] = list(structured_log_events)
         if metric_samples:
@@ -1507,7 +1522,11 @@ def with_runtime_observability(
     if metric_samples:
         enriched["runtime_execution_metric_samples"] = list(metric_samples)
     if enriched.get("status") == "failed" and runtime_result_refs:
-        enriched = with_failed_envelope_task_record_ref(enriched, f"task_record:{enriched.get('task_id')}")
+        current_error = enriched.get("error") if isinstance(enriched.get("error"), Mapping) else {}
+        current_details = current_error.get("details") if isinstance(current_error.get("details"), Mapping) else {}
+        current_task_record_ref = current_details.get("task_record_ref")
+        if current_task_record_ref != "none":
+            enriched = with_failed_envelope_task_record_ref(enriched, f"task_record:{enriched.get('task_id')}")
     if enriched.get("status") == "failed":
         enriched = with_failure_observability(enriched)
     return enriched
@@ -1515,6 +1534,7 @@ def with_runtime_observability(
 
 def public_task_execution_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
     public_envelope = dict(envelope)
+    public_envelope.pop("_runtime_failure_signals", None)
     public_envelope.pop("_runtime_structured_log_events", None)
     public_envelope.pop("_runtime_execution_metric_samples", None)
     return public_envelope
@@ -1557,7 +1577,7 @@ def with_failed_envelope_task_record_ref(envelope: Mapping[str, Any], task_recor
     enriched = dict(envelope)
     error = dict(enriched.get("error") if isinstance(enriched.get("error"), Mapping) else {})
     current_details = dict(error.get("details") if isinstance(error.get("details"), Mapping) else {})
-    current_details.setdefault("task_record_ref", task_record_ref)
+    current_details["task_record_ref"] = task_record_ref
     error["details"] = current_details
     enriched["error"] = error
     return enriched
@@ -1638,6 +1658,89 @@ def build_retry_scheduled_observability(
     return log_event, metric_sample
 
 
+def build_attempt_lifecycle_observability(
+    attempt_outcome_ref: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    task_id = str(attempt_outcome_ref.get("task_id") or "")
+    adapter_key = str(attempt_outcome_ref.get("adapter_key") or "")
+    capability = str(attempt_outcome_ref.get("capability") or "")
+    attempt_index = attempt_outcome_ref.get("attempt_index")
+    if isinstance(attempt_index, bool) or not isinstance(attempt_index, int) or attempt_index < 0:
+        attempt_index = 0
+    started_at = str(attempt_outcome_ref.get("started_at") or "")
+    ended_at = str(attempt_outcome_ref.get("ended_at") or started_at)
+    outcome = str(attempt_outcome_ref.get("outcome") or "")
+    duration_ms = 0
+    try:
+        started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        ended = datetime.fromisoformat(ended_at.replace("Z", "+00:00"))
+        duration_ms = max(0, int((ended - started).total_seconds() * 1000))
+    except ValueError:
+        duration_ms = 0
+    runtime_refs = [dict(attempt_outcome_ref)]
+    log_events = [
+        {
+            "event_id": f"runtime_log:{task_id}:attempt_started:{attempt_index}",
+            "task_id": task_id,
+            "adapter_key": adapter_key,
+            "capability": capability,
+            "event_type": "attempt_started",
+            "level": "info",
+            "attempt_index": attempt_index,
+            "failure_signal_id": "",
+            "resource_trace_refs": [],
+            "runtime_result_refs": runtime_refs,
+            "message": f"attempt {attempt_index} started",
+            "occurred_at": started_at,
+        },
+        {
+            "event_id": f"runtime_log:{task_id}:attempt_finished:{attempt_index}",
+            "task_id": task_id,
+            "adapter_key": adapter_key,
+            "capability": capability,
+            "event_type": "attempt_finished",
+            "level": "error" if outcome in {"failed", "timeout"} else "info",
+            "attempt_index": attempt_index,
+            "failure_signal_id": "",
+            "resource_trace_refs": [],
+            "runtime_result_refs": runtime_refs,
+            "message": f"attempt {attempt_index} finished: {outcome or 'unknown'}",
+            "occurred_at": ended_at,
+        },
+    ]
+    metric_samples = [
+        {
+            "metric_id": f"runtime_metric:{task_id}:attempt_started_total:{attempt_index}",
+            "task_id": task_id,
+            "metric_name": "attempt_started_total",
+            "metric_value": 1,
+            "unit": "count",
+            "adapter_key": adapter_key,
+            "capability": capability,
+            "error_category": "",
+            "error_code": "",
+            "failure_phase": "",
+            "attempt_index": attempt_index,
+            "occurred_at": started_at,
+        },
+        {
+            "metric_id": f"runtime_metric:{task_id}:execution_duration_ms:{attempt_index}",
+            "task_id": task_id,
+            "metric_name": "execution_duration_ms",
+            "metric_value": duration_ms,
+            "unit": "ms",
+            "adapter_key": adapter_key,
+            "capability": capability,
+            "error_category": "",
+            "error_code": "",
+            "failure_phase": "",
+            "attempt_index": attempt_index,
+            "occurred_at": ended_at,
+        },
+    ]
+    return log_events, metric_samples
+
+
 def with_observability_write_failed(
     envelope: Mapping[str, Any],
     *,
@@ -1694,7 +1797,6 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     capability = str(enriched.get("capability") or "")
     error_category = str(error.get("category") or "")
     error_code = str(error.get("code") or "")
-    occurred_at = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
     task_record_ref = details.get("task_record_ref")
     if not isinstance(task_record_ref, str) or not task_record_ref:
         task_record_ref = "none"
@@ -1705,6 +1807,36 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     metric_name = infer_failure_metric_name(event_type=event_type, failure_phase=failure_phase)
     signal_id = f"runtime_failure_signal:{task_id}:{error_category}:{error_code}:{failure_phase}"
     envelope_ref = f"failed_envelope:{task_id}:{error_category}:{error_code}"
+    existing_failure_signal = (
+        enriched.get("runtime_failure_signal") if isinstance(enriched.get("runtime_failure_signal"), Mapping) else {}
+    )
+    existing_log_events = list(
+        enriched.get("runtime_structured_log_events")
+        if isinstance(enriched.get("runtime_structured_log_events"), list)
+        else []
+    )
+    existing_metric_samples = list(
+        enriched.get("runtime_execution_metric_samples")
+        if isinstance(enriched.get("runtime_execution_metric_samples"), list)
+        else []
+    )
+    signal_occurred_at = stable_observability_occurred_at(
+        existing_failure_signal,
+        id_field="signal_id",
+        entry_id=signal_id,
+    )
+    log_id = f"runtime_log:{task_id}:task_failed:{error_category}:{error_code}"
+    metric_id = f"runtime_metric:{task_id}:{metric_name}:{error_category}:{error_code}"
+    log_occurred_at = stable_observability_occurred_at(
+        next((event for event in existing_log_events if isinstance(event, Mapping) and event.get("event_id") == log_id), {}),
+        id_field="event_id",
+        entry_id=log_id,
+    )
+    metric_occurred_at = stable_observability_occurred_at(
+        next((metric for metric in existing_metric_samples if isinstance(metric, Mapping) and metric.get("metric_id") == metric_id), {}),
+        id_field="metric_id",
+        entry_id=metric_id,
+    )
     failure_signal = {
         "signal_id": signal_id,
         "task_id": task_id,
@@ -1718,10 +1850,10 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "task_record_ref": task_record_ref,
         "resource_trace_refs": resource_trace_refs,
         "runtime_result_refs": runtime_result_refs,
-        "occurred_at": occurred_at,
+        "occurred_at": signal_occurred_at,
     }
     log_event = {
-        "event_id": f"runtime_log:{task_id}:task_failed:{error_category}:{error_code}",
+        "event_id": log_id,
         "task_id": task_id,
         "adapter_key": adapter_key,
         "capability": capability,
@@ -1732,10 +1864,10 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "resource_trace_refs": resource_trace_refs,
         "runtime_result_refs": runtime_result_refs,
         "message": f"task failed: {error_category}/{error_code}",
-        "occurred_at": occurred_at,
+        "occurred_at": log_occurred_at,
     }
     metric_sample = {
-        "metric_id": f"runtime_metric:{task_id}:{metric_name}:{error_category}:{error_code}",
+        "metric_id": metric_id,
         "task_id": task_id,
         "metric_name": metric_name,
         "metric_value": 1,
@@ -1746,19 +1878,9 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "error_code": error_code,
         "failure_phase": failure_phase,
         "attempt_index": log_event["attempt_index"],
-        "occurred_at": occurred_at,
+        "occurred_at": metric_occurred_at,
     }
     enriched["runtime_failure_signal"] = failure_signal
-    existing_log_events = list(
-        enriched.get("runtime_structured_log_events")
-        if isinstance(enriched.get("runtime_structured_log_events"), list)
-        else []
-    )
-    existing_metric_samples = list(
-        enriched.get("runtime_execution_metric_samples")
-        if isinstance(enriched.get("runtime_execution_metric_samples"), list)
-        else []
-    )
     retained_log_events = [
         event
         for event in existing_log_events
@@ -1772,6 +1894,12 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     enriched["runtime_structured_log_events"] = [*retained_log_events, log_event]
     enriched["runtime_execution_metric_samples"] = [*retained_metric_samples, metric_sample]
     return enriched
+
+
+def stable_observability_occurred_at(entry: Mapping[str, Any], *, id_field: str, entry_id: str) -> str:
+    if entry.get(id_field) == entry_id and isinstance(entry.get("occurred_at"), str) and entry["occurred_at"]:
+        return str(entry["occurred_at"])
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
 def infer_failure_phase(*, error_category: str, error_code: str, details: Mapping[str, Any]) -> str:
@@ -1880,7 +2008,9 @@ def finalize_task_execution_result(
     task_record_store: TaskRecordStore | None,
 ) -> TaskExecutionResult:
     envelope = (
-        with_failed_envelope_task_record_ref(envelope, record.task_record_ref or f"task_record:{task_id}")
+        with_failure_observability(
+            with_failed_envelope_task_record_ref(envelope, record.task_record_ref or f"task_record:{task_id}")
+        )
         if envelope.get("status") == "failed"
         else dict(envelope)
     )

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1828,7 +1828,12 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     runtime_result_refs = list(enriched.get("runtime_result_refs") if isinstance(enriched.get("runtime_result_refs"), list) else [])
     resource_trace_refs = list(details.get("resource_trace_refs") if isinstance(details.get("resource_trace_refs"), list) else [])
     failure_phase = infer_failure_phase(error_category=error_category, error_code=error_code, details=details)
-    event_type = infer_failure_log_event_type(error_code=error_code, details=details, task_record_ref=task_record_ref)
+    event_type = infer_failure_log_event_type(
+        error_category=error_category,
+        error_code=error_code,
+        details=details,
+        task_record_ref=task_record_ref,
+    )
     metric_name = infer_failure_metric_name(event_type=event_type, failure_phase=failure_phase)
     attempt_index = infer_attempt_index(runtime_result_refs)
     signal_id = f"runtime_failure_signal:{task_id}:{error_category}:{error_code}:{failure_phase}:{attempt_index}"
@@ -1954,7 +1959,7 @@ def infer_failure_phase(*, error_category: str, error_code: str, details: Mappin
         return "admission"
     if details.get("stage") == "pre_execution":
         return "pre_execution"
-    if error_code == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT or details.get("control_code") == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT:
+    if is_normal_execution_timeout_failure(error_category=error_category, error_code=error_code, details=details):
         return "timeout"
     if error_code in {"resource_unavailable", "invalid_resource_requirement"}:
         return "resource_acquire"
@@ -1966,16 +1971,20 @@ def infer_failure_phase(*, error_category: str, error_code: str, details: Mappin
         return "admission"
     if error_code in {"invalid_adapter_success_payload", "adapter_execution_error"}:
         return "adapter_execution"
-    if error_category == "invalid_input":
-        return "admission"
-    if error_category == "unsupported":
-        return "admission"
     if error_category == "runtime_contract":
         return "adapter_execution"
     return "adapter_execution"
 
 
-def infer_failure_log_event_type(*, error_code: str, details: Mapping[str, Any], task_record_ref: str) -> str:
+def is_normal_execution_timeout_failure(*, error_category: str, error_code: str, details: Mapping[str, Any]) -> bool:
+    return (
+        error_category == "platform"
+        and error_code == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT
+        and details.get("control_code") == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT
+    )
+
+
+def infer_failure_log_event_type(*, error_category: str, error_code: str, details: Mapping[str, Any], task_record_ref: str) -> str:
     event = details.get("execution_control_event")
     if isinstance(event, Mapping):
         event_type = event.get("event_type")
@@ -1986,7 +1995,7 @@ def infer_failure_log_event_type(*, error_code: str, details: Mapping[str, Any],
             return str(event_type)
     if error_code == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED and task_record_ref == "none":
         return EXECUTION_CONTROL_EVENT_ADMISSION_CONCURRENCY_REJECTED
-    if error_code == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT or details.get("control_code") == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT:
+    if is_normal_execution_timeout_failure(error_category=error_category, error_code=error_code, details=details):
         return "timeout_triggered"
     return "task_failed"
 

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -543,6 +543,10 @@ def execute_task_internal(
             return None
         release_details = dict(release_error.get("details", {}))
         release_details["stage"] = stage
+        release_details.setdefault(
+            "task_record_ref",
+            "none" if stage in {"create_task_record", "persist_accepted"} else f"task_record:{task_id}",
+        )
         release_error = dict(release_error)
         release_error["details"] = release_details
         return TaskExecutionResult(
@@ -1498,6 +1502,13 @@ def with_runtime_observability(
     return enriched
 
 
+def public_task_execution_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    public_envelope = dict(envelope)
+    public_envelope.pop("_runtime_structured_log_events", None)
+    public_envelope.pop("_runtime_execution_metric_samples", None)
+    return public_envelope
+
+
 def pre_accepted_failure_envelope(
     task_id: str,
     adapter_key: str,
@@ -1759,12 +1770,13 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     retained_log_events = [
         event
         for event in existing_log_events
-        if isinstance(event, Mapping) and event.get("event_type") == "retry_scheduled"
+        if isinstance(event, Mapping) and event.get("event_type") in {"retry_scheduled", "observability_write_failed"}
     ]
     retained_metric_samples = [
         metric
         for metric in existing_metric_samples
-        if isinstance(metric, Mapping) and metric.get("metric_name") == "retry_scheduled_total"
+        if isinstance(metric, Mapping)
+        and metric.get("metric_name") in {"retry_scheduled_total", "observability_write_failed_total"}
     ]
     enriched["runtime_structured_log_events"] = [*retained_log_events, log_event]
     enriched["runtime_execution_metric_samples"] = [*retained_metric_samples, metric_sample]
@@ -1883,7 +1895,7 @@ def finalize_task_execution_result(
         except Exception as invalidation_error:
             invalidation_details["invalidation_reason"] = str(invalidation_error)
         if preserve_envelope_on_record_error and task_record_store is None:
-            return TaskExecutionResult(dict(envelope), None)
+            return TaskExecutionResult(public_task_execution_envelope(envelope), None)
         if envelope.get("status") == "failed":
             return TaskExecutionResult(
                 with_observability_write_failed(envelope, stage="completion", reason=str(error), details=invalidation_details),
@@ -1923,7 +1935,7 @@ def finalize_task_execution_result(
                 None,
             )
         return persistence_error
-    return TaskExecutionResult(dict(envelope), persisted_record or terminal_record)
+    return TaskExecutionResult(public_task_execution_envelope(envelope), persisted_record or terminal_record)
 
 
 def persist_task_record(

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1805,7 +1805,8 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     failure_phase = infer_failure_phase(error_category=error_category, error_code=error_code, details=details)
     event_type = infer_failure_log_event_type(error_code=error_code, details=details, task_record_ref=task_record_ref)
     metric_name = infer_failure_metric_name(event_type=event_type, failure_phase=failure_phase)
-    signal_id = f"runtime_failure_signal:{task_id}:{error_category}:{error_code}:{failure_phase}"
+    attempt_index = infer_attempt_index(runtime_result_refs)
+    signal_id = f"runtime_failure_signal:{task_id}:{error_category}:{error_code}:{failure_phase}:{attempt_index}"
     envelope_ref = f"failed_envelope:{task_id}:{error_category}:{error_code}"
     existing_failure_signal = (
         enriched.get("runtime_failure_signal") if isinstance(enriched.get("runtime_failure_signal"), Mapping) else {}
@@ -1825,8 +1826,8 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         id_field="signal_id",
         entry_id=signal_id,
     )
-    log_id = f"runtime_log:{task_id}:task_failed:{error_category}:{error_code}"
-    metric_id = f"runtime_metric:{task_id}:{metric_name}:{error_category}:{error_code}"
+    log_id = f"runtime_log:{task_id}:task_failed:{error_category}:{error_code}:{attempt_index}"
+    metric_id = f"runtime_metric:{task_id}:{metric_name}:{error_category}:{error_code}:{attempt_index}"
     log_occurred_at = stable_observability_occurred_at(
         next((event for event in existing_log_events if isinstance(event, Mapping) and event.get("event_id") == log_id), {}),
         id_field="event_id",
@@ -1859,7 +1860,7 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "capability": capability,
         "event_type": event_type,
         "level": "error",
-        "attempt_index": infer_attempt_index(runtime_result_refs),
+        "attempt_index": attempt_index,
         "failure_signal_id": signal_id,
         "resource_trace_refs": resource_trace_refs,
         "runtime_result_refs": runtime_result_refs,
@@ -1877,19 +1878,22 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "error_category": error_category,
         "error_code": error_code,
         "failure_phase": failure_phase,
-        "attempt_index": log_event["attempt_index"],
+        "attempt_index": attempt_index,
         "occurred_at": metric_occurred_at,
     }
     enriched["runtime_failure_signal"] = failure_signal
     retained_log_events = [
         event
         for event in existing_log_events
-        if isinstance(event, Mapping) and event.get("event_type") in {"retry_scheduled", "observability_write_failed"}
+        if isinstance(event, Mapping)
+        and event.get("event_type")
+        in {"attempt_started", "attempt_finished", "retry_scheduled", "observability_write_failed"}
     ]
     retained_metric_samples = [
         metric
         for metric in existing_metric_samples
-        if isinstance(metric, Mapping) and metric.get("metric_name") == "retry_scheduled_total"
+        if isinstance(metric, Mapping)
+        and metric.get("metric_name") in {"attempt_started_total", "execution_duration_ms", "retry_scheduled_total"}
     ]
     enriched["runtime_structured_log_events"] = [*retained_log_events, log_event]
     enriched["runtime_execution_metric_samples"] = [*retained_metric_samples, metric_sample]

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1475,6 +1475,10 @@ def with_runtime_observability(
     metric_samples: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     enriched = dict(envelope)
+    if enriched.get("status") == "success":
+        if runtime_result_refs and (len(runtime_result_refs) > 1 or execution_control_events):
+            enriched["runtime_result_refs"] = list(runtime_result_refs)
+        return enriched
     if runtime_result_refs and (enriched.get("status") == "failed" or len(runtime_result_refs) > 1 or execution_control_events):
         enriched["runtime_result_refs"] = list(runtime_result_refs)
     if execution_control_events:
@@ -1674,8 +1678,18 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
         if isinstance(enriched.get("runtime_execution_metric_samples"), list)
         else []
     )
-    enriched["runtime_structured_log_events"] = [*existing_log_events, log_event]
-    enriched["runtime_execution_metric_samples"] = [*existing_metric_samples, metric_sample]
+    retained_log_events = [
+        event
+        for event in existing_log_events
+        if isinstance(event, Mapping) and event.get("event_type") == "retry_scheduled"
+    ]
+    retained_metric_samples = [
+        metric
+        for metric in existing_metric_samples
+        if isinstance(metric, Mapping) and metric.get("metric_name") == "retry_scheduled_total"
+    ]
+    enriched["runtime_structured_log_events"] = [*retained_log_events, log_event]
+    enriched["runtime_execution_metric_samples"] = [*retained_metric_samples, metric_sample]
     return enriched
 
 

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -491,7 +491,11 @@ def execute_task_internal(
                 task_id,
                 adapter_key,
                 capability,
-                runtime_contract_error("execution_control_state_invalid", "Core 未能物化默认执行控制策略"),
+                runtime_contract_error(
+                    "execution_control_state_invalid",
+                    "Core 未能物化默认执行控制策略",
+                    details={"stage": "pre_execution", "control_context": "default_execution_control_policy"},
+                ),
             ),
             None,
         )
@@ -1019,6 +1023,8 @@ def execute_single_controlled_adapter_attempt(
                     "execution concurrency slot became unavailable after guarded admission",
                     details={
                         "control_code": EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED,
+                        "stage": "pre_execution",
+                        "control_context": "guarded_admission",
                         "scope": policy.concurrency.scope,
                         "max_in_flight": policy.concurrency.max_in_flight,
                     },
@@ -1420,6 +1426,11 @@ def build_attempt_outcome_ref(
     terminal_envelope = dict(envelope)
     terminal_envelope.pop("runtime_result_refs", None)
     terminal_envelope.pop("execution_control_events", None)
+    terminal_envelope.pop("runtime_failure_signal", None)
+    terminal_envelope.pop("runtime_structured_log_events", None)
+    terminal_envelope.pop("runtime_execution_metric_samples", None)
+    terminal_envelope.pop("_runtime_structured_log_events", None)
+    terminal_envelope.pop("_runtime_execution_metric_samples", None)
     ref = {
         "ref_type": "ExecutionAttemptOutcome",
         "ref_id": f"{task_id}:attempt:{attempt_index}",
@@ -1515,20 +1526,17 @@ def pre_accepted_failure_envelope(
     capability: str,
     error: Mapping[str, Any],
 ) -> dict[str, Any]:
+    enriched_error = dict(error)
+    current_details = dict(enriched_error.get("details") if isinstance(enriched_error.get("details"), Mapping) else {})
+    current_details["task_record_ref"] = "none"
+    current_details.setdefault("stage", "pre_admission")
+    enriched_error["details"] = current_details
     return failure_envelope(
         task_id,
         adapter_key,
         capability,
-        with_error_details(error, {"task_record_ref": "none", "stage": "pre_admission"}),
+        enriched_error,
     )
-
-
-def with_error_details(error: Mapping[str, Any], details: Mapping[str, Any]) -> dict[str, Any]:
-    enriched = dict(error)
-    current_details = dict(enriched.get("details") if isinstance(enriched.get("details"), Mapping) else {})
-    current_details.update(details)
-    enriched["details"] = current_details
-    return enriched
 
 
 def with_failed_envelope_resource_trace_refs(envelope: Mapping[str, Any], refs: list[dict[str, Any]]) -> dict[str, Any]:
@@ -1641,6 +1649,10 @@ def with_observability_write_failed(
     task_id = str(enriched.get("task_id") or "")
     adapter_key = str(enriched.get("adapter_key") or "")
     capability = str(enriched.get("capability") or "")
+    failure_signal = enriched.get("runtime_failure_signal") if isinstance(enriched.get("runtime_failure_signal"), Mapping) else {}
+    resource_trace_refs = list(
+        failure_signal.get("resource_trace_refs") if isinstance(failure_signal.get("resource_trace_refs"), list) else []
+    )
     occurred_at = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
     event = {
         "event_id": f"runtime_log:{task_id}:observability_write_failed:{stage}",
@@ -1652,8 +1664,8 @@ def with_observability_write_failed(
         "attempt_index": infer_attempt_index(
             list(enriched.get("runtime_result_refs") if isinstance(enriched.get("runtime_result_refs"), list) else [])
         ),
-        "failure_signal_id": "",
-        "resource_trace_refs": [],
+        "failure_signal_id": str(failure_signal.get("signal_id") or ""),
+        "resource_trace_refs": resource_trace_refs,
         "runtime_result_refs": list(
             enriched.get("runtime_result_refs") if isinstance(enriched.get("runtime_result_refs"), list) else []
         ),
@@ -1661,32 +1673,12 @@ def with_observability_write_failed(
         "details": dict(details or {}),
         "occurred_at": occurred_at,
     }
-    metric = {
-        "metric_id": f"runtime_metric:{task_id}:observability_write_failed_total:{stage}",
-        "task_id": task_id,
-        "metric_name": "observability_write_failed_total",
-        "metric_value": 1,
-        "unit": "count",
-        "adapter_key": adapter_key,
-        "capability": capability,
-        "error_category": "runtime_contract",
-        "error_code": "observability_write_failed",
-        "failure_phase": "persistence",
-        "attempt_index": event["attempt_index"],
-        "occurred_at": occurred_at,
-    }
     existing_events = list(
         enriched.get("runtime_structured_log_events")
         if isinstance(enriched.get("runtime_structured_log_events"), list)
         else []
     )
-    existing_metrics = list(
-        enriched.get("runtime_execution_metric_samples")
-        if isinstance(enriched.get("runtime_execution_metric_samples"), list)
-        else []
-    )
     enriched["runtime_structured_log_events"] = [*existing_events, event]
-    enriched["runtime_execution_metric_samples"] = [*existing_metrics, metric]
     return enriched
 
 
@@ -1775,8 +1767,7 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     retained_metric_samples = [
         metric
         for metric in existing_metric_samples
-        if isinstance(metric, Mapping)
-        and metric.get("metric_name") in {"retry_scheduled_total", "observability_write_failed_total"}
+        if isinstance(metric, Mapping) and metric.get("metric_name") == "retry_scheduled_total"
     ]
     enriched["runtime_structured_log_events"] = [*retained_log_events, log_event]
     enriched["runtime_execution_metric_samples"] = [*retained_metric_samples, metric_sample]
@@ -1795,8 +1786,17 @@ def infer_failure_phase(*, error_category: str, error_code: str, details: Mappin
         return "retry_exhausted"
     if error_code == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED:
         return "concurrency_rejected"
+    if error_code == EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID:
+        if details.get("control_context") == "guarded_admission" or (
+            details.get("control_code") == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED
+        ):
+            return "concurrency_rejected"
+        if details.get("stage") == "pre_execution" or details.get("control_context") == "default_execution_control_policy":
+            return "pre_execution"
     if details.get("stage") == "pre_admission":
         return "admission"
+    if details.get("stage") == "pre_execution":
+        return "pre_execution"
     if error_code == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT or details.get("control_code") == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT:
         return "timeout"
     if error_code in {"resource_unavailable", "invalid_resource_requirement"}:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1478,6 +1478,10 @@ def with_runtime_observability(
     if enriched.get("status") == "success":
         if runtime_result_refs and (len(runtime_result_refs) > 1 or execution_control_events):
             enriched["runtime_result_refs"] = list(runtime_result_refs)
+        if structured_log_events:
+            enriched["_runtime_structured_log_events"] = list(structured_log_events)
+        if metric_samples:
+            enriched["_runtime_execution_metric_samples"] = list(metric_samples)
         return enriched
     if runtime_result_refs and (enriched.get("status") == "failed" or len(runtime_result_refs) > 1 or execution_control_events):
         enriched["runtime_result_refs"] = list(runtime_result_refs)
@@ -1487,6 +1491,8 @@ def with_runtime_observability(
         enriched["runtime_structured_log_events"] = list(structured_log_events)
     if metric_samples:
         enriched["runtime_execution_metric_samples"] = list(metric_samples)
+    if enriched.get("status") == "failed" and runtime_result_refs:
+        enriched = with_failed_envelope_task_record_ref(enriched, f"task_record:{enriched.get('task_id')}")
     if enriched.get("status") == "failed":
         enriched = with_failure_observability(enriched)
     return enriched
@@ -1521,6 +1527,18 @@ def with_failed_envelope_resource_trace_refs(envelope: Mapping[str, Any], refs: 
     error = dict(enriched.get("error") if isinstance(enriched.get("error"), Mapping) else {})
     current_details = dict(error.get("details") if isinstance(error.get("details"), Mapping) else {})
     current_details.setdefault("resource_trace_refs", refs)
+    error["details"] = current_details
+    enriched["error"] = error
+    return enriched
+
+
+def with_failed_envelope_task_record_ref(envelope: Mapping[str, Any], task_record_ref: str) -> dict[str, Any]:
+    if envelope.get("status") != "failed":
+        return dict(envelope)
+    enriched = dict(envelope)
+    error = dict(enriched.get("error") if isinstance(enriched.get("error"), Mapping) else {})
+    current_details = dict(error.get("details") if isinstance(error.get("details"), Mapping) else {})
+    current_details.setdefault("task_record_ref", task_record_ref)
     error["details"] = current_details
     enriched["error"] = error
     return enriched
@@ -1601,6 +1619,66 @@ def build_retry_scheduled_observability(
     return log_event, metric_sample
 
 
+def with_observability_write_failed(
+    envelope: Mapping[str, Any],
+    *,
+    stage: str,
+    reason: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    enriched = dict(envelope)
+    task_id = str(enriched.get("task_id") or "")
+    adapter_key = str(enriched.get("adapter_key") or "")
+    capability = str(enriched.get("capability") or "")
+    occurred_at = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    event = {
+        "event_id": f"runtime_log:{task_id}:observability_write_failed:{stage}",
+        "task_id": task_id,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "event_type": "observability_write_failed",
+        "level": "error",
+        "attempt_index": infer_attempt_index(
+            list(enriched.get("runtime_result_refs") if isinstance(enriched.get("runtime_result_refs"), list) else [])
+        ),
+        "failure_signal_id": "",
+        "resource_trace_refs": [],
+        "runtime_result_refs": list(
+            enriched.get("runtime_result_refs") if isinstance(enriched.get("runtime_result_refs"), list) else []
+        ),
+        "message": f"observability write failed during {stage}: {reason}",
+        "details": dict(details or {}),
+        "occurred_at": occurred_at,
+    }
+    metric = {
+        "metric_id": f"runtime_metric:{task_id}:observability_write_failed_total:{stage}",
+        "task_id": task_id,
+        "metric_name": "observability_write_failed_total",
+        "metric_value": 1,
+        "unit": "count",
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "error_category": "runtime_contract",
+        "error_code": "observability_write_failed",
+        "failure_phase": "persistence",
+        "attempt_index": event["attempt_index"],
+        "occurred_at": occurred_at,
+    }
+    existing_events = list(
+        enriched.get("runtime_structured_log_events")
+        if isinstance(enriched.get("runtime_structured_log_events"), list)
+        else []
+    )
+    existing_metrics = list(
+        enriched.get("runtime_execution_metric_samples")
+        if isinstance(enriched.get("runtime_execution_metric_samples"), list)
+        else []
+    )
+    enriched["runtime_structured_log_events"] = [*existing_events, event]
+    enriched["runtime_execution_metric_samples"] = [*existing_metrics, metric]
+    return enriched
+
+
 def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     if envelope.get("status") != "failed" or not isinstance(envelope.get("error"), Mapping):
         return dict(envelope)
@@ -1616,7 +1694,7 @@ def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
     occurred_at = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
     task_record_ref = details.get("task_record_ref")
     if not isinstance(task_record_ref, str) or not task_record_ref:
-        task_record_ref = "none" if error_code == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED else f"task_record:{task_id}"
+        task_record_ref = "none"
     runtime_result_refs = list(enriched.get("runtime_result_refs") if isinstance(enriched.get("runtime_result_refs"), list) else [])
     resource_trace_refs = list(details.get("resource_trace_refs") if isinstance(details.get("resource_trace_refs"), list) else [])
     failure_phase = infer_failure_phase(error_category=error_category, error_code=error_code, details=details)
@@ -1705,6 +1783,8 @@ def infer_failure_phase(*, error_category: str, error_code: str, details: Mappin
         return "retry_exhausted"
     if error_code == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED:
         return "concurrency_rejected"
+    if details.get("stage") == "pre_admission":
+        return "admission"
     if error_code == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT or details.get("control_code") == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT:
         return "timeout"
     if error_code in {"resource_unavailable", "invalid_resource_requirement"}:
@@ -1713,10 +1793,16 @@ def infer_failure_phase(*, error_category: str, error_code: str, details: Mappin
         return "persistence"
     if details.get("stage") in {"accepted", "running", "completion", "persist_accepted", "persist_running"}:
         return "persistence"
+    if error_code in {"adapter_not_found", "capability_not_supported", "target_type_not_supported", "collection_mode_not_supported"}:
+        return "admission"
+    if error_code in {"invalid_adapter_success_payload", "adapter_execution_error"}:
+        return "adapter_execution"
     if error_category == "invalid_input":
         return "admission"
+    if error_category == "unsupported":
+        return "admission"
     if error_category == "runtime_contract":
-        return "pre_execution"
+        return "adapter_execution"
     return "adapter_execution"
 
 
@@ -1781,6 +1867,11 @@ def finalize_task_execution_result(
     preserve_envelope_on_record_error: bool,
     task_record_store: TaskRecordStore | None,
 ) -> TaskExecutionResult:
+    envelope = (
+        with_failed_envelope_task_record_ref(envelope, record.task_record_ref or f"task_record:{task_id}")
+        if envelope.get("status") == "failed"
+        else dict(envelope)
+    )
     try:
         terminal_record = finish_task_record(record, envelope)
     except TaskRecordContractError as error:
@@ -1793,6 +1884,11 @@ def finalize_task_execution_result(
             invalidation_details["invalidation_reason"] = str(invalidation_error)
         if preserve_envelope_on_record_error and task_record_store is None:
             return TaskExecutionResult(dict(envelope), None)
+        if envelope.get("status") == "failed":
+            return TaskExecutionResult(
+                with_observability_write_failed(envelope, stage="completion", reason=str(error), details=invalidation_details),
+                None,
+            )
         return TaskExecutionResult(
             failure_envelope(
                 task_id,
@@ -1815,6 +1911,17 @@ def finalize_task_execution_result(
         task_record_store=task_record_store,
     )
     if persistence_error is not None:
+        if envelope.get("status") == "failed":
+            reason = persistence_error.envelope.get("error", {}).get("details", {}).get("reason", "")
+            return TaskExecutionResult(
+                with_observability_write_failed(
+                    envelope,
+                    stage="completion",
+                    reason=str(reason),
+                    details=dict(persistence_error.envelope.get("error", {}).get("details", {})),
+                ),
+                None,
+            )
         return persistence_error
     return TaskExecutionResult(dict(envelope), persisted_record or terminal_record)
 

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1418,7 +1418,139 @@ def with_runtime_observability(
         enriched["runtime_result_refs"] = list(runtime_result_refs)
     if execution_control_events:
         enriched["execution_control_events"] = list(execution_control_events)
+    if enriched.get("status") == "failed":
+        enriched = with_failure_observability(enriched)
     return enriched
+
+
+def with_failure_observability(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    if envelope.get("status") != "failed" or not isinstance(envelope.get("error"), Mapping):
+        return dict(envelope)
+
+    enriched = dict(envelope)
+    error = dict(enriched["error"])
+    details = dict(error.get("details") if isinstance(error.get("details"), Mapping) else {})
+    task_id = str(enriched.get("task_id") or "")
+    adapter_key = str(enriched.get("adapter_key") or "")
+    capability = str(enriched.get("capability") or "")
+    error_category = str(error.get("category") or "")
+    error_code = str(error.get("code") or "")
+    occurred_at = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    task_record_ref = details.get("task_record_ref")
+    if not isinstance(task_record_ref, str) or not task_record_ref:
+        task_record_ref = "none" if error_code == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED else f"task_record:{task_id}"
+    runtime_result_refs = list(enriched.get("runtime_result_refs") if isinstance(enriched.get("runtime_result_refs"), list) else [])
+    resource_trace_refs = list(details.get("resource_trace_refs") if isinstance(details.get("resource_trace_refs"), list) else [])
+    failure_phase = infer_failure_phase(error_category=error_category, error_code=error_code, details=details)
+    event_type = infer_failure_log_event_type(error_code=error_code, details=details, task_record_ref=task_record_ref)
+    metric_name = infer_failure_metric_name(event_type=event_type, failure_phase=failure_phase)
+    signal_id = f"runtime_failure_signal:{task_id}:{error_category}:{error_code}:{failure_phase}"
+    envelope_ref = f"failed_envelope:{task_id}:{error_category}:{error_code}"
+    failure_signal = {
+        "signal_id": signal_id,
+        "task_id": task_id,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "status": "failed",
+        "error_category": error_category,
+        "error_code": error_code,
+        "failure_phase": failure_phase,
+        "envelope_ref": envelope_ref,
+        "task_record_ref": task_record_ref,
+        "resource_trace_refs": resource_trace_refs,
+        "runtime_result_refs": runtime_result_refs,
+        "occurred_at": occurred_at,
+    }
+    log_event = {
+        "event_id": f"runtime_log:{task_id}:task_failed:{error_category}:{error_code}",
+        "task_id": task_id,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "event_type": event_type,
+        "level": "error",
+        "attempt_index": infer_attempt_index(runtime_result_refs),
+        "failure_signal_id": signal_id,
+        "resource_trace_refs": resource_trace_refs,
+        "runtime_result_refs": runtime_result_refs,
+        "message": f"task failed: {error_category}/{error_code}",
+        "occurred_at": occurred_at,
+    }
+    metric_sample = {
+        "metric_id": f"runtime_metric:{task_id}:{metric_name}:{error_category}:{error_code}",
+        "task_id": task_id,
+        "metric_name": metric_name,
+        "metric_value": 1,
+        "unit": "count",
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "error_category": error_category,
+        "error_code": error_code,
+        "failure_phase": failure_phase,
+        "attempt_index": log_event["attempt_index"],
+        "occurred_at": occurred_at,
+    }
+    enriched["runtime_failure_signal"] = failure_signal
+    enriched["runtime_structured_log_events"] = [log_event]
+    enriched["runtime_execution_metric_samples"] = [metric_sample]
+    return enriched
+
+
+def infer_failure_phase(*, error_category: str, error_code: str, details: Mapping[str, Any]) -> str:
+    event = details.get("execution_control_event")
+    if isinstance(event, Mapping):
+        event_type = event.get("event_type")
+        if event_type in {EXECUTION_CONTROL_EVENT_ADMISSION_CONCURRENCY_REJECTED, EXECUTION_CONTROL_EVENT_RETRY_CONCURRENCY_REJECTED}:
+            return "concurrency_rejected"
+        if event_type == EXECUTION_CONTROL_EVENT_RETRY_EXHAUSTED:
+            return "retry_exhausted"
+    if details.get("retry_exhausted") is True:
+        return "retry_exhausted"
+    if error_code == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED:
+        return "concurrency_rejected"
+    if error_code == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT or details.get("control_code") == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT:
+        return "timeout"
+    if error_code in {"resource_unavailable", "invalid_resource_requirement"}:
+        return "resource_acquire"
+    if error_category == "invalid_input":
+        return "admission"
+    if error_category == "runtime_contract":
+        return "pre_execution"
+    return "adapter_execution"
+
+
+def infer_failure_log_event_type(*, error_code: str, details: Mapping[str, Any], task_record_ref: str) -> str:
+    event = details.get("execution_control_event")
+    if isinstance(event, Mapping):
+        event_type = event.get("event_type")
+        if event_type in {
+            EXECUTION_CONTROL_EVENT_ADMISSION_CONCURRENCY_REJECTED,
+            EXECUTION_CONTROL_EVENT_RETRY_CONCURRENCY_REJECTED,
+        }:
+            return str(event_type)
+    if error_code == EXECUTION_CONTROL_CODE_CONCURRENCY_LIMIT_EXCEEDED and task_record_ref == "none":
+        return EXECUTION_CONTROL_EVENT_ADMISSION_CONCURRENCY_REJECTED
+    if error_code == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT or details.get("control_code") == EXECUTION_CONTROL_CODE_EXECUTION_TIMEOUT:
+        return "timeout_triggered"
+    return "task_failed"
+
+
+def infer_failure_metric_name(*, event_type: str, failure_phase: str) -> str:
+    if event_type == EXECUTION_CONTROL_EVENT_ADMISSION_CONCURRENCY_REJECTED:
+        return "admission_concurrency_rejected_total"
+    if event_type == EXECUTION_CONTROL_EVENT_RETRY_CONCURRENCY_REJECTED:
+        return "retry_concurrency_rejected_total"
+    if failure_phase == "timeout":
+        return "timeout_total"
+    return "task_failed_total"
+
+
+def infer_attempt_index(runtime_result_refs: list[Any]) -> int:
+    for entry in reversed(runtime_result_refs):
+        if isinstance(entry, Mapping):
+            attempt_index = entry.get("attempt_index")
+            if isinstance(attempt_index, int) and attempt_index >= 0:
+                return attempt_index
+    return 0
 
 
 def with_failed_envelope_control_details(
@@ -2291,7 +2423,7 @@ def failure_envelope(task_id: str, adapter_key: str, capability: str, error: Map
     details = error.get("details", {})
     if not isinstance(details, Mapping):
         details = {}
-    return {
+    envelope = {
         "task_id": task_id,
         "adapter_key": adapter_key,
         "capability": capability,
@@ -2303,6 +2435,7 @@ def failure_envelope(task_id: str, adapter_key: str, capability: str, error: Map
             "details": dict(details),
         },
     }
+    return with_failure_observability(envelope)
 
 
 def runtime_contract_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -817,6 +817,7 @@ def execute_controlled_adapter_attempts(
                 structured_log_events,
                 metric_samples,
             )
+        retry_result_refs = [attempt.attempt_outcome_ref] if attempt.attempt_outcome_ref is not None else []
         retry_log_event, retry_metric_sample = build_retry_scheduled_observability(
             task_id=task_id,
             adapter_key=adapter_key,
@@ -832,7 +833,7 @@ def execute_controlled_adapter_attempts(
                 if isinstance(envelope.get("runtime_failure_signal", {}).get("resource_trace_refs"), list)
                 else []
             ),
-            runtime_result_refs=runtime_result_refs,
+            runtime_result_refs=retry_result_refs,
             policy=policy,
         )
         structured_log_events.append(retry_log_event)

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -1066,7 +1066,8 @@ def execute_single_controlled_adapter_attempt(
             guard_release_error = release_attempt_admission_guard()
             if guard_release_error is not None:
                 envelope = failure_envelope(task_id, adapter_key, capability, guard_release_error)
-            return AdapterAttemptResult(envelope, None)
+                event = None
+            return AdapterAttemptResult(envelope, None, execution_control_event=event)
         guard_release_error = release_attempt_admission_guard()
         if guard_release_error is not None:
             release_error = release_execution_concurrency_slot(slot)
@@ -2116,17 +2117,20 @@ def persist_task_record(
     try:
         return task_record_store.write(record), None
     except TaskRecordConflictError as error:
+        envelope = failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error(
+                "task_record_conflict",
+                "共享任务记录写入与既有 durable truth 冲突",
+                details={"stage": stage, "reason": str(error)},
+            ),
+        )
+        if stage in {"running", "completion"}:
+            envelope = with_failed_envelope_task_record_ref(envelope, record.task_record_ref or f"task_record:{task_id}")
         return None, TaskExecutionResult(
-            with_failure_observability(failure_envelope(
-                task_id,
-                adapter_key,
-                capability,
-                runtime_contract_error(
-                    "task_record_conflict",
-                    "共享任务记录写入与既有 durable truth 冲突",
-                    details={"stage": stage, "reason": str(error)},
-                ),
-            )),
+            with_failure_observability(envelope),
             None,
         )
     except (TaskRecordContractError, TaskRecordStoreError, OSError) as error:
@@ -2136,6 +2140,7 @@ def persist_task_record(
             capability,
             stage=stage,
             task_record_store=task_record_store,
+            task_record_ref=record.task_record_ref or f"task_record:{task_id}" if stage in {"running", "completion"} else None,
             error=error,
         )
     except Exception as error:
@@ -2145,6 +2150,7 @@ def persist_task_record(
             capability,
             stage=stage,
             task_record_store=task_record_store,
+            task_record_ref=record.task_record_ref or f"task_record:{task_id}" if stage in {"running", "completion"} else None,
             error=error,
         )
 
@@ -2156,6 +2162,7 @@ def _fail_closed_task_record_persistence(
     *,
     stage: str,
     task_record_store: TaskRecordStore,
+    task_record_ref: str | None,
     error: Exception,
 ) -> tuple[TaskRecord | None, TaskExecutionResult | None]:
     invalidation_details: dict[str, Any] = {}
@@ -2165,6 +2172,9 @@ def _fail_closed_task_record_persistence(
         invalidation_details["invalidation_reason"] = str(invalidation_error)
     except Exception as invalidation_error:
         invalidation_details["invalidation_reason"] = str(invalidation_error)
+    details = {"stage": stage, "reason": str(error), **invalidation_details}
+    if task_record_ref:
+        details["task_record_ref"] = task_record_ref
     return None, TaskExecutionResult(
         with_failure_observability(failure_envelope(
             task_id,
@@ -2173,7 +2183,7 @@ def _fail_closed_task_record_persistence(
             runtime_contract_error(
                 "task_record_persistence_failed",
                 "共享任务记录无法可靠写入本地稳定存储",
-                details={"stage": stage, "reason": str(error), **invalidation_details},
+                details=details,
             ),
         )),
         None,

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -554,7 +554,7 @@ def execute_task_internal(
         release_error = dict(release_error)
         release_error["details"] = release_details
         return TaskExecutionResult(
-            failure_envelope(task_id, adapter_key, capability, release_error),
+            with_failure_observability(failure_envelope(task_id, adapter_key, capability, release_error)),
             None,
         )
 
@@ -565,7 +565,7 @@ def execute_task_internal(
         if release_failure is not None:
             return release_failure
         return TaskExecutionResult(
-            failure_envelope(
+            pre_accepted_failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
@@ -594,15 +594,28 @@ def execute_task_internal(
     except TaskRecordContractError as error:
         release_failure = release_admission_guard_or_failure("start_task_record")
         if release_failure is not None:
-            return release_failure
-        return TaskExecutionResult(
+            return finalize_task_execution_result(
+                task_id,
+                adapter_key,
+                capability,
+                record,
+                release_failure.envelope,
+                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
+                task_record_store=store,
+            )
+        return finalize_task_execution_result(
+            task_id,
+            adapter_key,
+            capability,
+            record,
             failure_envelope(
                 task_id,
                 adapter_key,
                 capability,
                 runtime_contract_error("invalid_task_record", str(error)),
             ),
-            None,
+            preserve_envelope_on_record_error=preserve_envelope_on_record_error,
+            task_record_store=store,
         )
     persisted_record, persistence_error = persist_task_record(
         task_id,
@@ -615,7 +628,15 @@ def execute_task_internal(
     if persistence_error is not None:
         release_failure = release_admission_guard_or_failure("persist_running")
         if release_failure is not None:
-            return release_failure
+            return finalize_task_execution_result(
+                task_id,
+                adapter_key,
+                capability,
+                record,
+                release_failure.envelope,
+                preserve_envelope_on_record_error=preserve_envelope_on_record_error,
+                task_record_store=store,
+            )
         return persistence_error
     if persisted_record is not None:
         record = persisted_record
@@ -2037,16 +2058,22 @@ def finalize_task_execution_result(
                 with_observability_write_failed(envelope, stage="completion", reason=str(error), details=invalidation_details),
                 None,
             )
+        failed_envelope = failure_envelope(
+            task_id,
+            adapter_key,
+            capability,
+            runtime_contract_error(
+                "envelope_not_json_serializable",
+                "共享终态结果无法收口为 JSON-safe TaskRecord",
+                details={"reason": str(error), **invalidation_details},
+            ),
+        )
         return TaskExecutionResult(
-            failure_envelope(
-                task_id,
-                adapter_key,
-                capability,
-                runtime_contract_error(
-                    "envelope_not_json_serializable",
-                    "共享终态结果无法收口为 JSON-safe TaskRecord",
-                    details={"reason": str(error), **invalidation_details},
-                ),
+            with_failure_observability(
+                with_failed_envelope_task_record_ref(
+                    failed_envelope,
+                    record.task_record_ref or f"task_record:{task_id}",
+                )
             ),
             None,
         )

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -60,6 +60,11 @@ RUNTIME_EXECUTION_METRIC_NAMES = frozenset(
         "execution_duration_ms",
     }
 )
+RUNTIME_RESULT_REF_TYPES = frozenset({"ExecutionAttemptOutcome", "ExecutionControlEvent"})
+EXECUTION_ATTEMPT_OUTCOMES = frozenset({"succeeded", "failed", "timeout"})
+EXECUTION_CONTROL_EVENT_TYPES = frozenset(
+    {"admission_concurrency_rejected", "retry_concurrency_rejected", "retry_exhausted"}
+)
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 
 
@@ -777,8 +782,8 @@ def validate_runtime_failure_signals(record: TaskRecord) -> None:
         task_record_ref = require_string(signal.get("task_record_ref"), field="RuntimeFailureSignal.task_record_ref")
         if task_record_ref != "none" and task_record_ref != record.task_record_ref:
             raise TaskRecordContractError("RuntimeFailureSignal.task_record_ref 与 TaskRecord 不一致")
-        _observability_entries(signal, "resource_trace_refs", ())
-        _observability_entries(signal, "runtime_result_refs", ())
+        validate_resource_trace_refs(signal, field="RuntimeFailureSignal.resource_trace_refs")
+        validate_runtime_result_refs(record, signal, field="RuntimeFailureSignal.runtime_result_refs")
         validate_timestamp(require_string(signal.get("occurred_at"), field="RuntimeFailureSignal.occurred_at"), field="RuntimeFailureSignal.occurred_at")
 
 
@@ -814,10 +819,69 @@ def validate_runtime_structured_log_events(record: TaskRecord) -> None:
         }:
             if not failure_signal_id or failure_signal_id not in signal_ids:
                 raise TaskRecordContractError("失败相关 RuntimeStructuredLogEvent 必须引用对应 RuntimeFailureSignal")
-        _observability_entries(event, "resource_trace_refs", ())
-        _observability_entries(event, "runtime_result_refs", ())
+        validate_resource_trace_refs(event, field="RuntimeStructuredLogEvent.resource_trace_refs")
+        validate_runtime_result_refs(record, event, field="RuntimeStructuredLogEvent.runtime_result_refs")
         require_string(event.get("message"), field="RuntimeStructuredLogEvent.message")
         validate_timestamp(require_string(event.get("occurred_at"), field="RuntimeStructuredLogEvent.occurred_at"), field="RuntimeStructuredLogEvent.occurred_at")
+
+
+def validate_resource_trace_refs(source: Mapping[str, Any], *, field: str) -> None:
+    field_name = field.rsplit(".", 1)[-1]
+    for ref in _observability_entries(source, field_name, ()):
+        if not isinstance(ref, Mapping):
+            raise TaskRecordContractError(f"{field} 项必须是对象")
+        ref_type = require_string(ref.get("ref_type"), field=f"{field}.ref_type")
+        if ref_type != "ResourceTraceEvent":
+            raise TaskRecordContractError(f"{field}.ref_type 必须为 ResourceTraceEvent")
+        require_string(ref.get("event_id"), field=f"{field}.event_id")
+        require_string(ref.get("lease_id"), field=f"{field}.lease_id")
+        require_string(ref.get("bundle_id"), field=f"{field}.bundle_id")
+        require_string(ref.get("resource_id"), field=f"{field}.resource_id")
+        require_string(ref.get("resource_type"), field=f"{field}.resource_type")
+
+
+def validate_runtime_result_refs(record: TaskRecord, source: Mapping[str, Any], *, field: str) -> None:
+    field_name = field.rsplit(".", 1)[-1]
+    for ref in _observability_entries(source, field_name, ()):
+        if not isinstance(ref, Mapping):
+            raise TaskRecordContractError(f"{field} 项必须是对象")
+        ref_type = require_string(ref.get("ref_type"), field=f"{field}.ref_type")
+        if ref_type not in RUNTIME_RESULT_REF_TYPES:
+            raise TaskRecordContractError(f"{field}.ref_type 不在允许值范围内")
+        task_id = require_string(ref.get("task_id"), field=f"{field}.task_id")
+        adapter_key = require_string(ref.get("adapter_key"), field=f"{field}.adapter_key")
+        capability = require_string(ref.get("capability"), field=f"{field}.capability")
+        if task_id != record.task_id or adapter_key != record.request.adapter_key or capability != record.request.capability:
+            raise TaskRecordContractError(f"{field} 必须绑定同一 TaskRecord 请求上下文")
+        require_string(ref.get("ref_id"), field=f"{field}.ref_id")
+        if ref_type == "ExecutionAttemptOutcome":
+            attempt_index = coerce_int(ref.get("attempt_index"), field=f"{field}.attempt_index")
+            if attempt_index < 0:
+                raise TaskRecordContractError(f"{field}.attempt_index 必须为非负整数")
+            validate_timestamp(require_string(ref.get("started_at"), field=f"{field}.started_at"), field=f"{field}.started_at")
+            validate_timestamp(require_string(ref.get("ended_at"), field=f"{field}.ended_at"), field=f"{field}.ended_at")
+            outcome = require_string(ref.get("outcome"), field=f"{field}.outcome")
+            if outcome not in EXECUTION_ATTEMPT_OUTCOMES:
+                raise TaskRecordContractError(f"{field}.outcome 不在允许值范围内")
+            if not isinstance(ref.get("terminal_envelope"), Mapping):
+                raise TaskRecordContractError(f"{field}.terminal_envelope 必须是对象")
+            control_code = ref.get("control_code", "")
+            if not isinstance(control_code, str):
+                raise TaskRecordContractError(f"{field}.control_code 必须是字符串")
+            continue
+        event_type = require_string(ref.get("event_type"), field=f"{field}.event_type")
+        if event_type not in EXECUTION_CONTROL_EVENT_TYPES:
+            raise TaskRecordContractError(f"{field}.event_type 不在允许值范围内")
+        attempt_count = coerce_int(ref.get("attempt_count"), field=f"{field}.attempt_count")
+        if attempt_count < 0:
+            raise TaskRecordContractError(f"{field}.attempt_count 必须为非负整数")
+        require_string(ref.get("control_code"), field=f"{field}.control_code")
+        task_record_ref = require_string(ref.get("task_record_ref"), field=f"{field}.task_record_ref")
+        if task_record_ref != "none" and task_record_ref != record.task_record_ref:
+            raise TaskRecordContractError(f"{field}.task_record_ref 与 TaskRecord 不一致")
+        if not isinstance(ref.get("policy"), Mapping):
+            raise TaskRecordContractError(f"{field}.policy 必须是对象")
+        validate_timestamp(require_string(ref.get("occurred_at"), field=f"{field}.occurred_at"), field=f"{field}.occurred_at")
 
 
 def validate_runtime_execution_metric_samples(record: TaskRecord) -> None:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -76,6 +76,66 @@ def task_record_ref_for(task_id: str) -> str:
     return f"task_record:{task_id}"
 
 
+def _runtime_structured_log_event(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    event_type: str,
+    level: str,
+    occurred_at: str,
+    message: str,
+    attempt_index: int = 0,
+    failure_signal_id: str = "",
+    resource_trace_refs: tuple[Any, ...] | list[Any] | None = None,
+    runtime_result_refs: tuple[Any, ...] | list[Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "event_id": f"runtime_log:{task_id}:{event_type}:{attempt_index}",
+        "task_id": task_id,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "event_type": event_type,
+        "level": level,
+        "attempt_index": attempt_index,
+        "failure_signal_id": failure_signal_id,
+        "resource_trace_refs": list(resource_trace_refs or []),
+        "runtime_result_refs": list(runtime_result_refs or []),
+        "message": message,
+        "occurred_at": occurred_at,
+    }
+
+
+def _runtime_execution_metric_sample(
+    *,
+    task_id: str,
+    adapter_key: str,
+    capability: str,
+    metric_name: str,
+    metric_value: int | float,
+    unit: str,
+    occurred_at: str,
+    attempt_index: int = 0,
+    error_category: str = "",
+    error_code: str = "",
+    failure_phase: str = "",
+) -> dict[str, Any]:
+    return {
+        "metric_id": f"runtime_metric:{task_id}:{metric_name}:{attempt_index}",
+        "task_id": task_id,
+        "metric_name": metric_name,
+        "metric_value": metric_value,
+        "unit": unit,
+        "adapter_key": adapter_key,
+        "capability": capability,
+        "error_category": error_category,
+        "error_code": error_code,
+        "failure_phase": failure_phase,
+        "attempt_index": attempt_index,
+        "occurred_at": occurred_at,
+    }
+
+
 def build_task_request_snapshot(request: Any) -> TaskRequestSnapshot:
     try:
         target = request.target
@@ -132,6 +192,28 @@ def create_task_record(
             ),
         ),
         task_record_ref=task_record_ref_for(task_id),
+        runtime_structured_log_events=(
+            _runtime_structured_log_event(
+                task_id=task_id,
+                adapter_key=request.adapter_key,
+                capability=request.capability,
+                event_type="task_accepted",
+                level="info",
+                occurred_at=timestamp,
+                message="task accepted",
+            ),
+        ),
+        runtime_execution_metric_samples=(
+            _runtime_execution_metric_sample(
+                task_id=task_id,
+                adapter_key=request.adapter_key,
+                capability=request.capability,
+                metric_name="task_started_total",
+                metric_value=1,
+                unit="count",
+                occurred_at=timestamp,
+            ),
+        ),
     )
     validate_task_record(record)
     return record
@@ -168,7 +250,18 @@ def start_task_record(record: TaskRecord, *, occurred_at: str | None = None) -> 
         runtime_result_refs=record.runtime_result_refs,
         execution_control_events=record.execution_control_events,
         runtime_failure_signals=record.runtime_failure_signals,
-        runtime_structured_log_events=record.runtime_structured_log_events,
+        runtime_structured_log_events=record.runtime_structured_log_events
+        + (
+            _runtime_structured_log_event(
+                task_id=record.task_id,
+                adapter_key=record.request.adapter_key,
+                capability=record.request.capability,
+                event_type="task_running",
+                level="info",
+                occurred_at=timestamp,
+                message="task running",
+            ),
+        ),
         runtime_execution_metric_samples=record.runtime_execution_metric_samples,
     )
     validate_task_record(updated)
@@ -181,6 +274,7 @@ def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occur
     normalized_envelope = normalize_json_value(envelope, field="result.envelope")
     if not isinstance(normalized_envelope, dict):
         raise TaskRecordContractError("TaskTerminalResult.envelope 必须是对象")
+    private_failure_signals = normalized_envelope.pop("_runtime_failure_signals", None)
     private_structured_log_events = normalized_envelope.pop("_runtime_structured_log_events", None)
     private_metric_samples = normalized_envelope.pop("_runtime_execution_metric_samples", None)
     if terminal_status == "succeeded":
@@ -213,6 +307,62 @@ def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occur
         if isinstance(code, str) and code:
             log_code = code
 
+    runtime_failure_signals = (
+        record.runtime_failure_signals
+        + _observability_entries({"runtime_failure_signals": private_failure_signals}, "runtime_failure_signals", ())
+        if private_failure_signals is not None
+        else _runtime_failure_signals(normalized_envelope, record.runtime_failure_signals)
+    )
+    runtime_structured_log_events = record.runtime_structured_log_events + _observability_entries(
+        {"runtime_structured_log_events": private_structured_log_events}
+        if private_structured_log_events is not None
+        else normalized_envelope,
+        "runtime_structured_log_events",
+        (),
+    )
+    runtime_execution_metric_samples = record.runtime_execution_metric_samples + _observability_entries(
+        {"runtime_execution_metric_samples": private_metric_samples}
+        if private_metric_samples is not None
+        else normalized_envelope,
+        "runtime_execution_metric_samples",
+        (),
+    )
+    if terminal_status == "succeeded":
+        runtime_structured_log_events = runtime_structured_log_events + (
+            _runtime_structured_log_event(
+                task_id=record.task_id,
+                adapter_key=record.request.adapter_key,
+                capability=record.request.capability,
+                event_type="task_succeeded",
+                level="info",
+                occurred_at=timestamp,
+                message="task succeeded",
+            ),
+        )
+        runtime_execution_metric_samples = runtime_execution_metric_samples + (
+            _runtime_execution_metric_sample(
+                task_id=record.task_id,
+                adapter_key=record.request.adapter_key,
+                capability=record.request.capability,
+                metric_name="task_succeeded_total",
+                metric_value=1,
+                unit="count",
+                occurred_at=timestamp,
+            ),
+            _runtime_execution_metric_sample(
+                task_id=record.task_id,
+                adapter_key=record.request.adapter_key,
+                capability=record.request.capability,
+                metric_name="execution_duration_ms",
+                metric_value=max(
+                    0,
+                    int((parse_timestamp(timestamp, field="terminal_at") - parse_timestamp(record.created_at, field="created_at")).total_seconds() * 1000),
+                ),
+                unit="ms",
+                occurred_at=timestamp,
+            ),
+        )
+
     updated = TaskRecord(
         schema_version=record.schema_version,
         task_id=record.task_id,
@@ -240,25 +390,9 @@ def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occur
             "execution_control_events",
             record.execution_control_events,
         ),
-        runtime_failure_signals=_runtime_failure_signals(normalized_envelope, record.runtime_failure_signals),
-        runtime_structured_log_events=_observability_entries(
-            (
-                {"runtime_structured_log_events": private_structured_log_events}
-                if private_structured_log_events is not None
-                else normalized_envelope
-            ),
-            "runtime_structured_log_events",
-            record.runtime_structured_log_events,
-        ),
-        runtime_execution_metric_samples=_observability_entries(
-            (
-                {"runtime_execution_metric_samples": private_metric_samples}
-                if private_metric_samples is not None
-                else normalized_envelope
-            ),
-            "runtime_execution_metric_samples",
-            record.runtime_execution_metric_samples,
-        ),
+        runtime_failure_signals=runtime_failure_signals,
+        runtime_structured_log_events=runtime_structured_log_events,
+        runtime_execution_metric_samples=runtime_execution_metric_samples,
     )
     validate_task_record(updated)
     return updated
@@ -391,6 +525,7 @@ def validate_task_record(record: TaskRecord) -> None:
         != record.runtime_failure_signals
     ):
         raise TaskRecordContractError("TaskRecord.runtime_failure_signals 必须预先满足 JSON-safe 约束")
+    validate_observability_replay_ids(record.runtime_failure_signals, id_field="signal_id", field="runtime_failure_signals")
     if (
         _observability_entries(
             {"runtime_structured_log_events": record.runtime_structured_log_events},
@@ -400,6 +535,11 @@ def validate_task_record(record: TaskRecord) -> None:
         != record.runtime_structured_log_events
     ):
         raise TaskRecordContractError("TaskRecord.runtime_structured_log_events 必须预先满足 JSON-safe 约束")
+    validate_observability_replay_ids(
+        record.runtime_structured_log_events,
+        id_field="event_id",
+        field="runtime_structured_log_events",
+    )
     if (
         _observability_entries(
             {"runtime_execution_metric_samples": record.runtime_execution_metric_samples},
@@ -409,6 +549,11 @@ def validate_task_record(record: TaskRecord) -> None:
         != record.runtime_execution_metric_samples
     ):
         raise TaskRecordContractError("TaskRecord.runtime_execution_metric_samples 必须预先满足 JSON-safe 约束")
+    validate_observability_replay_ids(
+        record.runtime_execution_metric_samples,
+        id_field="metric_id",
+        field="runtime_execution_metric_samples",
+    )
     validate_request_snapshot(record.request)
     if record.status not in TASK_RECORD_STATUSES:
         raise TaskRecordContractError("TaskRecord.status 不在允许值范围内")
@@ -553,6 +698,17 @@ def _observability_entries(source: Mapping[str, Any], field_name: str, default: 
     return tuple(normalized)
 
 
+def validate_observability_replay_ids(entries: tuple[Any, ...], *, id_field: str, field: str) -> None:
+    seen: dict[str, Any] = {}
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            raise TaskRecordContractError(f"TaskRecord.{field} 项必须是对象")
+        entry_id = require_string(entry.get(id_field), field=f"{field}.{id_field}")
+        if entry_id in seen and seen[entry_id] != entry:
+            raise TaskRecordContractError(f"TaskRecord.{field} 同一 {id_field} 不得对应不同 payload")
+        seen[entry_id] = entry
+
+
 def _runtime_failure_signals(envelope: Mapping[str, Any], default: tuple[Any, ...]) -> tuple[Any, ...]:
     if "runtime_failure_signal" in envelope:
         normalized = normalize_json_value(envelope["runtime_failure_signal"], field="runtime_failure_signal")
@@ -623,20 +779,29 @@ def validate_terminal_envelope_observability_contract(record: TaskRecord, envelo
             )
     if "runtime_failure_signal" in envelope or "runtime_failure_signals" in envelope:
         envelope_failure_signals = _runtime_failure_signals(envelope, ())
-        if envelope_failure_signals != record.runtime_failure_signals:
+        if not _observability_entries_are_subset(envelope_failure_signals, record.runtime_failure_signals):
             raise TaskRecordContractError("TaskTerminalResult.envelope.runtime_failure_signal 与 TaskRecord.runtime_failure_signals 不一致")
     if "runtime_structured_log_events" in envelope:
         envelope_log_events = _observability_entries(envelope, "runtime_structured_log_events", ())
-        if envelope_log_events != record.runtime_structured_log_events:
+        if not _observability_entries_are_subset(envelope_log_events, record.runtime_structured_log_events):
             raise TaskRecordContractError(
                 "TaskTerminalResult.envelope.runtime_structured_log_events 与 TaskRecord.runtime_structured_log_events 不一致"
             )
     if "runtime_execution_metric_samples" in envelope:
         envelope_metric_samples = _observability_entries(envelope, "runtime_execution_metric_samples", ())
-        if envelope_metric_samples != record.runtime_execution_metric_samples:
+        if not _observability_entries_are_subset(envelope_metric_samples, record.runtime_execution_metric_samples):
             raise TaskRecordContractError(
                 "TaskTerminalResult.envelope.runtime_execution_metric_samples 与 TaskRecord.runtime_execution_metric_samples 不一致"
             )
+
+
+def _observability_entries_are_subset(entries: tuple[Any, ...], superset: tuple[Any, ...]) -> bool:
+    remaining = list(superset)
+    for entry in entries:
+        if entry not in remaining:
+            return False
+        remaining.remove(entry)
+    return True
 
 
 def validate_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -181,6 +181,13 @@ def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occur
     normalized_envelope = normalize_json_value(envelope, field="result.envelope")
     if not isinstance(normalized_envelope, dict):
         raise TaskRecordContractError("TaskTerminalResult.envelope 必须是对象")
+    private_structured_log_events = normalized_envelope.pop("_runtime_structured_log_events", None)
+    private_metric_samples = normalized_envelope.pop("_runtime_execution_metric_samples", None)
+    if terminal_status == "succeeded":
+        normalized_envelope.pop("runtime_failure_signal", None)
+        normalized_envelope.pop("runtime_failure_signals", None)
+        normalized_envelope.pop("runtime_structured_log_events", None)
+        normalized_envelope.pop("runtime_execution_metric_samples", None)
     task_record_ref = _observability_task_record_ref(normalized_envelope, record)
     if task_record_ref is not None and "task_record_ref" not in normalized_envelope:
         normalized_envelope["task_record_ref"] = task_record_ref
@@ -235,12 +242,20 @@ def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occur
         ),
         runtime_failure_signals=_runtime_failure_signals(normalized_envelope, record.runtime_failure_signals),
         runtime_structured_log_events=_observability_entries(
-            normalized_envelope,
+            (
+                {"runtime_structured_log_events": private_structured_log_events}
+                if private_structured_log_events is not None
+                else normalized_envelope
+            ),
             "runtime_structured_log_events",
             record.runtime_structured_log_events,
         ),
         runtime_execution_metric_samples=_observability_entries(
-            normalized_envelope,
+            (
+                {"runtime_execution_metric_samples": private_metric_samples}
+                if private_metric_samples is not None
+                else normalized_envelope
+            ),
             "runtime_execution_metric_samples",
             record.runtime_execution_metric_samples,
         ),

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -804,7 +804,14 @@ def validate_runtime_structured_log_events(record: TaskRecord) -> None:
         failure_signal_id = event.get("failure_signal_id", "")
         if failure_signal_id is not None and not isinstance(failure_signal_id, str):
             raise TaskRecordContractError("RuntimeStructuredLogEvent.failure_signal_id 必须是字符串")
-        if event_type in {"task_failed", "timeout_triggered", "retry_scheduled", "observability_write_failed"}:
+        if event_type in {
+            "admission_concurrency_rejected",
+            "retry_concurrency_rejected",
+            "task_failed",
+            "timeout_triggered",
+            "retry_scheduled",
+            "observability_write_failed",
+        }:
             if not failure_signal_id or failure_signal_id not in signal_ids:
                 raise TaskRecordContractError("失败相关 RuntimeStructuredLogEvent 必须引用对应 RuntimeFailureSignal")
         _observability_entries(event, "resource_trace_refs", ())
@@ -847,6 +854,14 @@ def validate_runtime_execution_metric_samples(record: TaskRecord) -> None:
             raise TaskRecordContractError("RuntimeExecutionMetricSample.failure_phase 必须是字符串")
         if phase and phase not in RUNTIME_FAILURE_PHASES:
             raise TaskRecordContractError("RuntimeExecutionMetricSample.failure_phase 不在允许值范围内")
+        if metric_name in {
+            "task_failed_total",
+            "timeout_total",
+            "admission_concurrency_rejected_total",
+            "retry_concurrency_rejected_total",
+        }:
+            if not category or not error_code or not phase:
+                raise TaskRecordContractError("失败相关 RuntimeExecutionMetricSample 必须携带错误元数据")
         attempt_index = coerce_int(metric.get("attempt_index"), field="RuntimeExecutionMetricSample.attempt_index")
         if attempt_index < 0:
             raise TaskRecordContractError("RuntimeExecutionMetricSample.attempt_index 必须为非负整数")

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -63,6 +63,9 @@ class TaskRecord:
     task_record_ref: str | None = None
     runtime_result_refs: tuple[Any, ...] = field(default_factory=tuple)
     execution_control_events: tuple[Any, ...] = field(default_factory=tuple)
+    runtime_failure_signals: tuple[Any, ...] = field(default_factory=tuple)
+    runtime_structured_log_events: tuple[Any, ...] = field(default_factory=tuple)
+    runtime_execution_metric_samples: tuple[Any, ...] = field(default_factory=tuple)
 
 
 def now_rfc3339_utc() -> str:
@@ -164,6 +167,9 @@ def start_task_record(record: TaskRecord, *, occurred_at: str | None = None) -> 
         task_record_ref=record.task_record_ref,
         runtime_result_refs=record.runtime_result_refs,
         execution_control_events=record.execution_control_events,
+        runtime_failure_signals=record.runtime_failure_signals,
+        runtime_structured_log_events=record.runtime_structured_log_events,
+        runtime_execution_metric_samples=record.runtime_execution_metric_samples,
     )
     validate_task_record(updated)
     return updated
@@ -227,6 +233,17 @@ def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occur
             "execution_control_events",
             record.execution_control_events,
         ),
+        runtime_failure_signals=_runtime_failure_signals(normalized_envelope, record.runtime_failure_signals),
+        runtime_structured_log_events=_observability_entries(
+            normalized_envelope,
+            "runtime_structured_log_events",
+            record.runtime_structured_log_events,
+        ),
+        runtime_execution_metric_samples=_observability_entries(
+            normalized_envelope,
+            "runtime_execution_metric_samples",
+            record.runtime_execution_metric_samples,
+        ),
     )
     validate_task_record(updated)
     return updated
@@ -252,6 +269,9 @@ def task_record_to_dict(record: TaskRecord) -> dict[str, Any]:
         "task_record_ref": record.task_record_ref,
         "runtime_result_refs": list(record.runtime_result_refs),
         "execution_control_events": list(record.execution_control_events),
+        "runtime_failure_signals": list(record.runtime_failure_signals),
+        "runtime_structured_log_events": list(record.runtime_structured_log_events),
+        "runtime_execution_metric_samples": list(record.runtime_execution_metric_samples),
         "logs": [
             {
                 "sequence": entry.sequence,
@@ -326,6 +346,9 @@ def task_record_from_dict(payload: Mapping[str, Any]) -> TaskRecord:
         ),
         runtime_result_refs=_observability_entries(payload, "runtime_result_refs", ()),
         execution_control_events=_observability_entries(payload, "execution_control_events", ()),
+        runtime_failure_signals=_observability_entries(payload, "runtime_failure_signals", ()),
+        runtime_structured_log_events=_observability_entries(payload, "runtime_structured_log_events", ()),
+        runtime_execution_metric_samples=_observability_entries(payload, "runtime_execution_metric_samples", ()),
     )
     if len(record.logs) != len(logs_payload):
         raise TaskRecordContractError("TaskRecord.logs 项必须全部为对象")
@@ -348,6 +371,29 @@ def validate_task_record(record: TaskRecord) -> None:
         != record.execution_control_events
     ):
         raise TaskRecordContractError("TaskRecord.execution_control_events 必须预先满足 JSON-safe 约束")
+    if (
+        _observability_entries({"runtime_failure_signals": record.runtime_failure_signals}, "runtime_failure_signals", ())
+        != record.runtime_failure_signals
+    ):
+        raise TaskRecordContractError("TaskRecord.runtime_failure_signals 必须预先满足 JSON-safe 约束")
+    if (
+        _observability_entries(
+            {"runtime_structured_log_events": record.runtime_structured_log_events},
+            "runtime_structured_log_events",
+            (),
+        )
+        != record.runtime_structured_log_events
+    ):
+        raise TaskRecordContractError("TaskRecord.runtime_structured_log_events 必须预先满足 JSON-safe 约束")
+    if (
+        _observability_entries(
+            {"runtime_execution_metric_samples": record.runtime_execution_metric_samples},
+            "runtime_execution_metric_samples",
+            (),
+        )
+        != record.runtime_execution_metric_samples
+    ):
+        raise TaskRecordContractError("TaskRecord.runtime_execution_metric_samples 必须预先满足 JSON-safe 约束")
     validate_request_snapshot(record.request)
     if record.status not in TASK_RECORD_STATUSES:
         raise TaskRecordContractError("TaskRecord.status 不在允许值范围内")
@@ -492,6 +538,15 @@ def _observability_entries(source: Mapping[str, Any], field_name: str, default: 
     return tuple(normalized)
 
 
+def _runtime_failure_signals(envelope: Mapping[str, Any], default: tuple[Any, ...]) -> tuple[Any, ...]:
+    if "runtime_failure_signal" in envelope:
+        normalized = normalize_json_value(envelope["runtime_failure_signal"], field="runtime_failure_signal")
+        if not isinstance(normalized, Mapping):
+            raise TaskRecordContractError("runtime_failure_signal 必须是对象")
+        return (dict(normalized),)
+    return _observability_entries(envelope, "runtime_failure_signals", default)
+
+
 def coerce_int(value: Any, *, field: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         raise TaskRecordContractError(f"{field} 必须为整数")
@@ -550,6 +605,22 @@ def validate_terminal_envelope_observability_contract(record: TaskRecord, envelo
         if envelope_execution_control_events != record.execution_control_events:
             raise TaskRecordContractError(
                 "TaskTerminalResult.envelope.execution_control_events 与 TaskRecord.execution_control_events 不一致"
+            )
+    if "runtime_failure_signal" in envelope or "runtime_failure_signals" in envelope:
+        envelope_failure_signals = _runtime_failure_signals(envelope, ())
+        if envelope_failure_signals != record.runtime_failure_signals:
+            raise TaskRecordContractError("TaskTerminalResult.envelope.runtime_failure_signal 与 TaskRecord.runtime_failure_signals 不一致")
+    if "runtime_structured_log_events" in envelope:
+        envelope_log_events = _observability_entries(envelope, "runtime_structured_log_events", ())
+        if envelope_log_events != record.runtime_structured_log_events:
+            raise TaskRecordContractError(
+                "TaskTerminalResult.envelope.runtime_structured_log_events 与 TaskRecord.runtime_structured_log_events 不一致"
+            )
+    if "runtime_execution_metric_samples" in envelope:
+        envelope_metric_samples = _observability_entries(envelope, "runtime_execution_metric_samples", ())
+        if envelope_metric_samples != record.runtime_execution_metric_samples:
+            raise TaskRecordContractError(
+                "TaskTerminalResult.envelope.runtime_execution_metric_samples 与 TaskRecord.runtime_execution_metric_samples 不一致"
             )
 
 

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -18,6 +18,48 @@ SHARED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
 SHARED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
 ALLOWED_CONTENT_TYPES = frozenset({"video", "image_post", "mixed_media", "unknown"})
 ALLOWED_ERROR_CATEGORIES = frozenset({"invalid_input", "unsupported", "runtime_contract", "platform"})
+RUNTIME_FAILURE_PHASES = frozenset(
+    {
+        "admission",
+        "pre_execution",
+        "resource_acquire",
+        "adapter_execution",
+        "timeout",
+        "retry_exhausted",
+        "concurrency_rejected",
+        "persistence",
+        "observability",
+    }
+)
+RUNTIME_STRUCTURED_LOG_EVENT_TYPES = frozenset(
+    {
+        "task_accepted",
+        "task_running",
+        "attempt_started",
+        "attempt_finished",
+        "retry_scheduled",
+        "timeout_triggered",
+        "admission_concurrency_rejected",
+        "retry_concurrency_rejected",
+        "task_failed",
+        "task_succeeded",
+        "observability_write_failed",
+    }
+)
+RUNTIME_STRUCTURED_LOG_LEVELS = frozenset({"info", "warning", "error"})
+RUNTIME_EXECUTION_METRIC_NAMES = frozenset(
+    {
+        "task_started_total",
+        "task_succeeded_total",
+        "task_failed_total",
+        "attempt_started_total",
+        "retry_scheduled_total",
+        "timeout_total",
+        "admission_concurrency_rejected_total",
+        "retry_concurrency_rejected_total",
+        "execution_duration_ms",
+    }
+)
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 
 
@@ -310,6 +352,7 @@ def finish_task_record(record: TaskRecord, envelope: Mapping[str, Any], *, occur
     runtime_failure_signals = (
         record.runtime_failure_signals
         + _observability_entries({"runtime_failure_signals": private_failure_signals}, "runtime_failure_signals", ())
+        + _runtime_failure_signals(normalized_envelope, ())
         if private_failure_signals is not None
         else _runtime_failure_signals(normalized_envelope, record.runtime_failure_signals)
     )
@@ -526,6 +569,7 @@ def validate_task_record(record: TaskRecord) -> None:
     ):
         raise TaskRecordContractError("TaskRecord.runtime_failure_signals 必须预先满足 JSON-safe 约束")
     validate_observability_replay_ids(record.runtime_failure_signals, id_field="signal_id", field="runtime_failure_signals")
+    validate_runtime_failure_signals(record)
     if (
         _observability_entries(
             {"runtime_structured_log_events": record.runtime_structured_log_events},
@@ -540,6 +584,7 @@ def validate_task_record(record: TaskRecord) -> None:
         id_field="event_id",
         field="runtime_structured_log_events",
     )
+    validate_runtime_structured_log_events(record)
     if (
         _observability_entries(
             {"runtime_execution_metric_samples": record.runtime_execution_metric_samples},
@@ -554,6 +599,7 @@ def validate_task_record(record: TaskRecord) -> None:
         id_field="metric_id",
         field="runtime_execution_metric_samples",
     )
+    validate_runtime_execution_metric_samples(record)
     validate_request_snapshot(record.request)
     if record.status not in TASK_RECORD_STATUSES:
         raise TaskRecordContractError("TaskRecord.status 不在允许值范围内")
@@ -707,6 +753,104 @@ def validate_observability_replay_ids(entries: tuple[Any, ...], *, id_field: str
         if entry_id in seen and seen[entry_id] != entry:
             raise TaskRecordContractError(f"TaskRecord.{field} 同一 {id_field} 不得对应不同 payload")
         seen[entry_id] = entry
+
+
+def validate_runtime_failure_signals(record: TaskRecord) -> None:
+    for signal in record.runtime_failure_signals:
+        if not isinstance(signal, Mapping):
+            raise TaskRecordContractError("RuntimeFailureSignal 必须是对象")
+        task_id = require_string(signal.get("task_id"), field="RuntimeFailureSignal.task_id")
+        adapter_key = require_string(signal.get("adapter_key"), field="RuntimeFailureSignal.adapter_key")
+        capability = require_string(signal.get("capability"), field="RuntimeFailureSignal.capability")
+        if task_id != record.task_id or adapter_key != record.request.adapter_key or capability != record.request.capability:
+            raise TaskRecordContractError("RuntimeFailureSignal 必须绑定同一 TaskRecord 请求上下文")
+        if signal.get("status") != "failed":
+            raise TaskRecordContractError("RuntimeFailureSignal.status 必须为 failed")
+        category = require_string(signal.get("error_category"), field="RuntimeFailureSignal.error_category")
+        if category not in ALLOWED_ERROR_CATEGORIES:
+            raise TaskRecordContractError("RuntimeFailureSignal.error_category 不在允许值范围内")
+        require_string(signal.get("error_code"), field="RuntimeFailureSignal.error_code")
+        phase = require_string(signal.get("failure_phase"), field="RuntimeFailureSignal.failure_phase")
+        if phase not in RUNTIME_FAILURE_PHASES:
+            raise TaskRecordContractError("RuntimeFailureSignal.failure_phase 不在允许值范围内")
+        require_string(signal.get("envelope_ref"), field="RuntimeFailureSignal.envelope_ref")
+        task_record_ref = require_string(signal.get("task_record_ref"), field="RuntimeFailureSignal.task_record_ref")
+        if task_record_ref != "none" and task_record_ref != record.task_record_ref:
+            raise TaskRecordContractError("RuntimeFailureSignal.task_record_ref 与 TaskRecord 不一致")
+        _observability_entries(signal, "resource_trace_refs", ())
+        _observability_entries(signal, "runtime_result_refs", ())
+        validate_timestamp(require_string(signal.get("occurred_at"), field="RuntimeFailureSignal.occurred_at"), field="RuntimeFailureSignal.occurred_at")
+
+
+def validate_runtime_structured_log_events(record: TaskRecord) -> None:
+    signal_ids = {signal.get("signal_id") for signal in record.runtime_failure_signals if isinstance(signal, Mapping)}
+    for event in record.runtime_structured_log_events:
+        if not isinstance(event, Mapping):
+            raise TaskRecordContractError("RuntimeStructuredLogEvent 必须是对象")
+        task_id = require_string(event.get("task_id"), field="RuntimeStructuredLogEvent.task_id")
+        adapter_key = require_string(event.get("adapter_key"), field="RuntimeStructuredLogEvent.adapter_key")
+        capability = require_string(event.get("capability"), field="RuntimeStructuredLogEvent.capability")
+        if task_id != record.task_id or adapter_key != record.request.adapter_key or capability != record.request.capability:
+            raise TaskRecordContractError("RuntimeStructuredLogEvent 必须绑定同一 TaskRecord 请求上下文")
+        event_type = require_string(event.get("event_type"), field="RuntimeStructuredLogEvent.event_type")
+        if event_type not in RUNTIME_STRUCTURED_LOG_EVENT_TYPES:
+            raise TaskRecordContractError("RuntimeStructuredLogEvent.event_type 不在允许值范围内")
+        level = require_string(event.get("level"), field="RuntimeStructuredLogEvent.level")
+        if level not in RUNTIME_STRUCTURED_LOG_LEVELS:
+            raise TaskRecordContractError("RuntimeStructuredLogEvent.level 不在允许值范围内")
+        attempt_index = coerce_int(event.get("attempt_index"), field="RuntimeStructuredLogEvent.attempt_index")
+        if attempt_index < 0:
+            raise TaskRecordContractError("RuntimeStructuredLogEvent.attempt_index 必须为非负整数")
+        failure_signal_id = event.get("failure_signal_id", "")
+        if failure_signal_id is not None and not isinstance(failure_signal_id, str):
+            raise TaskRecordContractError("RuntimeStructuredLogEvent.failure_signal_id 必须是字符串")
+        if event_type in {"task_failed", "timeout_triggered", "retry_scheduled", "observability_write_failed"}:
+            if not failure_signal_id or failure_signal_id not in signal_ids:
+                raise TaskRecordContractError("失败相关 RuntimeStructuredLogEvent 必须引用对应 RuntimeFailureSignal")
+        _observability_entries(event, "resource_trace_refs", ())
+        _observability_entries(event, "runtime_result_refs", ())
+        require_string(event.get("message"), field="RuntimeStructuredLogEvent.message")
+        validate_timestamp(require_string(event.get("occurred_at"), field="RuntimeStructuredLogEvent.occurred_at"), field="RuntimeStructuredLogEvent.occurred_at")
+
+
+def validate_runtime_execution_metric_samples(record: TaskRecord) -> None:
+    for metric in record.runtime_execution_metric_samples:
+        if not isinstance(metric, Mapping):
+            raise TaskRecordContractError("RuntimeExecutionMetricSample 必须是对象")
+        task_id = require_string(metric.get("task_id"), field="RuntimeExecutionMetricSample.task_id")
+        adapter_key = require_string(metric.get("adapter_key"), field="RuntimeExecutionMetricSample.adapter_key")
+        capability = require_string(metric.get("capability"), field="RuntimeExecutionMetricSample.capability")
+        if task_id != record.task_id or adapter_key != record.request.adapter_key or capability != record.request.capability:
+            raise TaskRecordContractError("RuntimeExecutionMetricSample 必须绑定同一 TaskRecord 请求上下文")
+        metric_name = require_string(metric.get("metric_name"), field="RuntimeExecutionMetricSample.metric_name")
+        if metric_name not in RUNTIME_EXECUTION_METRIC_NAMES:
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.metric_name 不在允许值范围内")
+        value = metric.get("metric_value")
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or math.isnan(value) or value < 0:
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.metric_value 必须为非负数")
+        unit = require_string(metric.get("unit"), field="RuntimeExecutionMetricSample.unit")
+        if metric_name == "execution_duration_ms":
+            if unit != "ms":
+                raise TaskRecordContractError("RuntimeExecutionMetricSample execution_duration_ms unit 必须为 ms")
+        elif unit != "count" or not isinstance(value, int):
+            raise TaskRecordContractError("RuntimeExecutionMetricSample 计数指标必须使用 count 整数")
+        category = metric.get("error_category")
+        if not isinstance(category, str):
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.error_category 必须是字符串")
+        if category and category not in ALLOWED_ERROR_CATEGORIES:
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.error_category 不在允许值范围内")
+        error_code = metric.get("error_code")
+        if not isinstance(error_code, str):
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.error_code 必须是字符串")
+        phase = metric.get("failure_phase")
+        if not isinstance(phase, str):
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.failure_phase 必须是字符串")
+        if phase and phase not in RUNTIME_FAILURE_PHASES:
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.failure_phase 不在允许值范围内")
+        attempt_index = coerce_int(metric.get("attempt_index"), field="RuntimeExecutionMetricSample.attempt_index")
+        if attempt_index < 0:
+            raise TaskRecordContractError("RuntimeExecutionMetricSample.attempt_index 必须为非负整数")
+        validate_timestamp(require_string(metric.get("occurred_at"), field="RuntimeExecutionMetricSample.occurred_at"), field="RuntimeExecutionMetricSample.occurred_at")
 
 
 def _runtime_failure_signals(envelope: Mapping[str, Any], default: tuple[Any, ...]) -> tuple[Any, ...]:

--- a/syvert/task_record_store.py
+++ b/syvert/task_record_store.py
@@ -183,6 +183,8 @@ def reconcile_persisted_record(existing: TaskRecord | None, incoming: TaskRecord
             if incoming.result is None or incoming.terminal_at is None:
                 raise TaskRecordConflictError("终态任务记录缺少结果或终态时间")
             candidate = finish_task_record(existing, incoming.result.envelope, occurred_at=incoming.terminal_at)
+            if candidate != incoming:
+                candidate = merge_incoming_terminal_observability(candidate, incoming)
         elif existing.status in {"succeeded", "failed"} and incoming.status in {"succeeded", "failed"}:
             if incoming.result is None or incoming.terminal_at is None:
                 raise TaskRecordConflictError("终态任务记录缺少结果或终态时间")
@@ -192,13 +194,54 @@ def reconcile_persisted_record(existing: TaskRecord | None, incoming: TaskRecord
     except TaskRecordContractError as error:
         raise TaskRecordConflictError("本地持久化记录的生命周期推进不合法") from error
 
-    if candidate != incoming and incoming.status in {"succeeded", "failed"}:
-        candidate = replace(
-            candidate,
-            runtime_failure_signals=incoming.runtime_failure_signals,
-            runtime_structured_log_events=incoming.runtime_structured_log_events,
-            runtime_execution_metric_samples=incoming.runtime_execution_metric_samples,
-        )
     if candidate != incoming:
         raise TaskRecordConflictError("本地持久化记录与共享模型不一致")
     return candidate
+
+
+def merge_incoming_terminal_observability(candidate: TaskRecord, incoming: TaskRecord) -> TaskRecord:
+    if candidate.result != incoming.result or candidate.logs != incoming.logs:
+        return candidate
+    ensure_observability_no_conflict(
+        candidate.runtime_failure_signals,
+        incoming.runtime_failure_signals,
+        id_field="signal_id",
+        field="runtime_failure_signals",
+    )
+    ensure_observability_no_conflict(
+        candidate.runtime_structured_log_events,
+        incoming.runtime_structured_log_events,
+        id_field="event_id",
+        field="runtime_structured_log_events",
+    )
+    ensure_observability_no_conflict(
+        candidate.runtime_execution_metric_samples,
+        incoming.runtime_execution_metric_samples,
+        id_field="metric_id",
+        field="runtime_execution_metric_samples",
+    )
+    return replace(
+        candidate,
+        runtime_failure_signals=incoming.runtime_failure_signals,
+        runtime_structured_log_events=incoming.runtime_structured_log_events,
+        runtime_execution_metric_samples=incoming.runtime_execution_metric_samples,
+    )
+
+
+def ensure_observability_no_conflict(
+    candidate_entries: tuple[object, ...],
+    incoming_entries: tuple[object, ...],
+    *,
+    id_field: str,
+    field: str,
+) -> None:
+    by_id: dict[str, object] = {}
+    for entry in candidate_entries:
+        if isinstance(entry, Mapping) and isinstance(entry.get(id_field), str):
+            by_id[str(entry[id_field])] = entry
+    for entry in incoming_entries:
+        if not isinstance(entry, Mapping) or not isinstance(entry.get(id_field), str):
+            raise TaskRecordConflictError(f"本地持久化记录的 {field} 不满足共享模型")
+        entry_id = str(entry[id_field])
+        if entry_id in by_id and by_id[entry_id] != entry:
+            raise TaskRecordConflictError(f"本地持久化记录的 {field} 存在同 ID 冲突")

--- a/syvert/task_record_store.py
+++ b/syvert/task_record_store.py
@@ -192,7 +192,13 @@ def reconcile_persisted_record(existing: TaskRecord | None, incoming: TaskRecord
         elif existing.status in {"succeeded", "failed"} and incoming.status in {"succeeded", "failed"}:
             if incoming.result is None or incoming.terminal_at is None:
                 raise TaskRecordConflictError("终态任务记录缺少结果或终态时间")
-            candidate = finish_task_record(existing, incoming.result.envelope, occurred_at=incoming.terminal_at)
+            candidate = finish_task_record(
+                existing,
+                terminal_envelope_with_observability(incoming),
+                occurred_at=incoming.terminal_at,
+            )
+            if candidate != incoming:
+                candidate = merge_incoming_terminal_observability(candidate, incoming)
         else:
             raise TaskRecordConflictError("本地持久化记录的生命周期推进不合法")
     except TaskRecordContractError as error:

--- a/syvert/task_record_store.py
+++ b/syvert/task_record_store.py
@@ -182,7 +182,11 @@ def reconcile_persisted_record(existing: TaskRecord | None, incoming: TaskRecord
         elif existing.status == "running" and incoming.status in {"succeeded", "failed"}:
             if incoming.result is None or incoming.terminal_at is None:
                 raise TaskRecordConflictError("终态任务记录缺少结果或终态时间")
-            candidate = finish_task_record(existing, incoming.result.envelope, occurred_at=incoming.terminal_at)
+            candidate = finish_task_record(
+                existing,
+                terminal_envelope_with_observability(incoming),
+                occurred_at=incoming.terminal_at,
+            )
             if candidate != incoming:
                 candidate = merge_incoming_terminal_observability(candidate, incoming)
         elif existing.status in {"succeeded", "failed"} and incoming.status in {"succeeded", "failed"}:
@@ -226,6 +230,19 @@ def merge_incoming_terminal_observability(candidate: TaskRecord, incoming: TaskR
         runtime_structured_log_events=incoming.runtime_structured_log_events,
         runtime_execution_metric_samples=incoming.runtime_execution_metric_samples,
     )
+
+
+def terminal_envelope_with_observability(record: TaskRecord) -> dict:
+    if record.result is None:
+        raise TaskRecordConflictError("终态任务记录缺少结果")
+    envelope = dict(record.result.envelope)
+    if record.runtime_failure_signals:
+        envelope.setdefault("_runtime_failure_signals", list(record.runtime_failure_signals))
+    if record.runtime_structured_log_events:
+        envelope.setdefault("_runtime_structured_log_events", list(record.runtime_structured_log_events))
+    if record.runtime_execution_metric_samples:
+        envelope.setdefault("_runtime_execution_metric_samples", list(record.runtime_execution_metric_samples))
+    return envelope
 
 
 def ensure_observability_no_conflict(

--- a/syvert/task_record_store.py
+++ b/syvert/task_record_store.py
@@ -224,6 +224,24 @@ def merge_incoming_terminal_observability(candidate: TaskRecord, incoming: TaskR
         id_field="metric_id",
         field="runtime_execution_metric_samples",
     )
+    ensure_observability_superset(
+        candidate.runtime_failure_signals,
+        incoming.runtime_failure_signals,
+        id_field="signal_id",
+        field="runtime_failure_signals",
+    )
+    ensure_observability_superset(
+        candidate.runtime_structured_log_events,
+        incoming.runtime_structured_log_events,
+        id_field="event_id",
+        field="runtime_structured_log_events",
+    )
+    ensure_observability_superset(
+        candidate.runtime_execution_metric_samples,
+        incoming.runtime_execution_metric_samples,
+        id_field="metric_id",
+        field="runtime_execution_metric_samples",
+    )
     return replace(
         candidate,
         runtime_failure_signals=incoming.runtime_failure_signals,
@@ -262,3 +280,22 @@ def ensure_observability_no_conflict(
         entry_id = str(entry[id_field])
         if entry_id in by_id and by_id[entry_id] != entry:
             raise TaskRecordConflictError(f"本地持久化记录的 {field} 存在同 ID 冲突")
+
+
+def ensure_observability_superset(
+    candidate_entries: tuple[object, ...],
+    incoming_entries: tuple[object, ...],
+    *,
+    id_field: str,
+    field: str,
+) -> None:
+    incoming_by_id: dict[str, object] = {}
+    for entry in incoming_entries:
+        if isinstance(entry, Mapping) and isinstance(entry.get(id_field), str):
+            incoming_by_id[str(entry[id_field])] = entry
+    for entry in candidate_entries:
+        if not isinstance(entry, Mapping) or not isinstance(entry.get(id_field), str):
+            raise TaskRecordConflictError(f"本地持久化记录的 {field} 不满足共享模型")
+        entry_id = str(entry[id_field])
+        if incoming_by_id.get(entry_id) != entry:
+            raise TaskRecordConflictError(f"本地持久化记录的 {field} 不得被较小观测子集覆盖")

--- a/syvert/task_record_store.py
+++ b/syvert/task_record_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import json
 import os
 from pathlib import Path
@@ -192,6 +192,13 @@ def reconcile_persisted_record(existing: TaskRecord | None, incoming: TaskRecord
     except TaskRecordContractError as error:
         raise TaskRecordConflictError("本地持久化记录的生命周期推进不合法") from error
 
+    if candidate != incoming and incoming.status in {"succeeded", "failed"}:
+        candidate = replace(
+            candidate,
+            runtime_failure_signals=incoming.runtime_failure_signals,
+            runtime_structured_log_events=incoming.runtime_structured_log_events,
+            runtime_execution_metric_samples=incoming.runtime_execution_metric_samples,
+        )
     if candidate != incoming:
         raise TaskRecordConflictError("本地持久化记录与共享模型不一致")
     return candidate

--- a/tests/runtime/test_cli_http_same_path.py
+++ b/tests/runtime/test_cli_http_same_path.py
@@ -97,6 +97,7 @@ def normalize_record_payload(payload: dict[str, object]) -> dict[str, object]:
         for index, entry in enumerate(logs, start=1):
             if isinstance(entry, dict) and isinstance(entry.get("occurred_at"), str):
                 entry["occurred_at"] = f"normalized-log-{index}-occurred-at"
+    normalize_observability_identity(normalized)
     return normalized
 
 
@@ -107,6 +108,33 @@ def normalize_envelope_identity(envelope: object) -> None:
         envelope["task_id"] = "normalized-task-id"
     if isinstance(envelope.get("task_record_ref"), str):
         envelope["task_record_ref"] = "normalized-task-record-ref"
+
+
+def normalize_observability_identity(payload: object) -> None:
+    if isinstance(payload, dict):
+        for key, value in list(payload.items()):
+            if key == "task_id" and isinstance(value, str):
+                payload[key] = "normalized-task-id"
+            elif key == "task_record_ref" and isinstance(value, str):
+                payload[key] = "normalized-task-record-ref"
+            elif key in {"event_id", "metric_id", "signal_id", "ref_id", "failure_signal_id"} and isinstance(value, str):
+                payload[key] = normalize_generated_ref(value)
+            elif key in {"occurred_at", "started_at", "ended_at"} and isinstance(value, str):
+                payload[key] = "normalized-observability-occurred-at"
+            elif key == "metric_value" and payload.get("metric_name") == "execution_duration_ms":
+                payload[key] = "normalized-execution-duration-ms"
+            else:
+                normalize_observability_identity(value)
+    elif isinstance(payload, list):
+        for entry in payload:
+            normalize_observability_identity(entry)
+
+
+def normalize_generated_ref(value: str) -> str:
+    return value.replace("task-cli-same-success", "normalized-task-id").replace(
+        "task-http-same-success",
+        "normalized-task-id",
+    )
 
 
 def make_request_snapshot(url: str = "https://example.com/posts/same-path") -> TaskRequestSnapshot:

--- a/tests/runtime/test_cli_http_same_path.py
+++ b/tests/runtime/test_cli_http_same_path.py
@@ -340,7 +340,9 @@ class CliHttpSamePathTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result_response.body, query_payload["result"]["envelope"])
         self.assertEqual(result_response.body["error"]["category"], "platform")
         self.assertEqual(result_response.body["error"]["code"], "platform_broken")
-        self.assertEqual(result_response.body["error"]["details"], {"reason": "same-path", "retryable": False})
+        self.assertEqual(result_response.body["error"]["details"]["reason"], "same-path")
+        self.assertFalse(result_response.body["error"]["details"]["retryable"])
+        self.assertTrue(result_response.body["error"]["details"]["resource_trace_refs"])
 
     def test_same_path_pre_admission_invalid_input_does_not_create_task_record(self) -> None:
         url = "https://example.com/posts/invalid-capability"

--- a/tests/runtime/test_execution_control.py
+++ b/tests/runtime/test_execution_control.py
@@ -315,6 +315,15 @@ class ExecutionControlRuntimeTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
         self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
         self.assertEqual(result.envelope["error"]["details"]["resource_quarantine"], "INVALID")
+        self.assertNotEqual(result.envelope["runtime_failure_signal"]["failure_phase"], "timeout")
+        self.assertNotIn(
+            "timeout_triggered",
+            {event["event_type"] for event in result.envelope["runtime_structured_log_events"]},
+        )
+        self.assertNotIn(
+            "timeout_total",
+            {metric["metric_name"] for metric in result.envelope["runtime_execution_metric_samples"]},
+        )
         snapshot = default_resource_lifecycle_store().load_snapshot()
         self.assertEqual({lease.target_status_after_release for lease in snapshot.leases}, {"INVALID"})
         self.assertEqual(
@@ -386,6 +395,15 @@ class ExecutionControlRuntimeTests(ResourceStoreEnvMixin, unittest.TestCase):
             self.assertEqual(result.envelope["error"]["details"]["control_code"], "execution_timeout")
             self.assertEqual(result.envelope["error"]["details"]["retryable"], False)
             self.assertEqual(result.envelope["error"]["details"]["resource_quarantine"], "INVALID")
+            self.assertNotEqual(result.envelope["runtime_failure_signal"]["failure_phase"], "timeout")
+            self.assertNotIn(
+                "timeout_triggered",
+                {event["event_type"] for event in result.envelope["runtime_structured_log_events"]},
+            )
+            self.assertNotIn(
+                "timeout_total",
+                {metric["metric_name"] for metric in result.envelope["runtime_execution_metric_samples"]},
+            )
             self.assertNotIn("runtime_result_refs", result.envelope)
             self.assertEqual(result.task_record.status, "failed")
 

--- a/tests/runtime/test_execution_control.py
+++ b/tests/runtime/test_execution_control.py
@@ -725,6 +725,54 @@ class ExecutionControlRuntimeTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result.envelope["runtime_result_refs"][1], result.envelope["execution_control_events"][0])
         self.assertEqual(result.task_record.status, "failed")
 
+    def test_retry_slot_rejection_preserves_current_cleanup_failure(self) -> None:
+        real_acquire = runtime_module.acquire_execution_concurrency_slot
+        real_settle = runtime_module.settle_managed_resource_bundle
+        acquire_calls = 0
+        settle_calls = 0
+
+        def acquire_once_then_invalid(policy, *, adapter_key, capability):
+            nonlocal acquire_calls
+            acquire_calls += 1
+            if acquire_calls == 1:
+                return real_acquire(policy, adapter_key=adapter_key, capability=capability)
+            return None
+
+        def fail_second_settle(*args, **kwargs):
+            nonlocal settle_calls
+            settle_calls += 1
+            if settle_calls == 2:
+                return runtime_module.failure_envelope(
+                    "task-retry-slot-cleanup-failed",
+                    TEST_ADAPTER_KEY,
+                    TEST_CAPABILITY,
+                    runtime_module.runtime_contract_error(
+                        "resource_cleanup_failed",
+                        "resource cleanup failed during retry slot rejection",
+                        details={"stage": "resource_cleanup", "retryable": False},
+                    ),
+                )
+            return real_settle(*args, **kwargs)
+
+        with (
+            mock.patch("syvert.runtime.acquire_execution_concurrency_slot", side_effect=acquire_once_then_invalid),
+            mock.patch("syvert.runtime.settle_managed_resource_bundle", side_effect=fail_second_settle),
+        ):
+            result = execute_task_with_record(
+                make_request(make_policy(max_attempts=2)),
+                adapters={TEST_ADAPTER_KEY: RetryableFailureAdapter()},
+                task_id_factory=lambda: "task-retry-slot-cleanup-failed",
+                task_record_store=self.store,
+            )
+
+        self.assertIsNotNone(result.task_record)
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(result.envelope["error"]["code"], "resource_cleanup_failed")
+        self.assertEqual(result.envelope["execution_control_events"][0]["event_type"], "retry_concurrency_rejected")
+        self.assertEqual(result.envelope["runtime_result_refs"][1], result.envelope["execution_control_events"][0])
+        self.assertEqual(result.task_record.status, "failed")
+
     def test_concurrency_scope_keys_are_enforced_independently(self) -> None:
         global_policy = make_policy(scope="global")
         global_slot = runtime_module.acquire_execution_concurrency_slot(

--- a/tests/runtime/test_execution_control.py
+++ b/tests/runtime/test_execution_control.py
@@ -697,9 +697,14 @@ class ExecutionControlRuntimeTests(ResourceStoreEnvMixin, unittest.TestCase):
 
         self.assertIsNotNone(result.task_record)
         self.assertEqual(result.envelope["status"], "failed")
-        self.assertEqual(result.envelope["error"]["category"], "runtime_contract")
-        self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
-        self.assertNotIn("execution_control_events", result.envelope)
+        self.assertEqual(result.envelope["error"]["category"], "platform")
+        self.assertEqual(result.envelope["error"]["code"], "transient_platform")
+        self.assertEqual(result.envelope["execution_control_events"][0]["event_type"], "retry_concurrency_rejected")
+        self.assertEqual(
+            result.envelope["error"]["details"]["execution_control_event"],
+            result.envelope["execution_control_events"][0],
+        )
+        self.assertEqual(result.envelope["runtime_result_refs"][1], result.envelope["execution_control_events"][0])
         self.assertEqual(result.task_record.status, "failed")
 
     def test_concurrency_scope_keys_are_enforced_independently(self) -> None:

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -1217,7 +1217,8 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "platform")
         self.assertEqual(envelope["error"]["code"], "platform_broken")
-        self.assertEqual(envelope["error"]["details"], {})
+        self.assertEqual(set(envelope["error"]["details"]), {"resource_trace_refs"})
+        self.assertTrue(envelope["error"]["details"]["resource_trace_refs"])
 
     def test_execute_task_wraps_platform_error(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -1115,6 +1115,14 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertIsNotNone(outcome.task_record)
         self.assertEqual(outcome.task_record.status, "failed")
         self.assertEqual(outcome.task_record.result.envelope["error"]["code"], "resource_unavailable")
+        self.assertEqual(
+            outcome.envelope["runtime_failure_signal"]["task_record_ref"],
+            "task_record:task-unmatched-runtime-capabilities",
+        )
+        self.assertEqual(
+            outcome.task_record.result.envelope["runtime_failure_signal"]["task_record_ref"],
+            "task_record:task-unmatched-runtime-capabilities",
+        )
 
     def test_execute_task_rejects_unsupported_capability(self) -> None:
         request = TaskRequest(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -1217,7 +1217,7 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["category"], "platform")
         self.assertEqual(envelope["error"]["code"], "platform_broken")
-        self.assertEqual(set(envelope["error"]["details"]), {"resource_trace_refs"})
+        self.assertEqual(set(envelope["error"]["details"]), {"resource_trace_refs", "task_record_ref"})
         self.assertTrue(envelope["error"]["details"]["resource_trace_refs"])
 
     def test_execute_task_wraps_platform_error(self) -> None:

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -248,6 +248,42 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertNotIn("runtime_structured_log_events", envelope)
         self.assertNotIn("runtime_execution_metric_samples", envelope)
 
+    def test_retry_success_persists_retry_scheduled_carriers_outside_success_envelope(self) -> None:
+        adapter = RetryableThenSuccessAdapter()
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/retry-success-record"),
+            execution_control_policy=ExecutionControlPolicy(
+                timeout=ExecutionTimeoutPolicy(timeout_ms=30000),
+                retry=ExecutionRetryPolicy(max_attempts=2, backoff_ms=0),
+                concurrency=ExecutionConcurrencyPolicy(scope="global", max_in_flight=1, on_limit="reject"),
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as store_dir:
+            store = LocalTaskRecordStore(Path(store_dir))
+            result = execute_task_with_record(
+                request,
+                adapters={TEST_ADAPTER_KEY: adapter},
+                task_id_factory=lambda: "task-observability-retry-success-record",
+                task_record_store=store,
+            )
+            loaded = store.load("task-observability-retry-success-record")
+
+        self.assertEqual(result.envelope["status"], "success")
+        self.assertNotIn("runtime_structured_log_events", result.envelope)
+        payload = task_record_to_dict(loaded)
+        self.assertNotIn("runtime_structured_log_events", payload["result"]["envelope"])
+        self.assertIn(
+            "retry_scheduled",
+            {event["event_type"] for event in payload["runtime_structured_log_events"]},
+        )
+        self.assertIn(
+            "retry_scheduled_total",
+            {metric["metric_name"] for metric in payload["runtime_execution_metric_samples"]},
+        )
+
     def test_persistence_failures_project_persistence_phase(self) -> None:
         result = execute_task_with_record(
             make_request(),
@@ -259,6 +295,29 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result.envelope["status"], "failed")
         self.assertEqual(result.envelope["error"]["code"], "task_record_persistence_failed")
         self.assertEqual(result.envelope["runtime_failure_signal"]["failure_phase"], "persistence")
+
+    def test_failed_terminal_persistence_preserves_business_failure(self) -> None:
+        class CompletionFailingStore(LocalTaskRecordStore):
+            def write(self, record):
+                if record.status == "failed":
+                    raise OSError("boom-completion")
+                return super().write(record)
+
+        with tempfile.TemporaryDirectory() as store_dir:
+            result = execute_task_with_record(
+                make_request(),
+                adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
+                task_id_factory=lambda: "task-observability-failed-persist",
+                task_record_store=CompletionFailingStore(Path(store_dir)),
+            )
+
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["category"], "platform")
+        self.assertEqual(result.envelope["error"]["code"], "content_not_found")
+        self.assertIn(
+            "observability_write_failed",
+            {event["event_type"] for event in result.envelope["runtime_structured_log_events"]},
+        )
 
     def test_task_record_persists_observability_carriers(self) -> None:
         with tempfile.TemporaryDirectory() as store_dir:

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -326,6 +326,26 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
             "retry_scheduled_total",
             {metric["metric_name"] for metric in payload["runtime_execution_metric_samples"]},
         )
+        self.assertEqual(
+            {signal["signal_id"] for signal in payload["runtime_failure_signals"]},
+            {event["failure_signal_id"] for event in payload["runtime_structured_log_events"] if event["event_type"] == "retry_scheduled"},
+        )
+        self.assertIn(
+            "task_succeeded",
+            {event["event_type"] for event in payload["runtime_structured_log_events"]},
+        )
+        self.assertIn(
+            "attempt_started",
+            {event["event_type"] for event in payload["runtime_structured_log_events"]},
+        )
+        self.assertIn(
+            "attempt_finished",
+            {event["event_type"] for event in payload["runtime_structured_log_events"]},
+        )
+        self.assertIn(
+            "task_succeeded_total",
+            {metric["metric_name"] for metric in payload["runtime_execution_metric_samples"]},
+        )
 
     def test_persistence_failures_project_persistence_phase(self) -> None:
         result = execute_task_with_record(
@@ -387,8 +407,13 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         payload = task_record_to_dict(loaded)
         signal = result.envelope["runtime_failure_signal"]
         self.assertEqual(payload["runtime_failure_signals"], [signal])
-        self.assertEqual(payload["runtime_structured_log_events"], result.envelope["runtime_structured_log_events"])
-        self.assertEqual(payload["runtime_execution_metric_samples"], result.envelope["runtime_execution_metric_samples"])
+        for event in result.envelope["runtime_structured_log_events"]:
+            self.assertIn(event, payload["runtime_structured_log_events"])
+        for metric in result.envelope["runtime_execution_metric_samples"]:
+            self.assertIn(metric, payload["runtime_execution_metric_samples"])
+        self.assertIn("task_accepted", {event["event_type"] for event in payload["runtime_structured_log_events"]})
+        self.assertIn("task_running", {event["event_type"] for event in payload["runtime_structured_log_events"]})
+        self.assertIn("task_started_total", {metric["metric_name"] for metric in payload["runtime_execution_metric_samples"]})
         self.assertEqual(payload["result"]["envelope"]["runtime_failure_signal"], signal)
 
 

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -60,6 +60,21 @@ class RetryableThenSuccessAdapter(SuccessfulAdapter):
         return super().execute(request)
 
 
+class TwiceRetryableThenSuccessAdapter(SuccessfulAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def execute(self, request):
+        self.calls += 1
+        if self.calls <= 2:
+            raise PlatformAdapterError(
+                code="transient_platform",
+                message="try again later",
+                details={"retryable": True},
+            )
+        return super().execute(request)
+
+
 class AcceptedFailingStore:
     def write(self, record):
         raise OSError("boom")
@@ -88,12 +103,12 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertTrue(signal["resource_trace_refs"])
         self.assertEqual(signal["resource_trace_refs"], envelope["error"]["details"]["resource_trace_refs"])
 
-        log_event = envelope["runtime_structured_log_events"][0]
+        log_event = next(event for event in envelope["runtime_structured_log_events"] if event["event_type"] == "task_failed")
         self.assertEqual(log_event["event_type"], "task_failed")
         self.assertEqual(log_event["level"], "error")
         self.assertEqual(log_event["failure_signal_id"], signal["signal_id"])
 
-        metric = envelope["runtime_execution_metric_samples"][0]
+        metric = next(metric for metric in envelope["runtime_execution_metric_samples"] if metric["metric_name"] == "task_failed_total")
         self.assertEqual(metric["metric_name"], "task_failed_total")
         self.assertEqual(metric["metric_value"], 1)
         self.assertEqual(metric["error_category"], signal["error_category"])
@@ -214,18 +229,18 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
             "retry_scheduled_total",
             {metric["metric_name"] for metric in envelope["runtime_execution_metric_samples"]},
         )
-        non_retry_events = [
+        non_lifecycle_events = [
             event
             for event in envelope["runtime_structured_log_events"]
-            if event["event_type"] != "retry_scheduled"
+            if event["event_type"] not in {"attempt_started", "attempt_finished", "retry_scheduled"}
         ]
-        non_retry_metrics = [
+        non_lifecycle_metrics = [
             metric
             for metric in envelope["runtime_execution_metric_samples"]
-            if metric["metric_name"] != "retry_scheduled_total"
+            if metric["metric_name"] not in {"attempt_started_total", "execution_duration_ms", "retry_scheduled_total"}
         ]
-        self.assertEqual(len(non_retry_events), 1)
-        self.assertEqual(len(non_retry_metrics), 1)
+        self.assertEqual(len(non_lifecycle_events), 1)
+        self.assertEqual(len(non_lifecycle_metrics), 1)
         for runtime_ref in envelope["runtime_result_refs"]:
             if runtime_ref.get("ref_type") == "ExecutionAttemptOutcome":
                 self.assertNotIn("runtime_failure_signal", runtime_ref["terminal_envelope"])
@@ -414,7 +429,42 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertIn("task_accepted", {event["event_type"] for event in payload["runtime_structured_log_events"]})
         self.assertIn("task_running", {event["event_type"] for event in payload["runtime_structured_log_events"]})
         self.assertIn("task_started_total", {metric["metric_name"] for metric in payload["runtime_execution_metric_samples"]})
+        self.assertIn("attempt_started_total", {metric["metric_name"] for metric in payload["runtime_execution_metric_samples"]})
+        self.assertIn("execution_duration_ms", {metric["metric_name"] for metric in payload["runtime_execution_metric_samples"]})
         self.assertEqual(payload["result"]["envelope"]["runtime_failure_signal"], signal)
+
+    def test_repeated_identical_retry_failures_have_distinct_signals_before_success(self) -> None:
+        adapter = TwiceRetryableThenSuccessAdapter()
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/retry-twice-success-record"),
+            execution_control_policy=ExecutionControlPolicy(
+                timeout=ExecutionTimeoutPolicy(timeout_ms=30000),
+                retry=ExecutionRetryPolicy(max_attempts=3, backoff_ms=0),
+                concurrency=ExecutionConcurrencyPolicy(scope="global", max_in_flight=1, on_limit="reject"),
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as store_dir:
+            store = LocalTaskRecordStore(Path(store_dir))
+            result = execute_task_with_record(
+                request,
+                adapters={TEST_ADAPTER_KEY: adapter},
+                task_id_factory=lambda: "task-observability-retry-twice-success-record",
+                task_record_store=store,
+            )
+            payload = task_record_to_dict(store.load("task-observability-retry-twice-success-record"))
+
+        self.assertEqual(result.envelope["status"], "success")
+        self.assertEqual(adapter.calls, 3)
+        signal_ids = [signal["signal_id"] for signal in payload["runtime_failure_signals"]]
+        self.assertEqual(len(signal_ids), 2)
+        self.assertEqual(len(set(signal_ids)), 2)
+        self.assertEqual(
+            {event["failure_signal_id"] for event in payload["runtime_structured_log_events"] if event["event_type"] == "retry_scheduled"},
+            set(signal_ids),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -182,8 +182,7 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["runtime_failure_signal"]["task_record_ref"], "none")
         self.assertEqual(envelope["error"]["details"]["stage"], "pre_admission")
 
-    def test_retry_scheduled_log_and_metric_are_preserved(self) -> None:
-        adapter = RetryableThenSuccessAdapter()
+    def test_retry_scheduled_log_and_metric_are_preserved_on_terminal_failure(self) -> None:
         request = TaskRequest(
             adapter_key=TEST_ADAPTER_KEY,
             capability="content_detail_by_url",
@@ -197,12 +196,11 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
 
         envelope = execute_task(
             request,
-            adapters={TEST_ADAPTER_KEY: adapter},
+            adapters={TEST_ADAPTER_KEY: RetryablePlatformFailureAdapter()},
             task_id_factory=lambda: "task-observability-retry-scheduled",
         )
 
-        self.assertEqual(envelope["status"], "success")
-        self.assertEqual(adapter.calls, 2)
+        self.assertEqual(envelope["status"], "failed")
         self.assertIn(
             "retry_scheduled",
             {event["event_type"] for event in envelope["runtime_structured_log_events"]},
@@ -211,6 +209,44 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
             "retry_scheduled_total",
             {metric["metric_name"] for metric in envelope["runtime_execution_metric_samples"]},
         )
+        non_retry_events = [
+            event
+            for event in envelope["runtime_structured_log_events"]
+            if event["event_type"] != "retry_scheduled"
+        ]
+        non_retry_metrics = [
+            metric
+            for metric in envelope["runtime_execution_metric_samples"]
+            if metric["metric_name"] != "retry_scheduled_total"
+        ]
+        self.assertEqual(len(non_retry_events), 1)
+        self.assertEqual(len(non_retry_metrics), 1)
+
+    def test_retry_success_keeps_success_envelope_surface(self) -> None:
+        adapter = RetryableThenSuccessAdapter()
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/retry-success"),
+            execution_control_policy=ExecutionControlPolicy(
+                timeout=ExecutionTimeoutPolicy(timeout_ms=30000),
+                retry=ExecutionRetryPolicy(max_attempts=2, backoff_ms=0),
+                concurrency=ExecutionConcurrencyPolicy(scope="global", max_in_flight=1, on_limit="reject"),
+            ),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-observability-retry-success",
+        )
+
+        self.assertEqual(envelope["status"], "success")
+        self.assertEqual(adapter.calls, 2)
+        self.assertEqual([ref["attempt_index"] for ref in envelope["runtime_result_refs"]], [1, 2])
+        self.assertNotIn("runtime_failure_signal", envelope)
+        self.assertNotIn("runtime_structured_log_events", envelope)
+        self.assertNotIn("runtime_execution_metric_samples", envelope)
 
     def test_persistence_failures_project_persistence_phase(self) -> None:
         result = execute_task_with_record(

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -519,6 +519,21 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
             {event["failure_signal_id"] for event in payload["runtime_structured_log_events"] if event["event_type"] == "retry_scheduled"},
             set(signal_ids),
         )
+        retry_scheduled_events = [
+            event
+            for event in payload["runtime_structured_log_events"]
+            if event["event_type"] == "retry_scheduled"
+        ]
+        self.assertEqual(len(retry_scheduled_events), 2)
+        for event, direct_attempt_index in zip(retry_scheduled_events, (1, 2), strict=True):
+            self.assertEqual(
+                [ref.get("attempt_index") for ref in event["runtime_result_refs"]],
+                [direct_attempt_index],
+            )
+            self.assertEqual(
+                [ref.get("ref_type") for ref in event["runtime_result_refs"]],
+                ["ExecutionAttemptOutcome"],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -275,6 +275,10 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertNotIn("runtime_structured_log_events", result.envelope)
         payload = task_record_to_dict(loaded)
         self.assertNotIn("runtime_structured_log_events", payload["result"]["envelope"])
+        self.assertNotIn("_runtime_structured_log_events", result.envelope)
+        self.assertNotIn("_runtime_execution_metric_samples", result.envelope)
+        self.assertNotIn("_runtime_structured_log_events", payload["result"]["envelope"])
+        self.assertNotIn("_runtime_execution_metric_samples", payload["result"]["envelope"])
         self.assertIn(
             "retry_scheduled",
             {event["event_type"] for event in payload["runtime_structured_log_events"]},

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -20,7 +20,7 @@ from syvert.runtime import (
     release_execution_concurrency_slot,
     runtime_contract_error,
 )
-from syvert.task_record import task_record_to_dict
+from syvert.task_record import TaskRecordContractError, task_record_to_dict
 from syvert.task_record_store import LocalTaskRecordStore
 from tests.runtime.test_runtime import (
     TEST_ADAPTER_KEY,
@@ -93,6 +93,48 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertNotIn("runtime_failure_signal", envelope)
         self.assertNotIn("runtime_structured_log_events", envelope)
         self.assertNotIn("runtime_execution_metric_samples", envelope)
+
+    def test_record_lifecycle_contract_failures_project_failure_observability(self) -> None:
+        with mock.patch(
+            "syvert.runtime.create_task_record",
+            side_effect=TaskRecordContractError("bad-create"),
+        ):
+            create_failure = execute_task(
+                make_request(),
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                task_id_factory=lambda: "task-observability-create-record-failed",
+            )
+
+        self.assertEqual(create_failure["status"], "failed")
+        self.assertIn("runtime_failure_signal", create_failure)
+        self.assertIn("runtime_structured_log_events", create_failure)
+        self.assertEqual(create_failure["runtime_failure_signal"]["task_record_ref"], "none")
+        self.assertEqual(
+            create_failure["runtime_structured_log_events"][0]["failure_signal_id"],
+            create_failure["runtime_failure_signal"]["signal_id"],
+        )
+
+        with mock.patch(
+            "syvert.runtime.start_task_record",
+            side_effect=TaskRecordContractError("bad-start"),
+        ):
+            start_failure = execute_task(
+                make_request(),
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                task_id_factory=lambda: "task-observability-start-record-failed",
+            )
+
+        self.assertEqual(start_failure["status"], "failed")
+        self.assertIn("runtime_failure_signal", start_failure)
+        self.assertIn("runtime_structured_log_events", start_failure)
+        self.assertEqual(
+            start_failure["runtime_failure_signal"]["task_record_ref"],
+            "task_record:task-observability-start-record-failed",
+        )
+        self.assertEqual(
+            start_failure["runtime_structured_log_events"][0]["failure_signal_id"],
+            start_failure["runtime_failure_signal"]["signal_id"],
+        )
 
     def test_failed_envelope_projects_failure_signal_log_and_metric(self) -> None:
         envelope = execute_task(

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -44,6 +44,29 @@ class RetryablePlatformFailureAdapter(PlatformFailureAdapter):
         )
 
 
+class RetryableThenSuccessAdapter(SuccessfulAdapter):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def execute(self, request):
+        self.calls += 1
+        if self.calls == 1:
+            raise PlatformAdapterError(
+                code="transient_platform",
+                message="try again later",
+                details={"retryable": True},
+            )
+        return super().execute(request)
+
+
+class AcceptedFailingStore:
+    def write(self, record):
+        raise OSError("boom")
+
+    def mark_invalid(self, task_id: str, *, stage: str, reason: str) -> None:
+        self.invalid_marker = {"task_id": task_id, "stage": stage, "reason": reason}
+
+
 class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
     def test_failed_envelope_projects_failure_signal_log_and_metric(self) -> None:
         envelope = execute_task(
@@ -61,6 +84,8 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(signal["failure_phase"], "adapter_execution")
         self.assertEqual(signal["task_record_ref"], "task_record:task-observability-failed")
         self.assertEqual(signal["runtime_result_refs"], envelope["runtime_result_refs"])
+        self.assertTrue(signal["resource_trace_refs"])
+        self.assertEqual(signal["resource_trace_refs"], envelope["error"]["details"]["resource_trace_refs"])
 
         log_event = envelope["runtime_structured_log_events"][0]
         self.assertEqual(log_event["event_type"], "task_failed")
@@ -131,6 +156,8 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["error"]["code"], "concurrency_limit_exceeded")
         self.assertEqual(envelope["runtime_failure_signal"]["task_record_ref"], "none")
         self.assertEqual(envelope["runtime_failure_signal"]["failure_phase"], "concurrency_rejected")
+        self.assertEqual(envelope["runtime_failure_signal"]["runtime_result_refs"], envelope["runtime_result_refs"])
+        self.assertEqual(envelope["runtime_result_refs"][0]["event_type"], "admission_concurrency_rejected")
         self.assertEqual(
             envelope["runtime_structured_log_events"][0]["event_type"],
             "admission_concurrency_rejected",
@@ -139,6 +166,63 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
             envelope["runtime_execution_metric_samples"][0]["metric_name"],
             "admission_concurrency_rejected_total",
         )
+
+    def test_pre_accepted_invalid_input_observability_uses_none_task_record_ref(self) -> None:
+        envelope = execute_task(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="unsupported_capability",
+                input=TaskInput(url="https://example.com/posts/pre-accepted-invalid"),
+            ),
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+            task_id_factory=lambda: "task-observability-pre-accepted-invalid",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["runtime_failure_signal"]["task_record_ref"], "none")
+        self.assertEqual(envelope["error"]["details"]["stage"], "pre_admission")
+
+    def test_retry_scheduled_log_and_metric_are_preserved(self) -> None:
+        adapter = RetryableThenSuccessAdapter()
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="content_detail_by_url",
+            input=TaskInput(url="https://example.com/posts/retry-scheduled"),
+            execution_control_policy=ExecutionControlPolicy(
+                timeout=ExecutionTimeoutPolicy(timeout_ms=30000),
+                retry=ExecutionRetryPolicy(max_attempts=2, backoff_ms=0),
+                concurrency=ExecutionConcurrencyPolicy(scope="global", max_in_flight=1, on_limit="reject"),
+            ),
+        )
+
+        envelope = execute_task(
+            request,
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-observability-retry-scheduled",
+        )
+
+        self.assertEqual(envelope["status"], "success")
+        self.assertEqual(adapter.calls, 2)
+        self.assertIn(
+            "retry_scheduled",
+            {event["event_type"] for event in envelope["runtime_structured_log_events"]},
+        )
+        self.assertIn(
+            "retry_scheduled_total",
+            {metric["metric_name"] for metric in envelope["runtime_execution_metric_samples"]},
+        )
+
+    def test_persistence_failures_project_persistence_phase(self) -> None:
+        result = execute_task_with_record(
+            make_request(),
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+            task_id_factory=lambda: "task-observability-persistence",
+            task_record_store=AcceptedFailingStore(),
+        )
+
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["code"], "task_record_persistence_failed")
+        self.assertEqual(result.envelope["runtime_failure_signal"]["failure_phase"], "persistence")
 
     def test_task_record_persists_observability_carriers(self) -> None:
         with tempfile.TemporaryDirectory() as store_dir:

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -16,7 +16,9 @@ from syvert.runtime import (
     acquire_execution_concurrency_slot,
     execute_task,
     execute_task_with_record,
+    failure_envelope,
     release_execution_concurrency_slot,
+    runtime_contract_error,
 )
 from syvert.task_record import task_record_to_dict
 from syvert.task_record_store import LocalTaskRecordStore
@@ -84,6 +86,14 @@ class AcceptedFailingStore:
 
 
 class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
+    def test_generic_failure_envelope_does_not_inject_runtime_observability(self) -> None:
+        envelope = failure_envelope("", "", "", runtime_contract_error("generic_failure", "generic"))
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertNotIn("runtime_failure_signal", envelope)
+        self.assertNotIn("runtime_structured_log_events", envelope)
+        self.assertNotIn("runtime_execution_metric_samples", envelope)
+
     def test_failed_envelope_projects_failure_signal_log_and_metric(self) -> None:
         envelope = execute_task(
             make_request(),
@@ -459,8 +469,10 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result.envelope["status"], "success")
         self.assertEqual(adapter.calls, 3)
         signal_ids = [signal["signal_id"] for signal in payload["runtime_failure_signals"]]
+        envelope_refs = [signal["envelope_ref"] for signal in payload["runtime_failure_signals"]]
         self.assertEqual(len(signal_ids), 2)
         self.assertEqual(len(set(signal_ids)), 2)
+        self.assertEqual(len(set(envelope_refs)), 2)
         self.assertEqual(
             {event["failure_signal_id"] for event in payload["runtime_structured_log_events"] if event["event_type"] == "retry_scheduled"},
             set(signal_ids),

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 from syvert.runtime import (
     ExecutionConcurrencyPolicy,
@@ -97,6 +98,10 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(metric["metric_value"], 1)
         self.assertEqual(metric["error_category"], signal["error_category"])
         self.assertEqual(metric["error_code"], signal["error_code"])
+        attempt_envelope = envelope["runtime_result_refs"][0]["terminal_envelope"]
+        self.assertNotIn("runtime_failure_signal", attempt_envelope)
+        self.assertNotIn("runtime_structured_log_events", attempt_envelope)
+        self.assertNotIn("runtime_execution_metric_samples", attempt_envelope)
 
     def test_success_envelope_does_not_change_success_payload_shape(self) -> None:
         envelope = execute_task(
@@ -221,6 +226,40 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         ]
         self.assertEqual(len(non_retry_events), 1)
         self.assertEqual(len(non_retry_metrics), 1)
+        for runtime_ref in envelope["runtime_result_refs"]:
+            if runtime_ref.get("ref_type") == "ExecutionAttemptOutcome":
+                self.assertNotIn("runtime_failure_signal", runtime_ref["terminal_envelope"])
+                self.assertNotIn("runtime_structured_log_events", runtime_ref["terminal_envelope"])
+                self.assertNotIn("runtime_execution_metric_samples", runtime_ref["terminal_envelope"])
+
+    def test_execution_control_default_policy_failure_projects_pre_execution_phase(self) -> None:
+        with mock.patch("syvert.runtime.default_execution_control_policy", return_value=None):
+            envelope = execute_task(
+                make_request(),
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                task_id_factory=lambda: "task-observability-default-policy-invalid",
+            )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["code"], "execution_control_state_invalid")
+        self.assertEqual(envelope["error"]["details"]["stage"], "pre_execution")
+        self.assertEqual(envelope["runtime_failure_signal"]["task_record_ref"], "none")
+        self.assertEqual(envelope["runtime_failure_signal"]["failure_phase"], "pre_execution")
+
+    def test_guarded_admission_slot_disappearance_projects_concurrency_phase(self) -> None:
+        with tempfile.TemporaryDirectory() as store_dir:
+            with mock.patch("syvert.runtime.acquire_execution_concurrency_slot", return_value=None):
+                result = execute_task_with_record(
+                    make_request(),
+                    adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                    task_id_factory=lambda: "task-observability-guarded-slot-missing",
+                    task_record_store=LocalTaskRecordStore(Path(store_dir)),
+                )
+
+        self.assertEqual(result.envelope["status"], "failed")
+        self.assertEqual(result.envelope["error"]["code"], "execution_control_state_invalid")
+        self.assertEqual(result.envelope["error"]["details"]["control_context"], "guarded_admission")
+        self.assertEqual(result.envelope["runtime_failure_signal"]["failure_phase"], "concurrency_rejected")
 
     def test_retry_success_keeps_success_envelope_surface(self) -> None:
         adapter = RetryableThenSuccessAdapter()
@@ -321,6 +360,17 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertIn(
             "observability_write_failed",
             {event["event_type"] for event in result.envelope["runtime_structured_log_events"]},
+        )
+        write_failure_events = [
+            event
+            for event in result.envelope["runtime_structured_log_events"]
+            if event["event_type"] == "observability_write_failed"
+        ]
+        self.assertEqual(write_failure_events[0]["failure_signal_id"], result.envelope["runtime_failure_signal"]["signal_id"])
+        self.assertEqual(write_failure_events[0]["resource_trace_refs"], result.envelope["runtime_failure_signal"]["resource_trace_refs"])
+        self.assertNotIn(
+            "observability_write_failed_total",
+            {metric["metric_name"] for metric in result.envelope["runtime_execution_metric_samples"]},
         )
 
     def test_task_record_persists_observability_carriers(self) -> None:

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import unittest
+import tempfile
+from pathlib import Path
+
+from syvert.runtime import (
+    ExecutionConcurrencyPolicy,
+    ExecutionControlPolicy,
+    ExecutionRetryPolicy,
+    ExecutionTimeoutPolicy,
+    PlatformAdapterError,
+    TaskInput,
+    TaskRequest,
+    acquire_execution_concurrency_slot,
+    execute_task,
+    execute_task_with_record,
+    release_execution_concurrency_slot,
+)
+from syvert.task_record import task_record_to_dict
+from syvert.task_record_store import LocalTaskRecordStore
+from tests.runtime.test_runtime import (
+    TEST_ADAPTER_KEY,
+    PlatformFailureAdapter,
+    SuccessfulAdapter,
+)
+from tests.runtime.resource_fixtures import ResourceStoreEnvMixin
+
+
+def make_request() -> TaskRequest:
+    return TaskRequest(
+        adapter_key=TEST_ADAPTER_KEY,
+        capability="content_detail_by_url",
+        input=TaskInput(url="https://example.com/posts/observability"),
+    )
+
+
+class RetryablePlatformFailureAdapter(PlatformFailureAdapter):
+    def execute(self, request):
+        raise PlatformAdapterError(
+            code="transient_platform",
+            message="try again later",
+            details={"retryable": True},
+        )
+
+
+class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
+    def test_failed_envelope_projects_failure_signal_log_and_metric(self) -> None:
+        envelope = execute_task(
+            make_request(),
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
+            task_id_factory=lambda: "task-observability-failed",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        signal = envelope["runtime_failure_signal"]
+        self.assertEqual(signal["task_id"], "task-observability-failed")
+        self.assertEqual(signal["status"], "failed")
+        self.assertEqual(signal["error_category"], envelope["error"]["category"])
+        self.assertEqual(signal["error_code"], envelope["error"]["code"])
+        self.assertEqual(signal["failure_phase"], "adapter_execution")
+        self.assertEqual(signal["task_record_ref"], "task_record:task-observability-failed")
+        self.assertEqual(signal["runtime_result_refs"], envelope["runtime_result_refs"])
+
+        log_event = envelope["runtime_structured_log_events"][0]
+        self.assertEqual(log_event["event_type"], "task_failed")
+        self.assertEqual(log_event["level"], "error")
+        self.assertEqual(log_event["failure_signal_id"], signal["signal_id"])
+
+        metric = envelope["runtime_execution_metric_samples"][0]
+        self.assertEqual(metric["metric_name"], "task_failed_total")
+        self.assertEqual(metric["metric_value"], 1)
+        self.assertEqual(metric["error_category"], signal["error_category"])
+        self.assertEqual(metric["error_code"], signal["error_code"])
+
+    def test_success_envelope_does_not_change_success_payload_shape(self) -> None:
+        envelope = execute_task(
+            make_request(),
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+            task_id_factory=lambda: "task-observability-success",
+        )
+
+        self.assertEqual(envelope["status"], "success")
+        self.assertIn("raw", envelope)
+        self.assertIn("normalized", envelope)
+        self.assertNotIn("runtime_failure_signal", envelope)
+        self.assertNotIn("runtime_structured_log_events", envelope)
+        self.assertNotIn("runtime_execution_metric_samples", envelope)
+
+    def test_retryable_failure_signal_preserves_envelope_classification(self) -> None:
+        envelope = execute_task(
+            make_request(),
+            adapters={TEST_ADAPTER_KEY: RetryablePlatformFailureAdapter()},
+            task_id_factory=lambda: "task-observability-retryable",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "platform")
+        self.assertEqual(envelope["error"]["code"], "transient_platform")
+        self.assertEqual(envelope["runtime_failure_signal"]["error_category"], "platform")
+        self.assertEqual(envelope["runtime_failure_signal"]["error_code"], "transient_platform")
+
+    def test_admission_concurrency_rejection_observability_uses_none_task_record_ref(self) -> None:
+        policy = ExecutionControlPolicy(
+            timeout=ExecutionTimeoutPolicy(timeout_ms=30000),
+            retry=ExecutionRetryPolicy(max_attempts=1, backoff_ms=0),
+            concurrency=ExecutionConcurrencyPolicy(scope="global", max_in_flight=1, on_limit="reject"),
+        )
+        held_slot = acquire_execution_concurrency_slot(
+            policy.concurrency,
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="content_detail_by_url",
+        )
+        try:
+            request = TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/posts/concurrency"),
+                execution_control_policy=policy,
+            )
+            envelope = execute_task(
+                request,
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                task_id_factory=lambda: "task-observability-admission-rejected",
+            )
+        finally:
+            release_execution_concurrency_slot(held_slot)
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
+        self.assertEqual(envelope["error"]["code"], "concurrency_limit_exceeded")
+        self.assertEqual(envelope["runtime_failure_signal"]["task_record_ref"], "none")
+        self.assertEqual(envelope["runtime_failure_signal"]["failure_phase"], "concurrency_rejected")
+        self.assertEqual(
+            envelope["runtime_structured_log_events"][0]["event_type"],
+            "admission_concurrency_rejected",
+        )
+        self.assertEqual(
+            envelope["runtime_execution_metric_samples"][0]["metric_name"],
+            "admission_concurrency_rejected_total",
+        )
+
+    def test_task_record_persists_observability_carriers(self) -> None:
+        with tempfile.TemporaryDirectory() as store_dir:
+            store = LocalTaskRecordStore(Path(store_dir))
+            result = execute_task_with_record(
+                make_request(),
+                adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
+                task_id_factory=lambda: "task-observability-record",
+                task_record_store=store,
+            )
+            loaded = store.load("task-observability-record")
+
+        payload = task_record_to_dict(loaded)
+        signal = result.envelope["runtime_failure_signal"]
+        self.assertEqual(payload["runtime_failure_signals"], [signal])
+        self.assertEqual(payload["runtime_structured_log_events"], result.envelope["runtime_structured_log_events"])
+        self.assertEqual(payload["runtime_execution_metric_samples"], result.envelope["runtime_execution_metric_samples"])
+        self.assertEqual(payload["result"]["envelope"]["runtime_failure_signal"], signal)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_runtime_observability.py
+++ b/tests/runtime/test_runtime_observability.py
@@ -47,6 +47,16 @@ class RetryablePlatformFailureAdapter(PlatformFailureAdapter):
         )
 
 
+class InvalidInputAttemptFailureAdapter(SuccessfulAdapter):
+    def execute(self, request):
+        raise PlatformAdapterError(
+            code="adapter_precheck_failed",
+            message="adapter rejected request during execution",
+            category="invalid_input",
+            details={"reason": "adapter_precheck"},
+        )
+
+
 class RetryableThenSuccessAdapter(SuccessfulAdapter):
     def __init__(self) -> None:
         self.calls = 0
@@ -196,6 +206,20 @@ class RuntimeObservabilityTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["error"]["code"], "transient_platform")
         self.assertEqual(envelope["runtime_failure_signal"]["error_category"], "platform")
         self.assertEqual(envelope["runtime_failure_signal"]["error_code"], "transient_platform")
+
+    def test_adapter_attempt_invalid_input_projects_adapter_execution_phase(self) -> None:
+        envelope = execute_task(
+            make_request(),
+            adapters={TEST_ADAPTER_KEY: InvalidInputAttemptFailureAdapter()},
+            task_id_factory=lambda: "task-observability-attempt-invalid-input",
+        )
+
+        self.assertEqual(envelope["status"], "failed")
+        self.assertEqual(envelope["error"]["category"], "invalid_input")
+        self.assertEqual(envelope["runtime_failure_signal"]["failure_phase"], "adapter_execution")
+        error_event_types = {event["event_type"] for event in envelope["runtime_structured_log_events"] if event["level"] == "error"}
+        self.assertIn("task_failed", error_event_types)
+        self.assertNotIn("admission_concurrency_rejected", error_event_types)
 
     def test_admission_concurrency_rejection_observability_uses_none_task_record_ref(self) -> None:
         policy = ExecutionControlPolicy(

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -262,6 +262,99 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(invalid_metric)
 
+    def test_rejects_failed_observability_without_required_signal_or_error_metadata(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/observability-required-fields"),
+            ),
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
+            task_id_factory=lambda: "task-record-observability-required-fields",
+        )
+        payload = json.loads(json.dumps(task_record_to_dict(outcome.task_record)))
+
+        missing_signal_id = json.loads(json.dumps(payload))
+        missing_signal_id["runtime_failure_signals"][0]["signal_id"] = ""
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(missing_signal_id)
+
+        missing_signal_ref = json.loads(json.dumps(payload))
+        failed_event = next(
+            event
+            for event in missing_signal_ref["runtime_structured_log_events"]
+            if event["event_type"] == "task_failed"
+        )
+        failed_event["failure_signal_id"] = ""
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(missing_signal_ref)
+
+        for event_type in ("retry_scheduled", "observability_write_failed"):
+            with self.subTest(event_type=event_type):
+                missing_event_signal_ref = json.loads(json.dumps(payload))
+                failed_event = next(
+                    event
+                    for event in missing_event_signal_ref["runtime_structured_log_events"]
+                    if event["event_type"] == "task_failed"
+                )
+                extra_event = dict(failed_event)
+                extra_event["event_id"] = f"runtime_log_event:required-fields:{event_type}"
+                extra_event["event_type"] = event_type
+                extra_event["failure_signal_id"] = ""
+                missing_event_signal_ref["runtime_structured_log_events"].append(extra_event)
+                with self.assertRaises(TaskRecordContractError):
+                    task_record_from_dict(missing_event_signal_ref)
+
+        missing_error_metadata = json.loads(json.dumps(payload))
+        failed_metric = next(
+            metric
+            for metric in missing_error_metadata["runtime_execution_metric_samples"]
+            if metric["metric_name"] == "task_failed_total"
+        )
+        failed_metric["error_category"] = ""
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(missing_error_metadata)
+
+        missing_failure_phase = json.loads(json.dumps(payload))
+        failed_metric = next(
+            metric
+            for metric in missing_failure_phase["runtime_execution_metric_samples"]
+            if metric["metric_name"] == "task_failed_total"
+        )
+        failed_metric["failure_phase"] = ""
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(missing_failure_phase)
+
+        missing_error_code = json.loads(json.dumps(payload))
+        failed_metric = next(
+            metric
+            for metric in missing_error_code["runtime_execution_metric_samples"]
+            if metric["metric_name"] == "task_failed_total"
+        )
+        failed_metric["error_code"] = ""
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(missing_error_code)
+
+        for metric_name in (
+            "timeout_total",
+            "admission_concurrency_rejected_total",
+            "retry_concurrency_rejected_total",
+        ):
+            with self.subTest(metric_name=metric_name):
+                missing_metric_metadata = json.loads(json.dumps(payload))
+                failed_metric = next(
+                    metric
+                    for metric in missing_metric_metadata["runtime_execution_metric_samples"]
+                    if metric["metric_name"] == "task_failed_total"
+                )
+                extra_metric = dict(failed_metric)
+                extra_metric["metric_id"] = f"runtime_metric_sample:required-fields:{metric_name}"
+                extra_metric["metric_name"] = metric_name
+                extra_metric["error_category"] = ""
+                missing_metric_metadata["runtime_execution_metric_samples"].append(extra_metric)
+                with self.assertRaises(TaskRecordContractError):
+                    task_record_from_dict(missing_metric_metadata)
+
     def test_migrates_missing_and_rejects_mismatched_task_record_ref(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
@@ -563,6 +656,20 @@ class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         self.assertEqual(outcome.envelope["status"], "failed")
         self.assertEqual(outcome.envelope["error"]["code"], "envelope_not_json_serializable")
+        self.assertEqual(outcome.envelope["runtime_failure_signal"]["failure_phase"], "persistence")
+        self.assertEqual(outcome.envelope["runtime_failure_signal"]["task_record_ref"], "task_record:task-record-7")
+        task_failed_log = next(
+            event
+            for event in outcome.envelope["runtime_structured_log_events"]
+            if event["event_type"] == "task_failed"
+        )
+        self.assertEqual(task_failed_log["failure_signal_id"], outcome.envelope["runtime_failure_signal"]["signal_id"])
+        task_failed_metric = next(
+            metric
+            for metric in outcome.envelope["runtime_execution_metric_samples"]
+            if metric["metric_name"] == "task_failed_total"
+        )
+        self.assertEqual(task_failed_metric["error_code"], "envelope_not_json_serializable")
         self.assertIsNone(outcome.task_record)
 
     def test_execute_task_preserves_public_envelope_when_task_record_fails_to_close(self) -> None:

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -355,6 +355,36 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
                 with self.assertRaises(TaskRecordContractError):
                     task_record_from_dict(missing_metric_metadata)
 
+        invalid_signal_resource_refs = json.loads(json.dumps(payload))
+        invalid_signal_resource_refs["runtime_failure_signals"][0]["resource_trace_refs"] = [{"bogus": "value"}]
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(invalid_signal_resource_refs)
+
+        invalid_signal_runtime_refs = json.loads(json.dumps(payload))
+        invalid_signal_runtime_refs["runtime_failure_signals"][0]["runtime_result_refs"] = [{"bogus": "value"}]
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(invalid_signal_runtime_refs)
+
+        invalid_log_resource_refs = json.loads(json.dumps(payload))
+        failed_event = next(
+            event
+            for event in invalid_log_resource_refs["runtime_structured_log_events"]
+            if event["event_type"] == "task_failed"
+        )
+        failed_event["resource_trace_refs"] = [{"bogus": "value"}]
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(invalid_log_resource_refs)
+
+        invalid_log_runtime_refs = json.loads(json.dumps(payload))
+        failed_event = next(
+            event
+            for event in invalid_log_runtime_refs["runtime_structured_log_events"]
+            if event["event_type"] == "task_failed"
+        )
+        failed_event["runtime_result_refs"] = [{"bogus": "value"}]
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(invalid_log_runtime_refs)
+
     def test_migrates_missing_and_rejects_mismatched_task_record_ref(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import json
 import tempfile
 import unittest
 from unittest import mock
@@ -233,6 +234,33 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(payload)
+
+    def test_rejects_invalid_runtime_observability_enum_values(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/observability-enum"),
+            ),
+            adapters={TEST_ADAPTER_KEY: PlatformFailureAdapter()},
+            task_id_factory=lambda: "task-record-observability-enum",
+        )
+        payload = json.loads(json.dumps(task_record_to_dict(outcome.task_record)))
+
+        invalid_signal = json.loads(json.dumps(task_record_to_dict(outcome.task_record)))
+        invalid_signal["runtime_failure_signals"][0]["failure_phase"] = "not_approved"
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(invalid_signal)
+
+        invalid_event = json.loads(json.dumps(task_record_to_dict(outcome.task_record)))
+        invalid_event["runtime_structured_log_events"][0]["event_type"] = "not_approved"
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(invalid_event)
+
+        invalid_metric = payload
+        invalid_metric["runtime_execution_metric_samples"][0]["metric_name"] = "not_approved"
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(invalid_metric)
 
     def test_migrates_missing_and_rejects_mismatched_task_record_ref(self) -> None:
         outcome = execute_task_with_record(

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -216,6 +216,24 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(payload)
 
+    def test_rejects_conflicting_observability_replay_id(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_detail_by_url",
+                input=TaskInput(url="https://example.com/post/observability-conflict"),
+            ),
+            adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+            task_id_factory=lambda: "task-record-observability-conflict",
+        )
+        payload = task_record_to_dict(outcome.task_record)
+        duplicate_event = dict(payload["runtime_structured_log_events"][0])
+        duplicate_event["message"] = "conflicting replay"
+        payload["runtime_structured_log_events"].append(duplicate_event)
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
     def test_migrates_missing_and_rejects_mismatched_task_record_ref(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(

--- a/tests/runtime/test_task_record_store.py
+++ b/tests/runtime/test_task_record_store.py
@@ -728,6 +728,36 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
                 store.write(subset_terminal)
             self.assertEqual(store.load("task-store-observability-subset"), outcome.task_record)
 
+    def test_store_allows_terminal_rewrite_that_adds_observability_superset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = LocalTaskRecordStore(Path(temp_dir))
+            outcome = execute_task_with_record(
+                TaskRequest(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/post/store-observability-superset"),
+                ),
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                task_id_factory=lambda: "task-store-observability-superset",
+                task_record_store=store,
+            )
+            payload = task_record_to_dict(outcome.task_record)
+            legacy_payload = json.loads(json.dumps(payload))
+            legacy_payload["runtime_failure_signals"] = []
+            legacy_payload["runtime_structured_log_events"] = []
+            legacy_payload["runtime_execution_metric_samples"] = []
+            store.root.mkdir(parents=True, exist_ok=True)
+            store.record_path("task-store-observability-superset").write_text(
+                json.dumps(legacy_payload, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+            loaded_legacy = store.load("task-store-observability-superset")
+            self.assertEqual(loaded_legacy.runtime_structured_log_events, ())
+            self.assertTrue(outcome.task_record.runtime_structured_log_events)
+            self.assertEqual(store.write(outcome.task_record), outcome.task_record)
+            self.assertEqual(store.load("task-store-observability-superset"), outcome.task_record)
+
     def test_store_allows_idempotent_rewrite_after_loading_legacy_terminal_record(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             store = LocalTaskRecordStore(Path(temp_dir))

--- a/tests/runtime/test_task_record_store.py
+++ b/tests/runtime/test_task_record_store.py
@@ -14,6 +14,7 @@ from syvert.task_record import (
     create_task_record,
     finish_task_record,
     start_task_record,
+    task_record_from_dict,
     task_record_to_dict,
 )
 from syvert.task_record_store import LocalTaskRecordStore, TaskRecordStoreError
@@ -701,6 +702,31 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
             conflicting["error"]["code"] = "changed"
             with self.assertRaises((TaskRecordStoreError, TaskRecordContractError)):
                 store.write(finish_task_record(running, conflicting, occurred_at="2026-04-17T12:00:02Z"))
+
+    def test_store_rejects_terminal_rewrite_that_drops_existing_observability(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = LocalTaskRecordStore(Path(temp_dir))
+            outcome = execute_task_with_record(
+                TaskRequest(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/post/store-observability-subset"),
+                ),
+                adapters={TEST_ADAPTER_KEY: SuccessfulAdapter()},
+                task_id_factory=lambda: "task-store-observability-subset",
+                task_record_store=store,
+            )
+            payload = task_record_to_dict(outcome.task_record)
+            payload["runtime_failure_signals"] = []
+            payload["runtime_structured_log_events"] = []
+            payload["runtime_execution_metric_samples"] = []
+            subset_terminal = task_record_from_dict(payload)
+
+            self.assertTrue(outcome.task_record.runtime_structured_log_events)
+            self.assertTrue(outcome.task_record.runtime_execution_metric_samples)
+            with self.assertRaises(TaskRecordStoreError):
+                store.write(subset_terminal)
+            self.assertEqual(store.load("task-store-observability-subset"), outcome.task_record)
 
     def test_store_allows_idempotent_rewrite_after_loading_legacy_terminal_record(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/runtime/test_task_record_store.py
+++ b/tests/runtime/test_task_record_store.py
@@ -352,6 +352,7 @@ class TaskRecordStoreTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(outcome.envelope["error"]["category"], "runtime_contract")
         self.assertEqual(outcome.envelope["error"]["code"], "task_record_persistence_failed")
         self.assertEqual(outcome.envelope["error"]["details"]["stage"], "running")
+        self.assertEqual(outcome.envelope["runtime_failure_signal"]["task_record_ref"], "task_record:task-store-3b")
         self.assertEqual(adapter.calls, 0)
         self.assertIsNone(outcome.task_record)
 


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：实现 `FR-0017` 最小运行时失败可观测性 carrier，为 `v0.6.0` 的 `failure_log_metrics` gate 维度提供可复验 runtime evidence。
- 主要改动：
  - 在 Core failed envelope 上投影 `RuntimeFailureSignal`、`RuntimeStructuredLogEvent`、`RuntimeExecutionMetricSample`。
  - 扩展 `TaskRecord` durable truth，新增 `runtime_failure_signals`、`runtime_structured_log_events`、`runtime_execution_metric_samples` 三组 JSON-safe carrier 字段。
  - 保持 success envelope 的 `raw` / `normalized` contract 不变，不引入外部日志或指标后端。
  - 新增 `tests/runtime/test_runtime_observability.py` 覆盖失败投影、success 不改写、admission concurrency rejection、retryable 分类保留和 durable record round-trip。

## Issue 摘要

`#227` 要求在 `FR-0017` 边界内实现失败分类、结构化日志与最小执行指标；不引入日志后端、dashboard 或外部监控依赖，不把平台私有语义写入 Core。

## 关联事项

- Issue: #227
- item_key: `CHORE-0151-fr-0017-failure-logs-metrics-runtime`
- item_type: `CHORE`
- release: `v0.6.0`
- sprint: `2026-S19`
- Closing: Fixes #227

## 风险

- 风险级别：`normal`
- 审查关注：失败分类必须直接来自 shared failed envelope；success payload 不得新增 observability 字段；新增 TaskRecord 字段必须 additive，旧记录缺字段时按空数组解析；metrics/logs 只是本地 JSON-safe carrier，不是外部 backend。

## 验证

- 已执行：
  - `python3 -m py_compile syvert/runtime.py syvert/task_record.py tests/runtime/test_runtime_observability.py`
  - `python3 -m unittest tests.runtime.test_runtime_observability -v` (`Ran 5 tests`, `OK`)
  - `python3 -m unittest tests.runtime.test_task_record_store tests.runtime.test_runtime tests.runtime.test_http_api tests.runtime.test_cli_http_same_path tests.runtime.test_execution_control tests.runtime.test_runtime_observability` (`Ran 161 tests`, `OK`)
  - `python3 -m unittest discover -s tests` (`Ran 376 tests`, `OK`)
  - `python3 scripts/governance_gate.py --mode local --base-ref origin/main` (`governance-gate 通过。`)
  - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD` (`PR scope 校验通过。`)
- 未执行：无。

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no

补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销 `syvert/runtime.py`、`syvert/task_record.py`、`tests/runtime/test_runtime_observability.py` 与 `docs/exec-plans/CHORE-0151-fr-0017-failure-logs-metrics-runtime.md` 的增量。
