### PR TITLE
fix(runtime): 收敛运行时测试基线

### DIFF
--- a/docs/exec-plans/HOTFIX-0260-runtime-baseline-failures.md
+++ b/docs/exec-plans/HOTFIX-0260-runtime-baseline-failures.md
@@ -1,0 +1,80 @@
+# HOTFIX-0260 Runtime baseline failures 执行计划
+
+## 关联信息
+
+- item_key：`HOTFIX-0260-runtime-baseline-failures`
+- Issue：`#260`
+- item_type：`HOTFIX`
+- release：`v0.6.0`
+- sprint：`2026-S19`
+- 关联 spec：`docs/specs/FR-0007-release-gate-and-regression-checks/`
+- 关联 decision：
+- 关联 PR：`#261`
+- active 收口事项：`HOTFIX-0260-runtime-baseline-failures`
+- 状态：`active`
+
+## 目标
+
+- 收敛 `#259` Loom adoption 过程中显式拆出的 Syvert runtime baseline residual。
+- 恢复 `python3.11 -m unittest discover -s tests/runtime -p 'test_*.py'` 在主干上的稳定通过状态。
+
+## 范围
+
+- 本次纳入：`tests/runtime` 当前失败与异常耗时的最小修复，包括 CLI durable truth 等价测试规范化、Douyin browser bridge 单测签名依赖隔离、platform leakage 扫描性能修复，以及由此解除的 version gate 超时。
+- 本次不纳入：Loom runtime / governance carrier 变更、Core / Adapter SDK public contract 变更、v0.6.0 tag 或 GitHub Release 改写。
+
+## 当前停点
+
+- `#258/#257/#259` 已关闭，Loom adoption 已合入主干。
+- `#260` 已补齐事项上下文，当前 worktree 已完成 runtime baseline 最小修复。
+- PR `#261` 已创建，`tests/runtime` discovery 已在当前分支通过，等待最新 head 的 CI、guardian 与受控合并。
+
+## 下一步动作
+
+- 完成 PR `#261` 的 CI、guardian 与受控合并。
+- 合入后回写并关闭 `#260`。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为已发布的 `v0.6.0` 补齐 post-closeout runtime baseline hotfix，使后续治理迁移不再携带 `tests/runtime` waiver。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`v0.6.0` 发布后的 runtime baseline hotfix。
+- 阻塞：`#260` 关闭前，`tests/runtime` discovery 不能作为主干稳定门禁恢复使用。
+
+## 已验证项
+
+- `python3.11 -m unittest tests.runtime.test_cli.CliTests.test_run_subcommand_and_legacy_entrypoint_persist_equivalent_durable_truth`
+  - 结果：通过，`Ran 1 test`，`OK`。
+- `python3.11 -m unittest tests.runtime.test_douyin_browser_bridge.DouyinBrowserBridgeTests.test_extract_page_state_falls_back_to_authenticated_detail_request_when_page_state_misses_target`
+  - 结果：通过，`Ran 1 test`，`OK`。
+- `python3.11 -m unittest tests.runtime.test_platform_leakage`
+  - 结果：通过，`Ran 111 tests in 69.782s`，`OK`。
+- `python3.11 -m unittest tests.runtime.test_version_gate`
+  - 结果：通过，`Ran 99 tests in 2.546s`，`OK`。
+- `python3.11 -m unittest discover -s tests/runtime -p 'test_*.py'`
+  - 结果：通过，`Ran 832 tests in 79.697s`，`OK`。
+- `python3.11 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- `python3.11 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- `python3.11 -m py_compile syvert/*.py syvert/adapters/*.py`
+  - 结果：通过。
+- `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-260-fix-runtime-tests-runtime-baseline-failures`
+  - 结果：通过。
+
+## 未决风险
+
+- platform leakage 扫描器属于 release gate 证据链的一部分，性能修复必须保持 payload/report 形状不变。
+- Douyin browser bridge 的 signer 注入只能作为 adapter-private 测试隔离入口，默认运行路径必须继续使用既有签名请求。
+- CLI durable truth 等价修复只允许规范化测试中的动态 ID / 时间 / duration，不应放宽 production contract。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销本事项对 `tests/runtime/test_cli.py`、`tests/runtime/test_douyin_browser_bridge.py`、`syvert/adapters/douyin_browser_bridge.py`、`syvert/platform_leakage.py`、本 exec-plan 与 sprint 索引的增量。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `a0279906a05dde60296445a28277d49909fdfe52`
+- 说明：该 SHA 为本 hotfix worktree 从 `origin/main` 创建时的基线；进入 review 前会以当前 PR head 和验证证据更新执行状态。

