### PR TITLE
docs(release): 建立 v0.6.0 发布收口 carrier

### DIFF
--- a/docs/decisions/ADR-GOV-0037-v0-6-0-phase-and-release-closeout.md
+++ b/docs/decisions/ADR-GOV-0037-v0-6-0-phase-and-release-closeout.md
@@ -1,0 +1,33 @@
+# ADR-GOV-0037 Close out v0.6.0 phase and publish anchors in a single governed round
+
+## 关联信息
+
+- Issue：`#236`
+- item_key：`GOV-0037-v0-6-0-phase-and-release-closeout`
+- item_type：`GOV`
+- release：`v0.6.0`
+- sprint：`2026-S19`
+
+## 背景
+
+`v0.6.0` 的四个 FR parent 已全部收口并关闭：
+
+- `FR-0016` 最小执行控制：`#219`，parent closeout PR `#248`
+- `FR-0017` 失败可见性与最小可观测信号：`#220`，parent closeout PR `#250`
+- `FR-0018` HTTP 任务 API 与 Core 同路径服务面：`#221`，parent closeout PR `#251`
+- `FR-0019` 可运维发布门禁与回归矩阵：`#222`，parent closeout PR `#253`
+
+当前剩余工作是把 release / sprint 索引、发布锚点、GitHub Release 与 Phase `#218` 状态收成一致。
+
+## 决策
+
+- 使用单一治理 Work Item `#236 / GOV-0037-v0-6-0-phase-and-release-closeout` 承接 `v0.6.0` 的 phase / release closeout。
+- 本事项采用两个串行阶段：
+  - 阶段 A：通过 docs PR 建立仓内 carrier，包括 release / sprint 索引、本 decision 与 active exec-plan。
+  - 阶段 B：阶段 A 合入后，在阶段 A merge commit 上创建 `v0.6.0` tag 和 GitHub Release，再通过 metadata-only/docs follow-up 回写 published truth，并关闭 Phase `#218` 与 Work Item `#236`。
+- 本事项不重新打开 `FR-0016` 到 `FR-0019` 的 formal spec、runtime 或 evidence 语义。
+
+## 影响
+
+- `v0.6.0` 将从“FR parent 全部完成”推进到“仓内 release/sprint carrier 完成”，再推进到“tag、GitHub Release、Phase 与仓内最终真相一致”的正式发布态。
+- tag 与 GitHub Release 后置于阶段 A PR 合入后的主干提交，避免发布锚点指向未合入或未审查的事实。

--- a/docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md
@@ -54,6 +54,14 @@
 
 - 为 `v0.6.0` 完成“从 FR parent 全部收口到正式发布”的最后一段链路，使 release/sprint 索引、发布锚点与 GitHub closeout 进入一致完成态。
 
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`2026-S19` 的 phase / release closeout Work Item，承接 `FR-0016..FR-0019` parent closeout 后的最终发布动作。
+- 位置：本事项是 `v0.6.0` 收口链路的最后一个 Work Item；阶段 A 建立仓内 carrier，阶段 B 建立发布锚点并回写 published truth。
+- 阻塞：
+  - 阶段 A PR 合入前不得创建 `v0.6.0` tag 或 GitHub Release。
+  - 阶段 B 合入并完成 tag / Release / Phase closeout 前，不得声明 `v0.6.0` 完成。
+
 ## 已验证项
 
 - `env -u GH_TOKEN -u GITHUB_TOKEN gh api repos/MC-and-his-Agents/Syvert/issues/219`

