### PR TITLE
fix(governance): 关闭 spec mirror issue 调度噪音

### DIFF
--- a/docs/decisions/ADR-GOV-0262-spec-mirror-issue-cleanup.md
+++ b/docs/decisions/ADR-GOV-0262-spec-mirror-issue-cleanup.md
@@ -1,0 +1,28 @@
+# ADR-GOV-0262 Keep spec mirror issues closed
+
+## 关联信息
+
+- Issue：`#262`
+- item_key：`GOV-0262-spec-mirror-issue-cleanup`
+- item_type：`GOV`
+- release：`v0.7.0`
+- sprint：`2026-S20`
+
+## 背景
+
+`spec_issue_sync.py` 自动维护的 GitHub issue 只用于把仓内 formal spec 的最小索引信息投影到 GitHub。它们不是 Phase、FR 或 Work Item，也不承载执行入口。
+
+当前多个 spec mirror issue 处于 open 状态，导致 GitHub open issue 列表混入不可执行的索引镜像，干扰下一阶段事项识别。
+
+## 决策
+
+- spec mirror issue 必须保持 closed。
+- `spec_issue_sync.py` 在新建或更新 mirror issue 后必须立即关闭该 issue。
+- mirror 正文必须说明 canonical contract 仍以仓内 `docs/specs/**/spec.md` 为准，且该 issue 不是调度入口。
+- 后续进入交付漏斗时，只能使用真实 Phase / FR / Work Item；不得把 spec mirror issue 当作 backlog 或执行入口。
+
+## 影响
+
+- GitHub open issue 列表不再被 spec mirror 索引污染。
+- 已关闭的 mirror issue 仍可被同步脚本定位并更新，避免重复创建。
+- 若未来需要重新开放 spec mirror issue，必须另建治理事项说明其调度语义。