--- a/docs/sprints/2026-S19.md
+++ b/docs/sprints/2026-S19.md
@@ -24,6 +24,7 @@
 - `CHORE-0158-fr-0019-v0-6-release-gate-runtime`：`FR-0019` gate runtime，对应 Issue `#234`
 - `CHORE-0159-fr-0019-parent-closeout`：`FR-0019` parent closeout，对应 Issue `#235`
 - `GOV-0037-v0-6-0-phase-and-release-closeout`：`v0.6.0` phase 与发布收口，对应 Issue `#236`
+- `HOTFIX-0260-runtime-baseline-failures`：`v0.6.0` post-closeout runtime baseline hotfix，对应 Issue `#260`
 
 ## 进入前依赖
 
@@ -41,7 +42,7 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口。
-- 相关 Issue / PR：`#218`、`#219`、`#220`、`#221`、`#222`、`#224`、`#225`、`#227`、`#228`、`#230`、`#231`、`#232`、`#234`、`#235`、`#236`、`#245`、`#246`、`#248`、`#249`、`#250`、`#251`、`#252`、`#253`、`#254`、`#255`
+- 相关 Issue / PR：`#218`、`#219`、`#220`、`#221`、`#222`、`#224`、`#225`、`#227`、`#228`、`#230`、`#231`、`#232`、`#234`、`#235`、`#236`、`#245`、`#246`、`#248`、`#249`、`#250`、`#251`、`#252`、`#253`、`#254`、`#255`、`#260`
 
 ## 关联工件
 
@@ -57,6 +58,7 @@
   - `docs/exec-plans/FR-0018-http-task-api-same-core-path.md`
   - `docs/exec-plans/FR-0019-v0-6-operability-release-gate.md`
   - `docs/exec-plans/GOV-0037-v0-6-0-phase-and-release-closeout.md`
+  - `docs/exec-plans/HOTFIX-0260-runtime-baseline-failures.md`
 - decision：
   - `docs/decisions/ADR-GOV-0037-v0-6-0-phase-and-release-closeout.md`
 
@@ -66,3 +68,4 @@
 - 阶段 A 发布 carrier 已由 PR `#254` 合入主干，merge commit `123cd6dc0c6037050011fde87bace33ca0412098`。
 - `v0.6.0` tag 与 GitHub Release `v0.6.0` 已建立。
 - 当前 sprint 索引已由 PR `#255` 回写 published truth；正式 closeout 由 PR `#255` 合入后的 `#218/#236` issue 状态同步完成。
+- `#260` 作为 `v0.6.0` post-closeout runtime baseline hotfix，负责移除 `#259` Loom adoption 中接受的 `tests/runtime` waiver，不改写已发布 tag / GitHub Release 真相。

--- a/syvert/adapters/douyin_browser_bridge.py
+++ b/syvert/adapters/douyin_browser_bridge.py
@@ -149,9 +149,16 @@ def default_run_applescript(script: str, *, timeout_seconds: int) -> str:
 
 
 class DouyinAuthenticatedBrowserBridge:
-    def __init__(self, *, run_applescript=default_run_applescript, timeout_seconds: int = 10) -> None:
+    def __init__(
+        self,
+        *,
+        run_applescript=default_run_applescript,
+        timeout_seconds: int = 10,
+        _sign_browser_detail_request=None,
+    ) -> None:
         self._run_applescript = run_applescript
         self._timeout_seconds = max(timeout_seconds, 1)
+        self._sign_browser_detail_request = _sign_browser_detail_request or sign_browser_detail_request
 
     def list_tabs(self) -> list[ChromeTab]:
         output = self._run_script(self._build_list_tabs_script())
@@ -276,7 +283,7 @@ end tell
             ms_token=context.ms_token,
             webid=context.webid,
         )