--- a/docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md
+++ b/docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md
@@ -1,0 +1,100 @@
+# GOV-0037 v0.6.0 phase and release closeout 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0037-v0-6-0-phase-and-release-closeout`
+- Issue：`#236`
+- item_type：`GOV`
+- release：`v0.6.0`
+- sprint：`2026-S19`
+- 关联 spec：无（发布/治理收口事项）
+- 关联 decision：`docs/decisions/ADR-GOV-0037-v0-6-0-phase-and-release-closeout.md`
+- 状态：`active`
+
+## 目标
+
+- 在不引入新 runtime、formal spec 或测试语义的前提下，通过合法 Work Item `#236` 完成 `v0.6.0` 的 phase / release 发布收口。
+- 把 `docs/releases/v0.6.0.md`、`docs/sprints/2026-S19.md`、Git tag、GitHub Release 与 GitHub issue truth 收口到同一条版本 closeout 证据链。
+
+## 范围
+
+- 本次纳入：
+  - `docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md`
+  - `docs/decisions/ADR-GOV-0037-v0-6-0-phase-and-release-closeout.md`
+  - `docs/releases/v0.6.0.md`
+  - `docs/sprints/2026-S19.md`
+- 本次不纳入：
+  - 新 runtime / adapter / test 实现
+  - `FR-0016` 到 `FR-0019` formal spec 或 requirement 语义改写
+  - `v0.7.0` 及后续版本规划推进
+  - 阶段 A PR 内建立 tag / GitHub Release
+  - 阶段 A PR 内关闭 GitHub Phase `#218`
+
+## 当前停点
+
+- `FR-0016` parent closeout 已由 PR `#248` 合入，merge commit `3c57ec6ce6437b0e810645b104fd85d6bf1235ba`，Issue `#219` 已关闭。
+- `FR-0017` parent closeout 已由 PR `#250` 合入，merge commit `394d48a7be861de742aae439c38e18625cc44193`，Issue `#220` 已关闭。
+- `FR-0018` parent closeout 已由 PR `#251` 合入，merge commit `7a1439052f85f26ae34e7770dd7de3b4c73f7fb3`，Issue `#221` 已关闭。
+- `FR-0019` parent closeout 已由 PR `#253` 合入，merge commit `2413ecc3d8d1811270d45420b91a0ae98af064be`，Issue `#222` 已关闭。
+- Git tag `v0.6.0` 当前不存在。
+- GitHub Release `v0.6.0` 当前不存在。
+- Phase `#218` 仍为 `open`。
+- 当前 worktree：`/Users/mc/code/worktrees/syvert/issue-236-v0-6-0`
+- 当前主干基线：`2413ecc3d8d1811270d45420b91a0ae98af064be`
+
+## 下一步动作
+
+- 阶段 A：创建 docs PR，建立 release / sprint / decision / exec-plan carrier。
+- 阶段 A 合入后 fast-forward main，并在阶段 A merge commit 上创建并推送 `v0.6.0` tag。
+- 创建 GitHub Release `v0.6.0`。
+- 阶段 B：回写 published truth，合入 metadata-only/docs follow-up。
+- 阶段 B 合入后关闭 `#218/#236` 并退役 worktree / branch。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.6.0` 完成“从 FR parent 全部收口到正式发布”的最后一段链路，使 release/sprint 索引、发布锚点与 GitHub closeout 进入一致完成态。
+
+## 已验证项
+
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh api repos/MC-and-his-Agents/Syvert/issues/219`
+  - 结果：`state=closed`
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh api repos/MC-and-his-Agents/Syvert/issues/220`
+  - 结果：`state=closed`
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh api repos/MC-and-his-Agents/Syvert/issues/221`
+  - 结果：`state=closed`
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh api repos/MC-and-his-Agents/Syvert/issues/222`
+  - 结果：`state=closed`
+- `env -u GH_TOKEN -u GITHUB_TOKEN gh release view v0.6.0`
+  - 结果：当前不存在 GitHub Release `v0.6.0`
+- `git tag --list 'v0.6.0'`
+  - 结果：当前未找到 `v0.6.0`
+
+## closeout 证据
+
+- `FR-0016`：formal spec / runtime / parent closeout 已完成，见 `docs/exec-plans/FR-0016-minimal-execution-controls.md`
+- `FR-0017`：formal spec / runtime / parent closeout 已完成，见 `docs/exec-plans/FR-0017-runtime-failure-observability.md`
+- `FR-0018`：formal spec / HTTP runtime / same-path evidence / parent closeout 已完成，见 `docs/exec-plans/FR-0018-http-task-api-same-core-path.md`
+- `FR-0019`：formal spec / gate runtime / source evidence / renderer / parent closeout 已完成，见 `docs/exec-plans/FR-0019-v0-6-operability-release-gate.md`
+
+## 剩余 closeout 动作
+
+- 合入阶段 A docs carrier PR
+- 创建并推送 `v0.6.0` tag
+- 创建 GitHub Release `v0.6.0`
+- 合入阶段 B published-truth follow-up PR
+- 回写并关闭 `#218/#236`
+
+## 未决风险
+
+- 若阶段 A 合入后没有立即建立 tag / GitHub Release，仓内 release/sprint 索引仍会滞后于正式发布态。
+- 若只建立 tag 而不回写 published truth 与 GitHub issue closeout metadata，`v0.6.0` 会出现“发布锚点已存在，但仓内/issue 真相仍停在前一跳”的分叉。
+
+## 回滚方式
+
+- 仓内回滚：使用独立 revert PR 撤销本事项对 release / sprint 索引、decision 与 exec-plan 的增量修改。
+- 仓外回滚：若 tag / GitHub Release 已建立但主干事实有误，先修正主干与 GitHub truth，再按独立治理回合决定是否删除 / 重建发布锚点。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `2413ecc3d8d1811270d45420b91a0ae98af064be`
+- 说明：该 checkpoint 对应 `FR-0016..FR-0019` parent closeout 全部合入主干、`v0.6.0` 具备正式发布前主干基线。阶段 A carrier、tag / GitHub Release 与阶段 B metadata-only 回写属于该 checkpoint 之后的发布收口动作。

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -55,5 +55,5 @@
 ## 当前发布与 closeout 状态
 
 - `FR-0016`、`FR-0017`、`FR-0018`、`FR-0019` 的 formal spec、runtime/evidence 与 parent closeout 已在当前 sprint 合入主干。