--- a/docs/exec-plans/GOV-0262-spec-mirror-issue-cleanup.md
+++ b/docs/exec-plans/GOV-0262-spec-mirror-issue-cleanup.md
@@ -1,0 +1,82 @@
+# GOV-0262 spec mirror issue cleanup 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0262-spec-mirror-issue-cleanup`
+- Issue：`#262`
+- item_type：`GOV`
+- release：`v0.7.0`
+- sprint：`2026-S20`
+- 关联 spec：
+- 关联 decision：`docs/decisions/ADR-GOV-0262-spec-mirror-issue-cleanup.md`
+- 关联 PR：`#263`
+- active 收口事项：`GOV-0262-spec-mirror-issue-cleanup`
+- 状态：`active`
+
+## 目标
+
+- 清理 `spec_issue_sync.py` 自动维护的 spec mirror issue 对 GitHub open issue 调度真相的污染。
+- 让后续 spec mirror 同步在创建或更新 issue 后保持 closed，避免它们被误判为可执行 Phase / FR / Work Item。
+
+## 范围
+
+- 本次纳入：
+  - 修改 `scripts/spec_issue_sync.py` 的 GitHub issue upsert 行为，使 mirror issue 新建或更新后自动关闭。
+  - 为该行为补充 governance 单测。
+  - 关闭当前已存在的 open spec mirror issues，并记录 closeout comment。
+- 本次不纳入：
+  - 建立 `v0.7.0` Phase / FR / Work Item 正式交付树。
+  - 改写 formal spec 正文或历史 release truth。
+  - 改写 `spec_issue_sync.py` 对仓内 `docs/specs/**/spec.md` 的 canonical contract 来源判断。
+
+## 当前停点
+
+- `#260` 已收口，`v0.6.0` runtime baseline residual 已从主干清理。
+- 当前 GitHub open issues 中仍有多个 `spec_issue_sync.py` 自动维护的 spec mirror issue；它们不是调度入口。
+- `#262` 已建立为本治理清理 Work Item，绑定 `GOV-0262-spec-mirror-issue-cleanup`。
+
+## 下一步动作
+
+- 完成脚本与测试变更。
+- 创建 PR，完成本地门禁、review、guardian 与合并。
+- 合并后关闭现存 open spec mirror issues，并关闭 `#262`。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 作为进入 `v0.7.0` 交付漏斗前的 GitHub 调度真相 hygiene，确保 open issue 列表只保留真实待处理事项。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`v0.7.0 / 2026-S20` 启动前治理清理。
+- 阻塞：若 spec mirror issue 继续保持 open，后续 `v0.7.0` Phase / FR / Work Item 识别会受到噪音干扰。
+
+## 已验证项
+
+- `python3.11 -m unittest tests.governance.test_spec_issue_sync tests.governance.test_cli_smoke.CliSmokeTests.test_help_commands_exit_zero`
+  - 结果：通过，`Ran 4 tests`，`OK`。
+- `python3.11 -m py_compile scripts/spec_issue_sync.py`
+  - 结果：通过。
+- `python3.11 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- `python3.11 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-262-gov-spec-mirror-open-issue`
+  - 结果：通过。
+- `existing_issue_number("FR-0009-cli-task-query-and-core-path", "MC-and-his-Agents/Syvert")`
+  - 结果：通过，返回已存在 mirror issue `#155`，证明脚本能复用 closed mirror 而不是重复创建。
+
+## 未决风险
+
+- `spec_issue_sync.py` 仍需能找到已关闭的 mirror issue，避免下次同步重复创建。
+- 当前治理清理不能把 spec mirror issue 误描述为 canonical FR 或 Work Item；formal spec truth 仍只在仓内 `docs/specs/**/spec.md`。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销 `scripts/spec_issue_sync.py`、`tests/governance/test_spec_issue_sync.py`、`docs/decisions/ADR-GOV-0262-spec-mirror-issue-cleanup.md` 与本 exec-plan 的变更。
+- 若需要恢复 mirror issue open 状态，必须另建治理事项说明其调度语义，不能隐式重新进入 open issue 列表。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `44fad265e5bc51f47d16b828b3472856d4d7aa85`
+- worktree 创建基线：`7640550afce821d637c7c7edfa0d79f68e21462b`
+- 说明：`44fad265e5bc51f47d16b828b3472856d4d7aa85` 包含本轮 `spec_issue_sync.py` 行为变更、治理测试、ADR 与 exec-plan 首次完整版本；后续若仅修正 review 指出的 exec-plan 元数据，不改写脚本和测试语义 checkpoint。

--- a/scripts/spec_issue_sync.py
+++ b/scripts/spec_issue_sync.py
@@ -43,23 +43,38 @@ def existing_issue_number(directory_name: str, repo: str) -> str:
     completed = run(
         [
             "gh",
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "all",
-            "--search",
-            f"\"[{directory_name}]\" in:title",
-            "--json",
-            "number,title",
+            "api",
+            "--method",
+            "GET",
+            "search/issues",
+            "-f",
+            f'q=repo:{repo} "[{directory_name}]" in:title type:issue',
+            "-f",
+            "per_page=100",
         ]
     )
-    issues = json.loads(completed.stdout or "[]")
+    issues = json.loads(completed.stdout or "{}").get("items", [])
     for issue in issues:
         if issue["title"].startswith(f"[{directory_name}] "):
             return str(issue["number"])
     return ""
+
+
+def close_spec_mirror_issue(issue_number: str, repo: str) -> None:
+    run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{repo}/issues/{issue_number}",
+            "-f",
+            "state=closed",
+            "-f",
+            "state_reason=not_planned",
+        ],
+        cwd=REPO_ROOT,
+    )
 
 
 def upsert_issue(file_path: str, repo: str) -> None:
@@ -77,14 +92,45 @@ def upsert_issue(file_path: str, repo: str) -> None:
             f"- 最近同步时间: `{updated_at}`",
             "",
             "正式契约以仓库内 `spec.md` 为准，Issue 只保留索引信息，不镜像正文。",