-        params["a_bogus"] = sign_browser_detail_request(
+        params["a_bogus"] = self._sign_browser_detail_request(
             sign_base_url=sign_base_url,
             query_params=parse.urlencode(params),
             user_agent=context.user_agent,

--- a/syvert/platform_leakage.py
+++ b/syvert/platform_leakage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 import re
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +52,12 @@ _RUNTIME_SYMBOL_BOUNDARIES = {
     "invalid_input_error": "shared_error_model",
     "unsupported_error": "shared_error_model",
 }
+_RUNTIME_STATEMENT_BOUNDARY_OVERRIDE_FUNCTIONS = frozenset(
+    {
+        "execute_task_internal",
+        "run_adapter_attempt_with_timeout",
+    }
+)
 
 _PLATFORM_FIELD_RE = re.compile(r"\b(note_id|aweme_id|sign_base_url|sec_uid|xsec_token|web_rid)\b")
 _PLATFORM_STRING_FRAGMENT_RE = re.compile(
@@ -306,8 +312,8 @@ def _build_boundary_resolver(relative_name: str, source_text: str) -> Any:
 
 def _collect_runtime_statement_boundary_overrides(module: ast.Module) -> list[tuple[int, int, str]]:
     ranges: list[tuple[int, int, str]] = []
-    for node in module.body:
-        if not isinstance(node, ast.FunctionDef) or node.name != "execute_task_internal":
+    for node in ast.walk(module):
+        if not isinstance(node, ast.FunctionDef) or node.name not in _RUNTIME_STATEMENT_BOUNDARY_OVERRIDE_FUNCTIONS:
             continue
         for statement in sorted(
             (
@@ -330,6 +336,8 @@ def _classify_execute_task_statement_boundary(statement: ast.stmt) -> str | None
         return "shared_error_model"
     if isinstance(statement, (ast.Assign, ast.AnnAssign)) and _is_failure_envelope_expr(value):
         return "shared_error_model"
+    if isinstance(statement, ast.Return) and _return_contains_success_envelope(value):
+        return "shared_result_contract"
     if _is_success_envelope_expr(value):
         return "shared_result_contract"
     return None
@@ -349,7 +357,14 @@ def _is_failure_envelope_expr(value: ast.AST | None) -> bool:
     return (
         isinstance(value, ast.Call)
         and isinstance(value.func, ast.Name)
-        and value.func.id == "failure_envelope"
+        and value.func.id
+        in {
+            "failure_envelope",
+            "pre_accepted_failure_envelope",
+            "runtime_contract_error",
+            "invalid_input_error",
+            "unsupported_error",
+        }
     )
 
 
@@ -357,6 +372,12 @@ def _return_contains_failure_envelope(value: ast.AST | None) -> bool:
     if value is None:
         return False
     return any(_is_failure_envelope_expr(node) for node in ast.walk(value))
+
+
+def _return_contains_success_envelope(value: ast.AST | None) -> bool:
+    if value is None:
+        return False
+    return any(_is_success_envelope_expr(node) for node in ast.walk(value))
 
 
 def _is_success_envelope_expr(value: ast.AST | None) -> bool:
@@ -498,6 +519,7 @@ def _scan_file(
         ]
 
     findings: list[dict[str, str]] = []
+    statement_source_segment = _build_statement_source_segment(source_text)
     parent_index = _build_parent_index(module)
     platform_alias_histories = _build_platform_alias_histories(module, parent_index)
     key_signal_histories = _build_key_signal_histories(module, parent_index, platform_alias_histories)
@@ -533,7 +555,7 @@ def _scan_file(
                 continue
             boundary = boundary_resolver(line_number)
             evidence_ref = f"platform_leakage:{boundary}:{relative_name}:{line_number}"
-            function_source = _statement_source_segment(source_text, node)
+            function_source = statement_source_segment(node)
             if _function_has_single_platform_semantic(
                 node,
                 function_source,
@@ -595,7 +617,7 @@ def _scan_file(
 
         boundary = boundary_resolver(line_number)
         evidence_ref = f"platform_leakage:{boundary}:{relative_name}:{line_number}"
-        statement_source = _statement_source_segment(source_text, node)
+        statement_source = statement_source_segment(node)
         if _is_docstring_statement(node):
             continue
         if isinstance(node, ast.ClassDef) and _definition_has_platform_metadata(
@@ -682,8 +704,47 @@ def _statement_identity(node: ast.AST) -> tuple[int, int, int, int]:
     )
 
 
-def _statement_source_segment(source_text: str, node: ast.AST) -> str:
-    return ast.get_source_segment(source_text, node) or ""
+def _build_statement_source_segment(source_text: str) -> Callable[[ast.AST], str]:
+    source_lines = _split_source_lines_for_ast_positions(source_text)
+
+    def statement_source_segment(node: ast.AST) -> str:
+        try:
+            if node.end_lineno is None or node.end_col_offset is None:
+                return ""
+            line_index = node.lineno - 1
+            end_line_index = node.end_lineno - 1
+            col_offset = node.col_offset
+            end_col_offset = node.end_col_offset
+        except AttributeError:
+            return ""
+
+        if end_line_index == line_index:
+            return source_lines[line_index].encode()[col_offset:end_col_offset].decode()
+
+        first_line = source_lines[line_index].encode()[col_offset:].decode()
+        last_line = source_lines[end_line_index].encode()[:end_col_offset].decode()
+        return "".join((first_line, *source_lines[line_index + 1 : end_line_index], last_line))
+
+    return statement_source_segment
+
+
+def _split_source_lines_for_ast_positions(source_text: str) -> list[str]:
+    lines: list[str] = []
+    current_line = ""
+    index = 0
+    while index < len(source_text):
+        character = source_text[index]
+        current_line += character
+        index += 1
+        if character == "\r" and index < len(source_text) and source_text[index] == "\n":
+            current_line += "\n"
+            index += 1
+        if character in "\r\n":
+            lines.append(current_line)
+            current_line = ""
+    if current_line:
+        lines.append(current_line)
+    return lines
 
 
 def _build_parent_index(module: ast.AST) -> dict[ast.AST, ast.AST]:

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -4,6 +4,7 @@ from contextlib import ExitStack
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -93,27 +94,59 @@ class BrokenWriteStream(io.StringIO):
         raise BrokenPipeError("forced-broken-pipe")
 
 
+_EQUIVALENT_ENTRYPOINT_TASK_IDS = (
+    "task-cli-shared-legacy-1",
+    "task-cli-shared-run-equivalent-1",
+)
+_ISO_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+_DYNAMIC_TASK_ID_REF_PATHS = {
+    ("task_id",),
+    ("task_record_ref",),
+    ("result", "envelope", "task_id"),
+    ("result", "envelope", "task_record_ref"),
+    ("runtime_structured_log_events", "*", "event_id"),
+    ("runtime_structured_log_events", "*", "task_id"),
+    ("runtime_structured_log_events", "*", "runtime_result_refs", "*", "ref_id"),
+    ("runtime_structured_log_events", "*", "runtime_result_refs", "*", "task_id"),
+    ("runtime_structured_log_events", "*", "runtime_result_refs", "*", "terminal_envelope", "task_id"),
+    ("runtime_structured_log_events", "*", "runtime_result_refs", "*", "terminal_envelope", "task_record_ref"),
+    ("runtime_execution_metric_samples", "*", "metric_id"),
+    ("runtime_execution_metric_samples", "*", "task_id"),
+}
+_DYNAMIC_TIMESTAMP_PATHS = {
+    ("created_at",),
+    ("updated_at",),
+    ("terminal_at",),
+    ("logs", "*", "occurred_at"),
+    ("runtime_structured_log_events", "*", "occurred_at"),
+    ("runtime_structured_log_events", "*", "runtime_result_refs", "*", "started_at"),
+    ("runtime_structured_log_events", "*", "runtime_result_refs", "*", "ended_at"),
+    ("runtime_execution_metric_samples", "*", "occurred_at"),
+}
+_EXECUTION_DURATION_METRIC_SAMPLE_PATH = ("runtime_execution_metric_samples", "*")
+
+
+def normalize_persisted_task_record_value(value: object, *, path: tuple[str, ...] = ()) -> object:
+    if isinstance(value, dict):
+        normalized = {key: normalize_persisted_task_record_value(item, path=path + (key,)) for key, item in value.items()}
+        if path == _EXECUTION_DURATION_METRIC_SAMPLE_PATH and normalized.get("metric_name") == "execution_duration_ms":
+            normalized["metric_value"] = "normalized-execution-duration-ms"
+        return normalized
+    if isinstance(value, list):
+        return [normalize_persisted_task_record_value(item, path=path + ("*",)) for item in value]
+    if isinstance(value, str):
+        if path in _DYNAMIC_TIMESTAMP_PATHS and _ISO_TIMESTAMP_RE.match(value):
+            return "normalized-timestamp"
+        if path in _DYNAMIC_TASK_ID_REF_PATHS:
+            normalized = value
+            for task_id in _EQUIVALENT_ENTRYPOINT_TASK_IDS:
+                normalized = normalized.replace(task_id, "normalized-task-id")
+            return normalized
+    return value
+
+
 def normalize_persisted_task_record_payload(payload: dict[str, object]) -> dict[str, object]:
-    normalized = json.loads(json.dumps(payload))
-    normalized["task_id"] = "normalized-task-id"
-    if isinstance(normalized.get("task_record_ref"), str):
-        normalized["task_record_ref"] = "normalized-task-record-ref"
-    result = normalized.get("result")
-    if isinstance(result, dict):
-        envelope = result.get("envelope")
-        if isinstance(envelope, dict) and isinstance(envelope.get("task_id"), str):
-            envelope["task_id"] = "normalized-task-id"
-        if isinstance(envelope, dict) and isinstance(envelope.get("task_record_ref"), str):
-            envelope["task_record_ref"] = "normalized-task-record-ref"
-    for field in ("created_at", "updated_at", "terminal_at"):
-        if isinstance(normalized.get(field), str):
-            normalized[field] = f"normalized-{field}"
-    logs = normalized.get("logs")
-    if isinstance(logs, list):
-        for index, entry in enumerate(logs, start=1):
-            if isinstance(entry, dict) and isinstance(entry.get("occurred_at"), str):
-                entry["occurred_at"] = f"normalized-log-{index}-occurred-at"
-    return normalized
+    return normalize_persisted_task_record_value(json.loads(json.dumps(payload)))  # type: ignore[return-value]
 
 
 def unexpected_secondary_filesystem_consultation(*args: object, **kwargs: object) -> object:

--- a/tests/runtime/test_douyin_browser_bridge.py
+++ b/tests/runtime/test_douyin_browser_bridge.py
@@ -247,6 +247,8 @@ class DouyinBrowserBridgeTests(unittest.TestCase):
     def test_extract_page_state_falls_back_to_authenticated_detail_request_when_page_state_misses_target(self) -> None:
         from syvert.adapters.douyin_browser_bridge import DouyinAuthenticatedBrowserBridge
 
+        detail_request_scripts = []
+
         def run_applescript(script: str) -> str:
             if "set outputLines" in script:
                 return "1|目标页|https://www.douyin.com/video/7580570616932224282"
@@ -263,6 +265,7 @@ class DouyinBrowserBridgeTests(unittest.TestCase):
                     }
                 )
             if "new XMLHttpRequest()" in script:
+                detail_request_scripts.append(script)
                 return json.dumps(
                     {
                         "status": 200,
@@ -279,7 +282,31 @@ class DouyinBrowserBridgeTests(unittest.TestCase):
                 )
             raise AssertionError(script)
 
-        bridge = DouyinAuthenticatedBrowserBridge(run_applescript=run_applescript)
+        signer_calls = []
+
+        def fake_sign_browser_detail_request(
+            *,
+            sign_base_url: str,
+            query_params: str,
+            user_agent: str,
+            cookies: str,
+            timeout_seconds: int,
+        ) -> str:
+            signer_calls.append(
+                {
+                    "sign_base_url": sign_base_url,
+                    "query_params": query_params,
+                    "user_agent": user_agent,
+                    "cookies": cookies,
+                    "timeout_seconds": timeout_seconds,
+                }
+            )
+            return "fake-a-bogus"
+
+        bridge = DouyinAuthenticatedBrowserBridge(
+            run_applescript=run_applescript,
+            _sign_browser_detail_request=fake_sign_browser_detail_request,
+        )
 
         payload = bridge.extract_page_state(
             target_url="https://www.douyin.com/video/7580570616932224282",
@@ -288,6 +315,18 @@ class DouyinBrowserBridgeTests(unittest.TestCase):
         )
 
         self.assertEqual(payload["AWEME_DETAIL"]["desc"], "浏览器请求命中")
+        self.assertEqual(len(signer_calls), 1)
+        self.assertEqual(signer_calls[0]["sign_base_url"], "http://127.0.0.1:8989")
+        self.assertEqual(signer_calls[0]["user_agent"], "Mozilla/5.0 TestAgent")
+        self.assertEqual(signer_calls[0]["cookies"], "s_v_web_id=verify-browser-1")
+        signed_params = dict(parse.parse_qsl(signer_calls[0]["query_params"]))
+        self.assertEqual(signed_params["aweme_id"], "7580570616932224282")
+        self.assertEqual(signed_params["verifyFp"], "verify-browser-1")
+        self.assertEqual(signed_params["fp"], "verify-browser-1")
+        self.assertEqual(signed_params["msToken"], "ms-token-browser-1")
+        self.assertEqual(signed_params["webid"], "webid-browser-1")
+        self.assertEqual(len(detail_request_scripts), 1)
+        self.assertIn("a_bogus=fake-a-bogus", detail_request_scripts[0])
 
     def test_extract_page_state_accepts_percent_encoded_render_data_payload(self) -> None:
         from syvert.adapters.douyin_browser_bridge import DouyinAuthenticatedBrowserBridge

--- a/tests/runtime/test_platform_leakage.py
+++ b/tests/runtime/test_platform_leakage.py
@@ -162,8 +162,8 @@ class PlatformLeakageTests(unittest.TestCase):
         report = self.run_with_fixture(
             {
                 "syvert/runtime.py": (
-                    "    supported_targets = declaration.supported_targets\n",
-                    '    runtime_platform_hint = "xhs"\n    supported_targets = declaration.supported_targets\n',
+                    "    supported_targets = adapter_declaration.supported_targets\n",
+                    '    runtime_platform_hint = "xhs"\n    supported_targets = adapter_declaration.supported_targets\n',
                 )
             }
         )


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：收敛 #260 记录的 Syvert runtime baseline failures，恢复 `tests/runtime` discovery 为可通过门禁。
- 主要改动：隔离 Douyin browser bridge 单测签名服务依赖；规范化 CLI durable truth 等价测试中的动态 refs/timestamps/duration；优化 platform leakage AST source segment 提取并同步当前 runtime 边界归类；新增 HOTFIX-0260 exec-plan 与 S19 post-closeout 索引。

## Issue 摘要

## Scope

- Triage and fix the existing `tests/runtime` failures.
- Keep this separate from Loom governance adoption because PR #259 does not modify Syvert runtime business logic.
- Restore `tests/runtime` discovery as a required passing runtime validation once fixed.

## 关联事项

- Issue: #260
- item_key: `HOTFIX-0260-runtime-baseline-failures`
- item_type: `HOTFIX`
- release: `v0.6.0`
- sprint: `2026-S19`
- Closing: Fixes #260

## Review Artifacts

- Active exec-plan: `docs/exec-plans/HOTFIX-0260-runtime-baseline-failures.md`
- Governing spec / bootstrap contract: `docs/specs/FR-0007-release-gate-and-regression-checks`
- Review artifact: `code_review.md`
- Validation evidence: `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-260-fix-runtime-tests-runtime-baseline-failures`

## 风险

- 风险级别：`normal`
- 审查关注：platform leakage 报告形状必须保持兼容；Douyin signer 注入只作为 adapter-private 测试隔离入口；CLI durable truth 测试只规范化动态字段，不放宽 production TaskRecord contract。

## 验证

- 已执行：
  - `python3.11 -m unittest tests.runtime.test_cli.CliTests.test_run_subcommand_and_legacy_entrypoint_persist_equivalent_durable_truth` -> OK, Ran 1 test
  - `python3.11 -m unittest tests.runtime.test_douyin_browser_bridge.DouyinBrowserBridgeTests.test_extract_page_state_falls_back_to_authenticated_detail_request_when_page_state_misses_target` -> OK, Ran 1 test
  - `python3.11 -m unittest tests.runtime.test_platform_leakage` -> OK, Ran 111 tests in 69.782s
  - `python3.11 -m unittest tests.runtime.test_version_gate` -> OK, Ran 99 tests in 2.546s
  - `python3.11 -m unittest discover -s tests/runtime -p 'test_*.py'` -> OK, Ran 832 tests in 79.697s
  - `python3.11 scripts/docs_guard.py --mode ci` -> 通过
  - `python3.11 scripts/workflow_guard.py --mode ci` -> 通过
  - `python3.11 -m py_compile syvert/*.py syvert/adapters/*.py` -> 通过
  - `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-260-fix-runtime-tests-runtime-baseline-failures` -> 通过
- 未执行：无

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：使用独立 revert PR 撤销本次对 runtime tests、Douyin bridge、platform leakage scanner、HOTFIX-0260 exec-plan 与 S19 索引的增量。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.