-- 阶段 A 发布 carrier 已建立在当前 PR 中；正式 tag 与 GitHub Release 将后置于阶段 A PR 合入后的主干提交。
+- 阶段 A 发布 carrier 正在当前 PR 中建立；正式 tag 与 GitHub Release 将后置于阶段 A PR 合入后的主干提交。
 - 当前 release 索引回写的是 pre-publish closeout truth，不等同于正式发布完成；`GOV-0037` 仍待 tag / GitHub Release / Phase closeout 完成后才算正式收口。

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,59 @@
+# Release v0.6.0
+
+## 目标
+
+- 为 Syvert 建立最小可运维运行时与 HTTP 服务面，使任务执行控制、失败可见性、HTTP submit/status/result 与 CLI/API same-path evidence 能在发布前统一验证。
+
+## 明确不在范围
+
+- 不引入生产调度器、外部观测平台、SaaS dashboard 或分布式压测。
+- 不重写既有 `FR-0007` version gate；`FR-0019` 只作为 v0.6.0 operability gate 叠加层。
+- 不推进 `v0.7.0` 规划。
+
+## 目标判据
+
+- `FR-0016` 已冻结并落地 timeout / retry / concurrency 最小 runtime。
+- `FR-0017` 已冻结并落地 failure signal、structured log、minimal metrics runtime。
+- `FR-0018` 已冻结并落地 stdlib HTTP submit/status/result surface，并证明 CLI/API same Core path。
+- `FR-0019` 已冻结并落地 v0.6.0 operability gate runner、source evidence artifact 与 renderer。
+- GitHub Phase / FR、release / sprint 索引、tag 与 GitHub Release 最终保持一致。
+
+## 纳入事项
+
+- `FR-0016-minimal-execution-controls`：`v0.6.0` 最小执行控制，对应 Issue `#219`
+- `CHORE-0148-fr-0016-runtime-timeout-retry-concurrency`：`FR-0016` runtime implementation，对应 Issue `#224`
+- `CHORE-0149-fr-0016-parent-closeout`：`FR-0016` parent closeout，对应 Issue `#225`
+- `FR-0017-runtime-failure-observability`：`v0.6.0` 失败可见性与最小可观测信号，对应 Issue `#220`
+- `CHORE-0151-fr-0017-failure-logs-metrics-runtime`：`FR-0017` runtime implementation，对应 Issue `#227`
+- `CHORE-0152-fr-0017-parent-closeout`：`FR-0017` parent closeout，对应 Issue `#228`
+- `FR-0018-http-task-api-same-core-path`：`v0.6.0` HTTP 任务 API 与 Core 同路径服务面，对应 Issue `#221`
+- `CHORE-0154-fr-0018-http-submit-status-result-runtime`：`FR-0018` HTTP runtime，对应 Issue `#230`
+- `CHORE-0155-fr-0018-cli-api-same-path-regression`：`FR-0018` CLI/API same-path evidence，对应 Issue `#231`
+- `CHORE-0156-fr-0018-parent-closeout`：`FR-0018` parent closeout，对应 Issue `#232`
+- `FR-0019-v0-6-operability-release-gate`：`v0.6.0` 可运维发布门禁与回归矩阵，对应 Issue `#222`
+- `CHORE-0158-fr-0019-v0-6-release-gate-runtime`：`FR-0019` gate runtime，对应 Issue `#234`
+- `CHORE-0159-fr-0019-parent-closeout`：`FR-0019` parent closeout，对应 Issue `#235`
+- `GOV-0037-v0-6-0-phase-and-release-closeout`：`v0.6.0` phase 与发布收口，对应 Issue `#236`
+
+## 关联工件
+
+- sprint：`docs/sprints/2026-S19.md`
+- spec：
+  - `docs/specs/FR-0016-minimal-execution-controls/`
+  - `docs/specs/FR-0017-runtime-failure-observability/`
+  - `docs/specs/FR-0018-http-task-api-same-core-path/`
+  - `docs/specs/FR-0019-v0-6-operability-release-gate/`
+- exec-plan：
+  - `docs/exec-plans/FR-0016-minimal-execution-controls.md`
+  - `docs/exec-plans/FR-0017-runtime-failure-observability.md`
+  - `docs/exec-plans/FR-0018-http-task-api-same-core-path.md`
+  - `docs/exec-plans/FR-0019-v0-6-operability-release-gate.md`
+  - `docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md`
+- decision：
+  - `docs/decisions/ADR-GOV-0037-v0-6-0-phase-and-release-closeout.md`
+
+## 当前发布与 closeout 状态
+
+- `FR-0016`、`FR-0017`、`FR-0018`、`FR-0019` 的 formal spec、runtime/evidence 与 parent closeout 已在当前 sprint 合入主干。
+- 阶段 A 发布 carrier 已建立在当前 PR 中；正式 tag 与 GitHub Release 将后置于阶段 A PR 合入后的主干提交。
+- 当前 release 索引回写的是 pre-publish closeout truth，不等同于正式发布完成；`GOV-0037` 仍待 tag / GitHub Release / Phase closeout 完成后才算正式收口。