+            "该索引 issue 同步后必须保持 closed，避免污染 GitHub open issue 调度真相。",
         ]
     )
 
     existing = existing_issue_number(directory_name, repo)
     if existing:
-        run(["gh", "issue", "edit", existing, "--repo", repo, "--title", issue_title, "--body", body], cwd=REPO_ROOT)
+        run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "PATCH",
+                f"repos/{repo}/issues/{existing}",
+                "-f",
+                f"title={issue_title}",
+                "-f",
+                f"body={body}",
+            ],
+            cwd=REPO_ROOT,
+        )
+        close_spec_mirror_issue(existing, repo)
     else:
-        run(["gh", "issue", "create", "--repo", repo, "--title", issue_title, "--body", body], cwd=REPO_ROOT)
+        completed = run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{repo}/issues",
+                "-f",
+                f"title={issue_title}",
+                "-f",
+                f"body={body}",
+                "--jq",
+                ".number",
+            ],
+            cwd=REPO_ROOT,
+        )
+        close_spec_mirror_issue(completed.stdout.strip(), repo)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/governance/test_spec_issue_sync.py
+++ b/tests/governance/test_spec_issue_sync.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from unittest import mock
+
+from scripts import spec_issue_sync
+
+
+def completed(stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=stdout, stderr="")
+
+
+class SpecIssueSyncTests(unittest.TestCase):
+    def test_existing_issue_number_finds_closed_mirror_by_title(self) -> None:
+        with mock.patch.object(
+            spec_issue_sync,
+            "run",
+            return_value=completed(
+                json.dumps(
+                    {
+                        "items": [
+                            {
+                                "number": 155,
+                                "state": "closed",
+                                "title": "[FR-0009-cli-task-query-and-core-path] FR-0009 CLI task query and core path",
+                            }
+                        ]
+                    }
+                )
+            ),
+        ) as run:
+            issue_number = spec_issue_sync.existing_issue_number("FR-0009-cli-task-query-and-core-path", "owner/repo")
+
+        self.assertEqual(issue_number, "155")
+        self.assertEqual(run.call_args.args[0][0:4], ["gh", "api", "--method", "GET"])
+        self.assertIn("search/issues", run.call_args.args[0])
+        self.assertIn('q=repo:owner/repo "[FR-0009-cli-task-query-and-core-path]" in:title type:issue', run.call_args.args[0])
+        self.assertNotIn("state:open", " ".join(run.call_args.args[0]))
+
+    def test_upsert_existing_spec_mirror_updates_and_closes_issue(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(command)
+            if command[:4] == ["gh", "api", "--method", "GET"]:
+                return completed(json.dumps({"items": [{"number": 155, "title": "[FR-0009-cli-task-query-and-core-path] old"}]}))
+            return completed()
+
+        with mock.patch.object(spec_issue_sync, "run", side_effect=fake_run):
+            spec_issue_sync.upsert_issue("docs/specs/FR-0009-cli-task-query-and-core-path/spec.md", "owner/repo")
+
+        self.assertTrue(any(command[:4] == ["gh", "api", "--method", "GET"] for command in calls))
+        self.assertFalse(any(command[:4] == ["gh", "api", "--method", "POST"] for command in calls))
+        self.assertTrue(
+            any(
+                command[:5] == ["gh", "api", "--method", "PATCH", "repos/owner/repo/issues/155"]
+                and any(item.startswith("title=[FR-0009-cli-task-query-and-core-path] ") for item in command)
+                and any(item.startswith("body=") for item in command)
+                for command in calls
+            )
+        )
+        self.assertTrue(
+            any(
+                command[:5] == ["gh", "api", "--method", "PATCH", "repos/owner/repo/issues/155"]
+                and "state=closed" in command
+                and "state_reason=not_planned" in command
+                for command in calls
+            )
+        )
+
+    def test_upsert_new_spec_mirror_creates_and_closes_issue(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(command)
+            if command[:4] == ["gh", "api", "--method", "GET"]:
+                return completed(json.dumps({"items": []}))
+            if command[:4] == ["gh", "api", "--method", "POST"]:
+                return completed("987\n")
+            return completed()
+
+        with mock.patch.object(spec_issue_sync, "run", side_effect=fake_run):
+            spec_issue_sync.upsert_issue("docs/specs/FR-0019-v0-6-operability-release-gate/spec.md", "owner/repo")
+
+        self.assertTrue(
+            any(
+                command[:5] == ["gh", "api", "--method", "POST", "repos/owner/repo/issues"]
+                and any(item.startswith("title=[FR-0019-v0-6-operability-release-gate] ") for item in command)
+                and any(item.startswith("body=") for item in command)
+                and "--jq" in command
+                and ".number" in command
+                for command in calls
+            )
+        )
+        self.assertTrue(
+            any(
+                command[:5] == ["gh", "api", "--method", "PATCH", "repos/owner/repo/issues/987"]
+                and "state=closed" in command
+                and "state_reason=not_planned" in command
+                for command in calls
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- PR Class: `governance`
- 变更目的：清理 `spec_issue_sync.py` 自动维护的 spec mirror issue 对 GitHub open issue 调度真相的污染，为 `v0.7.0` 交付漏斗启动前恢复干净的 open issue 视图。
- 主要改动：`spec_issue_sync.py` 改为通过 REST 查找 all-state mirror issue、创建或更新后立即关闭 mirror；新增 ADR/exec-plan 记录治理决策；新增 governance 单测覆盖 closed mirror 复用、新建后关闭、更新后关闭。

## Issue 摘要

## Scope

- 修改 `spec_issue_sync.py`，使 spec mirror issue 在同步后保持 closed，不进入 open issue 调度列表。
- 为该行为补充单元测试，避免后续回归。
- 关闭当前已存在的 open spec mirror issues，并写明 canonical scheduling truth 仍以真实 Phase / FR / Work Item 与仓内 spec 为准。

## 关联事项

- Issue: #262
- item_key: `GOV-0262-spec-mirror-issue-cleanup`
- item_type: `GOV`
- release: `v0.7.0`
- sprint: `2026-S20`
- Closing: Fixes #262

## Review Artifacts

- Active exec-plan: `docs/exec-plans/GOV-0262-spec-mirror-issue-cleanup.md`
- Governing spec / bootstrap contract: `docs/decisions/ADR-GOV-0262-spec-mirror-issue-cleanup.md`
- Review artifact: `code_review.md`
- Validation evidence: `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-262-gov-spec-mirror-open-issue`

## 风险

- 风险级别：`normal`
- 审查关注：closed mirror issue 必须能被后续同步复用，不能重复创建；spec mirror issue 只能是索引镜像，不能被误标为 Phase / FR / Work Item 调度入口。

## 验证

- 已执行：
  - `python3.11 -m unittest tests.governance.test_spec_issue_sync tests.governance.test_cli_smoke.CliSmokeTests.test_help_commands_exit_zero` -> OK, Ran 4 tests
  - `python3.11 -m py_compile scripts/spec_issue_sync.py` -> 通过
  - `python3.11 scripts/docs_guard.py --mode ci` -> 通过
  - `python3.11 scripts/workflow_guard.py --mode ci` -> 通过
  - `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-262-gov-spec-mirror-open-issue` -> 通过
  - `existing_issue_number("FR-0009-cli-task-query-and-core-path", "MC-and-his-Agents/Syvert")` -> 返回 `155`
- 未执行：无

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：使用独立 revert PR 撤销 `scripts/spec_issue_sync.py`、`tests/governance/test_spec_issue_sync.py`、`docs/decisions/ADR-GOV-0262-spec-mirror-issue-cleanup.md` 与 `docs/exec-plans/GOV-0262-spec-mirror-issue-cleanup.md` 的增量。若需要恢复 mirror issue open 状态，必须另建治理事项说明其调度语义。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.