--- a/docs/sprints/2026-S19.md
+++ b/docs/sprints/2026-S19.md
@@ -1,0 +1,66 @@
+# Sprint 2026-S19
+
+## release
+
+- `v0.6.0`
+
+## 本轮目标
+
+- 为 `v0.6.0` 收口最小可运维运行时与 HTTP 服务面：冻结最小执行控制、失败可见性、HTTP submit/status/result、CLI/API same-path evidence 与 operability release gate。
+
+## 入口事项
+
+- `FR-0016-minimal-execution-controls`：最小执行控制，对应 Issue `#219`
+- `CHORE-0148-fr-0016-runtime-timeout-retry-concurrency`：`FR-0016` runtime，对应 Issue `#224`
+- `CHORE-0149-fr-0016-parent-closeout`：`FR-0016` parent closeout，对应 Issue `#225`
+- `FR-0017-runtime-failure-observability`：失败可见性与最小可观测信号，对应 Issue `#220`
+- `CHORE-0151-fr-0017-failure-logs-metrics-runtime`：`FR-0017` runtime，对应 Issue `#227`
+- `CHORE-0152-fr-0017-parent-closeout`：`FR-0017` parent closeout，对应 Issue `#228`
+- `FR-0018-http-task-api-same-core-path`：HTTP 任务 API 与 Core 同路径服务面，对应 Issue `#221`
+- `CHORE-0154-fr-0018-http-submit-status-result-runtime`：`FR-0018` HTTP runtime，对应 Issue `#230`
+- `CHORE-0155-fr-0018-cli-api-same-path-regression`：`FR-0018` CLI/API same-path evidence，对应 Issue `#231`
+- `CHORE-0156-fr-0018-parent-closeout`：`FR-0018` parent closeout，对应 Issue `#232`
+- `FR-0019-v0-6-operability-release-gate`：可运维发布门禁与回归矩阵，对应 Issue `#222`
+- `CHORE-0158-fr-0019-v0-6-release-gate-runtime`：`FR-0019` gate runtime，对应 Issue `#234`
+- `CHORE-0159-fr-0019-parent-closeout`：`FR-0019` parent closeout，对应 Issue `#235`
+- `GOV-0037-v0-6-0-phase-and-release-closeout`：`v0.6.0` phase 与发布收口，对应 Issue `#236`
+
+## 进入前依赖
+
+- `v0.5.0` 已正式发布，并冻结资源能力抽象、能力匹配与双参考 evidence baseline。
+- GitHub Phase `#218` 已建立并关联 `FR-0016..FR-0019`。
+
+## 目标判据
+
+- `FR-0016` runtime 已在 Core path 内提供 timeout / retry / concurrency 最小控制。
+- `FR-0017` runtime 已提供 failure signal、structured log 与 minimal metrics carrier。
+- `FR-0018` HTTP runtime 与 CLI/API same-path evidence 已证明共享 Core path、TaskRecord truth 与 terminal envelope truth。
+- `FR-0019` operability gate runner 已覆盖四个 mandatory dimensions，并可基于 source evidence + renderer 产出可复验 gate result。
+- `v0.6.0` 的 phase / release closeout 已把 release/sprint 索引、tag、GitHub Release 与 GitHub issue 状态收成一致。
+
+## 协作入口
+
+- GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口。
+- 相关 Issue / PR：`#218`、`#219`、`#220`、`#221`、`#222`、`#224`、`#225`、`#227`、`#228`、`#230`、`#231`、`#232`、`#234`、`#235`、`#236`、`#245`、`#246`、`#248`、`#249`、`#250`、`#251`、`#252`、`#253`
+
+## 关联工件
+
+- release：`docs/releases/v0.6.0.md`
+- spec：
+  - `docs/specs/FR-0016-minimal-execution-controls/`
+  - `docs/specs/FR-0017-runtime-failure-observability/`
+  - `docs/specs/FR-0018-http-task-api-same-core-path/`
+  - `docs/specs/FR-0019-v0-6-operability-release-gate/`
+- exec-plan：
+  - `docs/exec-plans/FR-0016-minimal-execution-controls.md`
+  - `docs/exec-plans/FR-0017-runtime-failure-observability.md`
+  - `docs/exec-plans/FR-0018-http-task-api-same-core-path.md`
+  - `docs/exec-plans/FR-0019-v0-6-operability-release-gate.md`
+  - `docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md`
+- decision：
+  - `docs/decisions/ADR-GOV-0037-v0-6-0-phase-and-release-closeout.md`
+
+## 当前发布与 closeout 状态
+
+- `FR-0016`、`FR-0017`、`FR-0018`、`FR-0019` 的 parent closeout 已完成。
+- 阶段 A 发布 carrier 正在建立；正式 tag、GitHub Release 与 Phase closeout 将在阶段 A 合入后完成。


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：为 `v0.6.0` phase/release closeout 建立阶段 A carrier。
- 主要改动：新增 release index、sprint index、ADR 与 active exec-plan。

## Issue 摘要

- Work Item: #236 / `GOV-0037-v0-6-0-phase-and-release-closeout`
- Phase: #218 / `v0.6.0 最小可运维与 HTTP 服务面`
- 关联 FR: #219/#220/#221/#222，当前均已关闭。
- 边界：本 PR 不创建 tag / GitHub Release，不关闭 #218；这些动作在阶段 A 合入后执行，再由阶段 B follow-up 回写 published truth。

## 关联事项

- Issue: #236
- item_key: `GOV-0037-v0-6-0-phase-and-release-closeout`
- item_type: `GOV`
- release: `v0.6.0`
- sprint: `2026-S19`
- Closing: Fixes #236

## 风险

- 风险级别：`lightweight`
- 审查关注：确认这是阶段 A carrier，不提前声明 tag / GitHub Release 已完成。

## 验证

- 已执行：
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
  - `python3 scripts/governance_gate.py --mode local --base-ref origin/main`
- 未执行：runtime tests；本 PR 为 docs-only release carrier。

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no

补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次 release/sprint carrier、ADR 与 exec-plan 变更。