### PR TITLE
feat(runtime): 实现 FR-0027 多 profile matcher

### DIFF
--- a/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
+++ b/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
@@ -1,0 +1,87 @@
+# CHORE-0300-fr-0027-matcher-runtime-contract 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0300-fr-0027-matcher-runtime-contract`
+- Issue：`#301`
+- item_type：`CHORE`
+- release：`v0.8.0`
+- sprint：`2026-S21`
+- 关联 spec：`docs/specs/FR-0027-multi-profile-resource-requirement-contract/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`CHORE-0300-fr-0027-matcher-runtime-contract`
+- 状态：`active`
+
+## 目标
+
+- 基于 `FR-0027` 与 `#300` 已合入的 profile evidence truth，落地 multi-profile declaration runtime consumption 与 matcher `one-of` 语义，同时保持非法声明 fail-closed、合法未命中继续映射为 `resource_unavailable`。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/resource_capability_evidence.py`
+  - `syvert/registry.py`
+  - `syvert/runtime.py`
+  - `tests/runtime/test_resource_capability_evidence.py`
+  - `tests/runtime/test_resource_capability_matcher.py`
+  - `tests/runtime/test_registry.py`
+  - `tests/runtime/test_runtime.py`
+  - `docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md`
+  - `docs/releases/v0.8.0.md`
+  - `docs/sprints/2026-S21.md`
+- 本次不纳入：
+  - reference adapter declaration migration
+  - provider compatibility / priority / fallback
+  - 新共享能力词汇
+  - `#294` parent closeout
+
+## 当前停点
+
+- `#299` formal spec 与 `#300` profile evidence truth 已合入主干。
+- 当前执行现场位于 `issue-301-fr-0027-matcher-profile-runtime-contract` worktree，基线为 `8414b0625ec0b9c4f17be135cb47d75998765056`。
+- 已新增 machine-readable `ResourceRequirementProfileEvidenceRecord` 与 `ApprovedSharedResourceRequirementProfileEvidenceEntry` carrier，并与 `FR-0015` research 表格 fail-closed 对齐。
+- 已新增 `AdapterResourceRequirementDeclarationV2` 与 `AdapterResourceRequirementProfile`，registry 可双读 V1/V2。
+- 已把 matcher 扩展为 V2 `one-of` 语义；V1 matcher 兼容路径保留。
+- runtime 对 V2 合法未命中仍映射为 `resource_unavailable`，并返回 profile-aware details。
+
+## 下一步动作
+
+- 运行完整 runtime / docs / governance 门禁。
+- 提交并创建 `#301` 受控 PR。
+- 等待 reviewer / guardian / checks 收口后执行受控合并，并关闭 `#301`。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.8.0` 的 FR-0027 reference adapter declaration migration 提供可运行、可验证的 multi-profile matcher/runtime contract。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`2026-S21` 中 `FR-0027` 的 matcher/runtime implementation Work Item。
+- 阻塞：
+  - `#302` reference adapter declaration migration 必须等待本事项提供 V2 carrier、registry validation 与 matcher runtime path。
+
+## 已验证项
+
+- `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- `python3 -m unittest tests.runtime.test_registry tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，25 tests。
+- `python3 -m unittest tests.runtime.test_resource_capability_evidence`
+  - 结果：通过，27 tests。
+- `python3 -m unittest tests.runtime.test_runtime`
+  - 结果：通过，59 tests。
+
+## 未决风险
+
+- `#302` 迁移前 reference adapters 仍使用 V1 declaration；本事项通过双读避免提前混入 adapter migration。
+- 当前 approved shared profile truth 只覆盖 `account+proxy` 与 `account-only`；`none` 的 matcher 语义已支持，但主干当前没有 approved `none` proof。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销本事项对 runtime / registry / evidence carrier / tests / exec-plan / release-sprint 索引的增量修改。
+- 若发现 declaration model 不足，必须回到 `FR-0027` formal spec 或 `FR-0015` evidence truth，不在 runtime 层私自补字段。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `<pending-checkpoint-sha>`

--- a/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
+++ b/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
@@ -9,7 +9,7 @@
 - sprint：`2026-S21`
 - 关联 spec：`docs/specs/FR-0027-multi-profile-resource-requirement-contract/`
 - 关联 decision：
-- 关联 PR：
+- 关联 PR：`#306`
 - active 收口事项：`CHORE-0300-fr-0027-matcher-runtime-contract`
 - 状态：`active`
 
@@ -83,6 +83,8 @@
   - 结果：通过。
 - `BASE=$(git merge-base origin/main HEAD); HEAD_SHA=$(git rev-parse HEAD); python3 scripts/governance_gate.py --mode ci --base-sha "$BASE" --head-sha "$HEAD_SHA" --head-ref issue-301-fr-0027-matcher-profile-runtime-contract`
   - 结果：通过。
+- `python3 scripts/open_pr.py --class implementation --issue 301 --item-key CHORE-0300-fr-0027-matcher-runtime-contract --item-type CHORE --release v0.8.0 --sprint 2026-S21 --title "feat(runtime): 实现 FR-0027 多 profile matcher" --closing fixes --integration-touchpoint none --shared-contract-changed no --integration-ref none --external-dependency none --merge-gate local_only --contract-surface none --joint-acceptance-needed no --integration-status-checked-before-pr no --integration-status-checked-before-merge no`
+  - 结果：已创建当前受审 implementation PR `#306 https://github.com/MC-and-his-Agents/Syvert/pull/306`。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
+++ b/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
@@ -84,4 +84,5 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- `<pending-checkpoint-sha>`
+- `02e1e54361878fcce34d20e3a0a50b48a27b8b58`
+- 说明：该 checkpoint 首次把 FR-0027 V2 profile evidence carrier、registry V2 declaration validation、matcher `one-of` runtime path、runtime unmatched 映射与测试同步落盘；后续若只补 PR / guardian / merge gate 元数据，则作为 review-sync follow-up，不把版本化 exec-plan 退化为 live head 状态面。

--- a/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
+++ b/docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md
@@ -71,6 +71,18 @@
   - 结果：通过，27 tests。
 - `python3 -m unittest tests.runtime.test_runtime`
   - 结果：通过，59 tests。
+- `python3 -m unittest tests.runtime.test_resource_capability_matcher tests.runtime.test_resource_capability_evidence tests.runtime.test_registry tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_runtime tests.runtime.test_task_record`
+  - 结果：通过，151 tests。
+- `python3 -m py_compile syvert/resource_capability_evidence.py syvert/registry.py syvert/runtime.py`
+  - 结果：通过。
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过。
+- `BASE=$(git merge-base origin/main HEAD); HEAD_SHA=$(git rev-parse HEAD); python3 scripts/governance_gate.py --mode ci --base-sha "$BASE" --head-sha "$HEAD_SHA" --head-ref issue-301-fr-0027-matcher-profile-runtime-contract`
+  - 结果：通过。
 
 ## 未决风险
 

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -41,5 +41,6 @@
   - `docs/exec-plans/FR-0027-multi-profile-resource-requirement-contract.md`
   - `docs/exec-plans/CHORE-0298-fr-0027-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0299-fr-0027-dual-reference-profile-evidence.md`
+  - `docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md`
 - decision：
   - `docs/decisions/ADR-CHORE-0291-open-adapter-provider-boundary.md`

--- a/docs/sprints/2026-S21.md
+++ b/docs/sprints/2026-S21.md
@@ -27,7 +27,7 @@
 ## 协作入口
 
 - GitHub Project / iteration：以 GitHub Issues / Projects 为状态真相源，本文件只提供索引入口。
-- 相关 Issue / PR：`#291`、`#294`、`#299`、`#300`
+- 相关 Issue / PR：`#291`、`#294`、`#299`、`#300`、`#301`
 
 ## 关联工件
 
@@ -41,5 +41,6 @@
   - `docs/exec-plans/FR-0027-multi-profile-resource-requirement-contract.md`
   - `docs/exec-plans/CHORE-0298-fr-0027-formal-spec-closeout.md`
   - `docs/exec-plans/CHORE-0299-fr-0027-dual-reference-profile-evidence.md`
+  - `docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md`
 - decision：
   - `docs/decisions/ADR-CHORE-0291-open-adapter-provider-boundary.md`

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -4,7 +4,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from syvert.resource_capability_evidence import approved_resource_capability_ids
+from syvert.resource_capability_evidence import (
+    ApprovedSharedResourceRequirementProfileEvidenceEntry,
+    approved_resource_capability_ids,
+    approved_shared_resource_requirement_profile_evidence_entries,
+)
 from syvert.resource_capability_evidence import frozen_dual_reference_resource_capability_evidence_records
 
 
@@ -21,6 +25,21 @@ _DECLARATION_FIELD_NAMES = frozenset(
     {
         "adapter_key",
         "capability",
+        "resource_dependency_mode",
+        "required_capabilities",
+        "evidence_refs",
+    }
+)
+_DECLARATION_V2_FIELD_NAMES = frozenset(
+    {
+        "adapter_key",
+        "capability",
+        "resource_requirement_profiles",
+    }
+)
+_PROFILE_FIELD_NAMES = frozenset(
+    {
+        "profile_key",
         "resource_dependency_mode",
         "required_capabilities",
         "evidence_refs",
@@ -45,6 +64,8 @@ _FORBIDDEN_RESOURCE_REQUIREMENT_KEYS = frozenset(
         "chromium",
         "browser_provider",
         "sign_service",
+        "preferred_profiles",
+        "provider_offer",
     }
 )
 _FROZEN_REQUIRED_CAPABILITY_IDS = ("account", "proxy")
@@ -90,13 +111,36 @@ class AdapterResourceRequirementDeclaration:
 
 
 @dataclass(frozen=True)
+class AdapterResourceRequirementProfile:
+    profile_key: str
+    resource_dependency_mode: str
+    required_capabilities: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AdapterResourceRequirementDeclarationV2:
+    adapter_key: str
+    capability: str
+    resource_requirement_profiles: tuple[AdapterResourceRequirementProfile, ...]
+
+
+AdapterResourceRequirementDeclarationCarrier = (
+    AdapterResourceRequirementDeclaration | AdapterResourceRequirementDeclarationV2
+)
+
+
+@dataclass(frozen=True)
 class AdapterDeclaration:
     adapter_key: str
     adapter: Any
     supported_capabilities: frozenset[str]
     supported_targets: frozenset[str]
     supported_collection_modes: frozenset[str]
-    resource_requirement_declarations: tuple[AdapterResourceRequirementDeclaration, ...]
+    resource_requirement_declarations: tuple[
+        AdapterResourceRequirementDeclaration | AdapterResourceRequirementDeclarationV2,
+        ...
+    ]
 
 
 class AdapterRegistry:
@@ -174,7 +218,7 @@ class AdapterRegistry:
     def discover_resource_requirements(
         self,
         adapter_key: str,
-    ) -> tuple[AdapterResourceRequirementDeclaration, ...] | None:
+    ) -> tuple[AdapterResourceRequirementDeclarationCarrier, ...] | None:
         declaration = self.lookup(adapter_key)
         if declaration is None:
             return None
@@ -184,7 +228,7 @@ class AdapterRegistry:
         self,
         adapter_key: str,
         capability: str,
-    ) -> AdapterResourceRequirementDeclaration | None:
+    ) -> AdapterResourceRequirementDeclarationCarrier | None:
         declaration = self.lookup(adapter_key)
         if declaration is None:
             return None
@@ -310,7 +354,7 @@ def _validate_resource_requirement_declarations(
     raw_declarations: Any,
     *,
     supported_capabilities: frozenset[str],
-) -> tuple[AdapterResourceRequirementDeclaration, ...]:
+) -> tuple[AdapterResourceRequirementDeclarationCarrier, ...]:
     if raw_declarations is MISSING:
         return ()
 
@@ -319,7 +363,7 @@ def _validate_resource_requirement_declarations(
         missing_code="invalid_adapter_resource_requirements",
         message="resource_requirement_declarations 必须为 AdapterResourceRequirementDeclaration 集合",
     )
-    validated: list[AdapterResourceRequirementDeclaration] = []
+    validated: list[AdapterResourceRequirementDeclarationCarrier] = []
     seen_capabilities: set[str] = set()
     for declaration in declarations:
         validated_declaration = _validate_resource_requirement_declaration(
@@ -357,7 +401,7 @@ def _validate_resource_requirement_declaration_collection(
     *,
     missing_code: str,
     message: str,
-) -> tuple[AdapterResourceRequirementDeclaration, ...]:
+) -> tuple[AdapterResourceRequirementDeclarationCarrier, ...]:
     if raw_values is None:
         raise RegistryError(
             missing_code,
@@ -379,7 +423,7 @@ def _validate_resource_requirement_declaration_collection(
             details={"actual_type": type(raw_values).__name__},
         )
 
-    validated: list[AdapterResourceRequirementDeclaration] = []
+    validated: list[AdapterResourceRequirementDeclarationCarrier] = []
     try:
         for value in iterator:
             validated.append(_normalize_resource_requirement_declaration_candidate(value))
@@ -396,8 +440,8 @@ def _validate_resource_requirement_declaration_collection(
 
 def _normalize_resource_requirement_declaration_candidate(
     raw_value: Any,
-) -> AdapterResourceRequirementDeclaration:
-    if isinstance(raw_value, AdapterResourceRequirementDeclaration):
+) -> AdapterResourceRequirementDeclarationCarrier:
+    if isinstance(raw_value, (AdapterResourceRequirementDeclaration, AdapterResourceRequirementDeclarationV2)):
         return raw_value
     if not isinstance(raw_value, Mapping):
         raise RegistryError(
@@ -422,6 +466,27 @@ def _normalize_resource_requirement_declaration_candidate(
             details={"forbidden_fields": forbidden_keys},
         )
 
+    if "resource_requirement_profiles" in raw_keys:
+        missing_fields = tuple(sorted(_DECLARATION_V2_FIELD_NAMES - raw_keys))
+        extra_fields = tuple(sorted(raw_keys - _DECLARATION_V2_FIELD_NAMES))
+        if missing_fields or extra_fields:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "AdapterResourceRequirementDeclarationV2 必须保持固定字段集合",
+                details={
+                    "missing_fields": missing_fields,
+                    "extra_fields": extra_fields,
+                },
+            )
+        return AdapterResourceRequirementDeclarationV2(
+            adapter_key=raw_value["adapter_key"],
+            capability=raw_value["capability"],
+            resource_requirement_profiles=tuple(
+                _normalize_resource_requirement_profile_candidate(profile)
+                for profile in raw_value["resource_requirement_profiles"]
+            ),
+        )
+
     missing_fields = tuple(sorted(_DECLARATION_FIELD_NAMES - raw_keys))
     extra_fields = tuple(sorted(raw_keys - _DECLARATION_FIELD_NAMES))
     if missing_fields or extra_fields:
@@ -443,11 +508,61 @@ def _normalize_resource_requirement_declaration_candidate(
     )
 
 
+def _normalize_resource_requirement_profile_candidate(raw_value: Any) -> AdapterResourceRequirementProfile:
+    if isinstance(raw_value, AdapterResourceRequirementProfile):
+        return raw_value
+    if not isinstance(raw_value, Mapping):
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "AdapterResourceRequirementProfile 只能使用 canonical profile carrier",
+            details={"invalid_value_type": type(raw_value).__name__},
+        )
+    raw_keys = {key for key in raw_value}
+    if any(not isinstance(key, str) for key in raw_keys):
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "AdapterResourceRequirementProfile 字段名必须为字符串",
+            details={"actual_keys": tuple(sorted(str(key) for key in raw_keys))},
+        )
+    forbidden_keys = tuple(sorted(raw_keys & _FORBIDDEN_RESOURCE_REQUIREMENT_KEYS))
+    if forbidden_keys:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "AdapterResourceRequirementProfile 禁止包含 fallback/priority/provider-selection 等扩张字段",
+            details={"forbidden_fields": forbidden_keys},
+        )
+    missing_fields = tuple(sorted(_PROFILE_FIELD_NAMES - raw_keys))
+    extra_fields = tuple(sorted(raw_keys - _PROFILE_FIELD_NAMES))
+    if missing_fields or extra_fields:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "AdapterResourceRequirementProfile 必须保持固定字段集合",
+            details={
+                "missing_fields": missing_fields,
+                "extra_fields": extra_fields,
+            },
+        )
+    return AdapterResourceRequirementProfile(
+        profile_key=raw_value["profile_key"],
+        resource_dependency_mode=raw_value["resource_dependency_mode"],
+        required_capabilities=tuple(raw_value["required_capabilities"]),
+        evidence_refs=tuple(raw_value["evidence_refs"]),
+    )
+
+
 def _validate_resource_requirement_declaration(
     *,
     adapter_key: str,
-    declaration: AdapterResourceRequirementDeclaration,
-) -> AdapterResourceRequirementDeclaration:
+    declaration: AdapterResourceRequirementDeclarationCarrier,
+) -> AdapterResourceRequirementDeclarationCarrier:
+    if type(declaration) is AdapterResourceRequirementDeclarationV2:
+        return _validate_resource_requirement_declaration_v2(adapter_key=adapter_key, declaration=declaration)
+    if type(declaration) is not AdapterResourceRequirementDeclaration:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "resource_requirement_declarations 只能包含 canonical declaration carrier",
+            details={"adapter_key": adapter_key, "actual_type": type(declaration).__name__},
+        )
     normalized_adapter_key = _require_non_empty_string(
         declaration.adapter_key,
         code="invalid_adapter_resource_requirements",
@@ -584,6 +699,244 @@ def _validate_resource_requirement_declaration(
         required_capabilities=required_capabilities,
         evidence_refs=evidence_refs,
     )
+
+
+def _validate_resource_requirement_declaration_v2(
+    *,
+    adapter_key: str,
+    declaration: AdapterResourceRequirementDeclarationV2,
+) -> AdapterResourceRequirementDeclarationV2:
+    normalized_adapter_key = _require_non_empty_string(
+        declaration.adapter_key,
+        code="invalid_adapter_resource_requirements",
+        message="AdapterResourceRequirementDeclarationV2.adapter_key 必须为非空字符串",
+        details={"adapter_key": adapter_key},
+    )
+    if normalized_adapter_key != adapter_key:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "AdapterResourceRequirementDeclarationV2.adapter_key 必须与 adapter_key 一致",
+            details={"adapter_key": adapter_key, "declaration_adapter_key": normalized_adapter_key},
+        )
+    capability = _require_non_empty_string(
+        declaration.capability,
+        code="invalid_adapter_resource_requirements",
+        message="AdapterResourceRequirementDeclarationV2.capability 必须为非空字符串",
+        details={"adapter_key": adapter_key},
+    )
+    if capability not in _ALLOWED_RESOURCE_REQUIREMENT_CAPABILITIES:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "AdapterResourceRequirementDeclarationV2.capability 未被共享证据批准",
+            details={"adapter_key": adapter_key, "capability": capability},
+        )
+    profiles = _validate_profile_collection(
+        declaration.resource_requirement_profiles,
+        adapter_key=adapter_key,
+        capability=capability,
+    )
+    return AdapterResourceRequirementDeclarationV2(
+        adapter_key=normalized_adapter_key,
+        capability=capability,
+        resource_requirement_profiles=profiles,
+    )
+
+
+def _validate_profile_collection(
+    raw_profiles: Any,
+    *,
+    adapter_key: str,
+    capability: str,
+) -> tuple[AdapterResourceRequirementProfile, ...]:
+    if raw_profiles is None:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "resource_requirement_profiles 必须为非空 AdapterResourceRequirementProfile 集合",
+            details={"adapter_key": adapter_key, "capability": capability, "actual_type": "NoneType"},
+        )
+    if isinstance(raw_profiles, (str, bytes)):
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "resource_requirement_profiles 必须为非空 AdapterResourceRequirementProfile 集合",
+            details={"adapter_key": adapter_key, "capability": capability, "actual_type": type(raw_profiles).__name__},
+        )
+    try:
+        iterator = iter(raw_profiles)
+    except TypeError:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "resource_requirement_profiles 必须为非空 AdapterResourceRequirementProfile 集合",
+            details={"adapter_key": adapter_key, "capability": capability, "actual_type": type(raw_profiles).__name__},
+        )
+    profiles = tuple(_normalize_resource_requirement_profile_candidate(profile) for profile in iterator)
+    if not profiles:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "resource_requirement_profiles 不得为空",
+            details={"adapter_key": adapter_key, "capability": capability},
+        )
+
+    approved_profile_entries = {
+        entry.profile_ref: entry
+        for entry in approved_shared_resource_requirement_profile_evidence_entries()
+    }
+    validated: list[AdapterResourceRequirementProfile] = []
+    seen_profile_keys: set[str] = set()
+    seen_tuples: set[tuple[str, tuple[str, ...]]] = set()
+    for profile in profiles:
+        profile_key = _require_non_empty_string(
+            profile.profile_key,
+            code="invalid_adapter_resource_requirements",
+            message="AdapterResourceRequirementProfile.profile_key 必须为非空字符串",
+            details={"adapter_key": adapter_key, "capability": capability},
+        )
+        if profile_key in seen_profile_keys:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "resource_requirement_profiles 不得重复 profile_key",
+                details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+            )
+        seen_profile_keys.add(profile_key)
+
+        resource_dependency_mode = _require_non_empty_string(
+            profile.resource_dependency_mode,
+            code="invalid_adapter_resource_requirements",
+            message="AdapterResourceRequirementProfile.resource_dependency_mode 必须为非空字符串",
+            details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+        )
+        if resource_dependency_mode not in _ALLOWED_RESOURCE_DEPENDENCY_MODES:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "AdapterResourceRequirementProfile.resource_dependency_mode 仅允许 none|required",
+                details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+            )
+        required_capabilities = _validate_unique_string_tuple(
+            profile.required_capabilities,
+            code="invalid_adapter_resource_requirements",
+            message="AdapterResourceRequirementProfile.required_capabilities 必须为去重字符串数组",
+            details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+        )
+        unknown_required_capabilities = tuple(
+            value for value in required_capabilities if value not in _APPROVED_RESOURCE_CAPABILITY_IDS
+        )
+        if unknown_required_capabilities:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "AdapterResourceRequirementProfile.required_capabilities 只能使用 FR-0015 已批准 capability ids",
+                details={
+                    "adapter_key": adapter_key,
+                    "capability": capability,
+                    "profile_key": profile_key,
+                    "unknown_required_capabilities": unknown_required_capabilities,
+                },
+            )
+        if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE and required_capabilities:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "resource_dependency_mode=none 时 profile.required_capabilities 必须为空",
+                details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+            )
+        if resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_REQUIRED and not required_capabilities:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "resource_dependency_mode=required 时 profile.required_capabilities 必须非空",
+                details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+            )
+        normalized_required_capabilities = _canonicalize_required_capabilities(required_capabilities)
+        if required_capabilities != normalized_required_capabilities:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "AdapterResourceRequirementProfile.required_capabilities 必须使用 canonical 顺序",
+                details={
+                    "adapter_key": adapter_key,
+                    "capability": capability,
+                    "profile_key": profile_key,
+                    "expected_required_capabilities": normalized_required_capabilities,
+                    "actual_required_capabilities": required_capabilities,
+                },
+            )
+        semantic_tuple = (resource_dependency_mode, normalized_required_capabilities)
+        if semantic_tuple in seen_tuples:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "resource_requirement_profiles 不得声明语义重复 profile",
+                details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+            )
+        seen_tuples.add(semantic_tuple)
+
+        evidence_refs = _validate_unique_string_tuple(
+            profile.evidence_refs,
+            code="invalid_adapter_resource_requirements",
+            message="AdapterResourceRequirementProfile.evidence_refs 必须为非空去重字符串数组",
+            details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+        )
+        if len(evidence_refs) != 1:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "AdapterResourceRequirementProfile.evidence_refs 当前必须且只能绑定一个 profile proof",
+                details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+            )
+        proof = approved_profile_entries.get(evidence_refs[0])
+        if proof is None:
+            raise RegistryError(
+                "invalid_adapter_resource_requirements",
+                "AdapterResourceRequirementProfile.evidence_refs 必须绑定到 FR-0027 approved shared profile proof",
+                details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+            )
+        _validate_profile_proof_alignment(
+            proof,
+            adapter_key=adapter_key,
+            capability=capability,
+            profile_key=profile_key,
+            resource_dependency_mode=resource_dependency_mode,
+            required_capabilities=normalized_required_capabilities,
+        )
+        validated.append(
+            AdapterResourceRequirementProfile(
+                profile_key=profile_key,
+                resource_dependency_mode=resource_dependency_mode,
+                required_capabilities=normalized_required_capabilities,
+                evidence_refs=evidence_refs,
+            )
+        )
+    return tuple(validated)
+
+
+def _validate_profile_proof_alignment(
+    proof: ApprovedSharedResourceRequirementProfileEvidenceEntry,
+    *,
+    adapter_key: str,
+    capability: str,
+    profile_key: str,
+    resource_dependency_mode: str,
+    required_capabilities: tuple[str, ...],
+) -> None:
+    if proof.capability != capability:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "profile proof capability 必须与 declaration capability 完全一致",
+            details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+        )
+    if adapter_key not in proof.reference_adapters:
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "profile proof reference_adapters 必须覆盖 declaration adapter_key",
+            details={"adapter_key": adapter_key, "capability": capability, "profile_key": profile_key},
+        )
+    if (
+        proof.resource_dependency_mode != resource_dependency_mode
+        or proof.required_capabilities != required_capabilities
+    ):
+        raise RegistryError(
+            "invalid_adapter_resource_requirements",
+            "profile proof 必须与 declaration profile tuple 完全一致",
+            details={
+                "adapter_key": adapter_key,
+                "capability": capability,
+                "profile_key": profile_key,
+                "proof_profile_ref": proof.profile_ref,
+            },
+        )
 
 
 def _validate_supported_axis(
@@ -749,6 +1102,14 @@ def _canonical_required_evidence_refs(
             if evidence_ref not in ordered_refs:
                 ordered_refs.append(evidence_ref)
     return tuple(ordered_refs)
+
+
+def _canonicalize_required_capabilities(required_capabilities: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        capability_id
+        for capability_id in _REQUIRED_CAPABILITY_ORDER
+        if capability_id in frozenset(required_capabilities)
+    )
 
 
 def _canonical_declaration_evidence_refs(

--- a/syvert/resource_capability_evidence.py
+++ b/syvert/resource_capability_evidence.py
@@ -8,12 +8,23 @@ import re
 
 _ALLOWED_ADAPTER_KEYS = frozenset({"xhs", "douyin"})
 _ALLOWED_CAPABILITY_FAMILIES = frozenset({"content_detail"})
+_ALLOWED_RESOURCE_DEPENDENCY_MODES = frozenset({"none", "required"})
 _ALLOWED_SHARED_STATUSES = frozenset({"shared", "adapter_only", "rejected"})
 _ALLOWED_DECISIONS = frozenset({"approve_for_v0_5_0", "keep_adapter_local", "reject_for_v0_5_0"})
 _ALLOWED_SHARED_STATUS_TO_DECISION = {
     "shared": "approve_for_v0_5_0",
     "adapter_only": "keep_adapter_local",
     "rejected": "reject_for_v0_5_0",
+}
+_ALLOWED_PROFILE_DECISIONS = frozenset({
+    "approve_profile_for_v0_8_0",
+    "keep_adapter_local",
+    "reject_profile_for_v0_8_0",
+})
+_ALLOWED_PROFILE_SHARED_STATUS_TO_DECISION = {
+    "shared": "approve_profile_for_v0_8_0",
+    "adapter_only": "keep_adapter_local",
+    "rejected": "reject_profile_for_v0_8_0",
 }
 _ALLOWED_APPROVAL_STATUS = frozenset({"approved"})
 _APPROVED_RESOURCE_CAPABILITY_IDS = ("account", "proxy")
@@ -63,6 +74,32 @@ class ApprovedResourceCapabilityVocabularyEntry:
 
 
 @dataclass(frozen=True)
+class ResourceRequirementProfileEvidenceRecord:
+    profile_ref: str
+    capability: str
+    execution_path: ExecutionPathDescriptor
+    resource_dependency_mode: str
+    required_capabilities: tuple[str, ...]
+    reference_adapters: tuple[str, ...]
+    shared_status: str
+    decision: str
+    evidence_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ApprovedSharedResourceRequirementProfileEvidenceEntry:
+    profile_ref: str
+    capability: str
+    execution_path: ExecutionPathDescriptor
+    resource_dependency_mode: str
+    required_capabilities: tuple[str, ...]
+    reference_adapters: tuple[str, ...]
+    shared_status: str
+    decision: str
+    evidence_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class FormalResearchEvidenceReferenceEntry:
     evidence_ref: str
     source_file: str
@@ -87,10 +124,24 @@ class FormalResearchEvidenceRecordEntry:
 
 
 @dataclass(frozen=True)
+class FormalResearchProfileEvidenceRecordEntry:
+    profile_ref: str
+    capability: str
+    execution_path: ExecutionPathDescriptor
+    resource_dependency_mode: str
+    required_capabilities: tuple[str, ...]
+    reference_adapters: tuple[str, ...]
+    shared_status: str
+    decision: str
+    evidence_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class FormalResearchBaseline:
     evidence_reference_entries: tuple[FormalResearchEvidenceReferenceEntry, ...]
     approved_capability_entries: tuple[FormalResearchApprovedCapabilityEntry, ...]
     evidence_record_entries: tuple[FormalResearchEvidenceRecordEntry, ...]
+    profile_evidence_record_entries: tuple[FormalResearchProfileEvidenceRecordEntry, ...]
 
 
 _FROZEN_EVIDENCE_REFERENCE_ENTRIES = (
@@ -619,6 +670,96 @@ _APPROVED_RESOURCE_CAPABILITY_VOCABULARY_ENTRIES = (
     ),
 )
 
+_FROZEN_RESOURCE_REQUIREMENT_PROFILE_EVIDENCE_RECORDS = (
+    ResourceRequirementProfileEvidenceRecord(
+        profile_ref="fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+        capability="content_detail",
+        execution_path=ExecutionPathDescriptor(**_FROZEN_EXECUTION_PATH),
+        resource_dependency_mode="required",
+        required_capabilities=("account", "proxy"),
+        reference_adapters=("xhs", "douyin"),
+        shared_status="shared",
+        decision="approve_profile_for_v0_8_0",
+        evidence_refs=(
+            "fr-0015:runtime:content-detail-by-url-hybrid:requested-slots",
+            "fr-0015:xhs:content-detail:url:hybrid:account-material",
+            "fr-0015:douyin:content-detail:url:hybrid:account-material",
+            "fr-0015:regression:xhs:managed-proxy-seed",
+            "fr-0015:regression:douyin:managed-proxy-seed",
+        ),
+    ),
+    ResourceRequirementProfileEvidenceRecord(
+        profile_ref="fr-0027:profile:content-detail-by-url-hybrid:account",
+        capability="content_detail",
+        execution_path=ExecutionPathDescriptor(**_FROZEN_EXECUTION_PATH),
+        resource_dependency_mode="required",
+        required_capabilities=("account",),
+        reference_adapters=("xhs", "douyin"),
+        shared_status="shared",
+        decision="approve_profile_for_v0_8_0",
+        evidence_refs=(
+            "fr-0015:xhs:content-detail:url:hybrid:account-material",
+            "fr-0015:douyin:content-detail:url:hybrid:account-material",
+        ),
+    ),
+    ResourceRequirementProfileEvidenceRecord(
+        profile_ref="fr-0027:profile:content-detail-by-url-hybrid:douyin-account-private-material",
+        capability="content_detail",
+        execution_path=ExecutionPathDescriptor(**_FROZEN_EXECUTION_PATH),
+        resource_dependency_mode="required",
+        required_capabilities=("account", "verify_fp", "ms_token", "webid"),
+        reference_adapters=("douyin",),
+        shared_status="adapter_only",
+        decision="keep_adapter_local",
+        evidence_refs=(
+            "fr-0015:douyin:content-detail:url:hybrid:account-material",
+        ),
+    ),
+    ResourceRequirementProfileEvidenceRecord(
+        profile_ref="fr-0027:profile:content-detail-by-url-hybrid:proxy",
+        capability="content_detail",
+        execution_path=ExecutionPathDescriptor(**_FROZEN_EXECUTION_PATH),
+        resource_dependency_mode="required",
+        required_capabilities=("proxy",),
+        reference_adapters=("xhs", "douyin"),
+        shared_status="rejected",
+        decision="reject_profile_for_v0_8_0",
+        evidence_refs=(
+            "fr-0015:runtime:content-detail-by-url-hybrid:requested-slots",
+            "fr-0015:regression:xhs:managed-proxy-seed",
+            "fr-0015:regression:douyin:managed-proxy-seed",
+        ),
+    ),
+    ResourceRequirementProfileEvidenceRecord(
+        profile_ref="fr-0027:profile:content-detail-by-url-hybrid:none",
+        capability="content_detail",
+        execution_path=ExecutionPathDescriptor(**_FROZEN_EXECUTION_PATH),
+        resource_dependency_mode="none",
+        required_capabilities=(),
+        reference_adapters=("xhs", "douyin"),
+        shared_status="rejected",
+        decision="reject_profile_for_v0_8_0",
+        evidence_refs=(
+            "fr-0015:xhs:content-detail:url:hybrid:account-material",
+            "fr-0015:douyin:content-detail:url:hybrid:account-material",
+        ),
+    ),
+)
+
+_EXPECTED_FROZEN_PROFILE_RECORD_BASELINE = {
+    record.profile_ref: {
+        "capability": record.capability,
+        "execution_path": record.execution_path,
+        "resource_dependency_mode": record.resource_dependency_mode,
+        "required_capabilities": record.required_capabilities,
+        "reference_adapters": record.reference_adapters,
+        "shared_status": record.shared_status,
+        "decision": record.decision,
+        "evidence_refs": record.evidence_refs,
+    }
+    for record in _FROZEN_RESOURCE_REQUIREMENT_PROFILE_EVIDENCE_RECORDS
+}
+
 
 def frozen_evidence_reference_entries() -> tuple[EvidenceReferenceEntry, ...]:
     _validate_internal_frozen_resource_capability_evidence_baseline()
@@ -641,6 +782,20 @@ def approved_resource_capability_vocabulary_entries() -> tuple[ApprovedResourceC
 def approved_resource_capability_ids() -> frozenset[str]:
     _validate_internal_frozen_resource_capability_evidence_baseline()
     return frozenset(entry.capability_id for entry in _APPROVED_RESOURCE_CAPABILITY_VOCABULARY_ENTRIES)
+
+
+def frozen_resource_requirement_profile_evidence_records() -> tuple[ResourceRequirementProfileEvidenceRecord, ...]:
+    _validate_internal_frozen_resource_capability_evidence_baseline()
+    return _FROZEN_RESOURCE_REQUIREMENT_PROFILE_EVIDENCE_RECORDS
+
+
+def approved_shared_resource_requirement_profile_evidence_entries() -> tuple[
+    ApprovedSharedResourceRequirementProfileEvidenceEntry, ...
+]:
+    _validate_internal_frozen_resource_capability_evidence_baseline()
+    return _approved_shared_resource_requirement_profile_evidence_entries(
+        _FROZEN_RESOURCE_REQUIREMENT_PROFILE_EVIDENCE_RECORDS
+    )
 
 
 
@@ -760,6 +915,8 @@ def _validate_internal_frozen_resource_capability_evidence_baseline() -> tuple[
         if shared_adapters != _ALLOWED_ADAPTER_KEYS:
             raise ValueError("approved capability ids must be backed by shared xhs and douyin evidence records")
 
+    _validate_resource_requirement_profile_evidence_records(evidence_entry_index, approved_capability_ids)
+
     return evidence_entry_index, record_index, vocabulary_index
 
 
@@ -810,6 +967,29 @@ def validate_frozen_resource_capability_evidence_contract() -> None:
         if vocabulary_entry.approval_basis_evidence_refs != formal_capability_entry.evidence_refs:
             raise ValueError("approved capability vocabulary entries must stay aligned with the formal research baseline")
 
+    profile_record_index = _validate_resource_requirement_profile_evidence_records(
+        evidence_entry_index,
+        frozenset(vocabulary_index),
+    )
+    formal_profile_record_index = {
+        entry.profile_ref: entry for entry in formal_research_baseline.profile_evidence_record_entries
+    }
+    if frozenset(profile_record_index) != frozenset(formal_profile_record_index):
+        raise ValueError("profile evidence records must stay aligned with the formal research baseline")
+    for profile_ref, formal_record in formal_profile_record_index.items():
+        record = profile_record_index[profile_ref]
+        if (
+            record.capability != formal_record.capability
+            or record.execution_path != formal_record.execution_path
+            or record.resource_dependency_mode != formal_record.resource_dependency_mode
+            or record.required_capabilities != formal_record.required_capabilities
+            or record.reference_adapters != formal_record.reference_adapters
+            or record.shared_status != formal_record.shared_status
+            or record.decision != formal_record.decision
+            or record.evidence_refs != formal_record.evidence_refs
+        ):
+            raise ValueError("profile evidence records must stay aligned with the formal research baseline")
+
 
 
 def _require_non_empty_string(value: str, *, field_name: str) -> None:
@@ -821,6 +1001,15 @@ def _require_non_empty_string(value: str, *, field_name: str) -> None:
 def _require_unique_non_empty_strings(values: tuple[str, ...], *, field_name: str) -> None:
     if not isinstance(values, tuple) or not values:
         raise ValueError(f"{field_name} must be a non-empty tuple of strings")
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} must not contain duplicates")
+    for value in values:
+        _require_non_empty_string(value, field_name=field_name)
+
+
+def _require_unique_strings(values: tuple[str, ...], *, field_name: str) -> None:
+    if not isinstance(values, tuple):
+        raise ValueError(f"{field_name} must be a tuple of strings")
     if len(set(values)) != len(values):
         raise ValueError(f"{field_name} must not contain duplicates")
     for value in values:
@@ -855,6 +1044,98 @@ def _expected_approved_vocabulary_entries(
     )
 
 
+def _validate_resource_requirement_profile_evidence_records(
+    evidence_entry_index: dict[str, EvidenceReferenceEntry],
+    approved_capability_ids: frozenset[str],
+) -> dict[str, ResourceRequirementProfileEvidenceRecord]:
+    records = _FROZEN_RESOURCE_REQUIREMENT_PROFILE_EVIDENCE_RECORDS
+    if not records:
+        raise ValueError("frozen resource requirement profile evidence records must not be empty")
+    record_index = {record.profile_ref: record for record in records}
+    if len(record_index) != len(records):
+        raise ValueError("profile evidence records must not duplicate profile_ref values")
+    if frozenset(record_index) != frozenset(_EXPECTED_FROZEN_PROFILE_RECORD_BASELINE):
+        raise ValueError("profile evidence records must keep the full canonical profile matrix")
+
+    for record in records:
+        expected_record = _EXPECTED_FROZEN_PROFILE_RECORD_BASELINE[record.profile_ref]
+        _require_non_empty_string(record.profile_ref, field_name="profile_ref")
+        if record.capability not in _ALLOWED_CAPABILITY_FAMILIES:
+            raise ValueError(f"unsupported capability family in profile evidence record: {record.capability}")
+        if record.execution_path != ExecutionPathDescriptor(**_FROZEN_EXECUTION_PATH):
+            raise ValueError("profile evidence records must all bind to the approved execution path")
+        if record.resource_dependency_mode not in _ALLOWED_RESOURCE_DEPENDENCY_MODES:
+            raise ValueError("profile evidence records must use a supported resource_dependency_mode")
+        if record.shared_status not in _ALLOWED_SHARED_STATUSES:
+            raise ValueError("profile evidence records must use a supported shared_status")
+        if record.decision not in _ALLOWED_PROFILE_DECISIONS:
+            raise ValueError("profile evidence records must use a supported profile decision")
+        if _ALLOWED_PROFILE_SHARED_STATUS_TO_DECISION[record.shared_status] != record.decision:
+            raise ValueError("profile shared_status and decision mapping must stay canonical")
+        if record.resource_dependency_mode == "none" and record.required_capabilities:
+            raise ValueError("none profile evidence records must not carry required_capabilities")
+        if record.resource_dependency_mode == "required" and not record.required_capabilities:
+            raise ValueError("required profile evidence records must carry required_capabilities")
+        _require_unique_strings(record.required_capabilities, field_name="required_capabilities")
+        _require_unique_non_empty_strings(record.reference_adapters, field_name="reference_adapters")
+        if any(adapter_key not in _ALLOWED_ADAPTER_KEYS for adapter_key in record.reference_adapters):
+            raise ValueError("profile evidence records reference unsupported adapters")
+        _require_unique_non_empty_strings(record.evidence_refs, field_name="evidence_refs")
+        if any(ref not in evidence_entry_index for ref in record.evidence_refs):
+            raise ValueError("profile evidence record references unknown evidence_ref")
+        if (
+            record.capability != expected_record["capability"]
+            or record.execution_path != expected_record["execution_path"]
+            or record.resource_dependency_mode != expected_record["resource_dependency_mode"]
+            or record.required_capabilities != expected_record["required_capabilities"]
+            or record.reference_adapters != expected_record["reference_adapters"]
+            or record.shared_status != expected_record["shared_status"]
+            or record.decision != expected_record["decision"]
+            or record.evidence_refs != expected_record["evidence_refs"]
+        ):
+            raise ValueError("profile evidence records must keep canonical tuples, evidence refs, and outcomes")
+        if record.shared_status == "shared":
+            if frozenset(record.reference_adapters) != _ALLOWED_ADAPTER_KEYS:
+                raise ValueError("approved shared profile evidence records must cover xhs and douyin")
+            if not frozenset(record.required_capabilities) <= approved_capability_ids:
+                raise ValueError("approved shared profile evidence records must only use approved capability ids")
+            canonical_required_capabilities = tuple(
+                capability_id
+                for capability_id in _APPROVED_RESOURCE_CAPABILITY_IDS
+                if capability_id in record.required_capabilities
+            )
+            if canonical_required_capabilities != record.required_capabilities:
+                raise ValueError("approved shared profile evidence records must use canonical capability order")
+
+    approved_profile_entries = _approved_shared_resource_requirement_profile_evidence_entries(records)
+    if {entry.profile_ref for entry in approved_profile_entries} != {
+        "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+        "fr-0027:profile:content-detail-by-url-hybrid:account",
+    }:
+        raise ValueError("approved shared profile entries must stay frozen to account+proxy and account")
+    return record_index
+
+
+def _approved_shared_resource_requirement_profile_evidence_entries(
+    records: tuple[ResourceRequirementProfileEvidenceRecord, ...],
+) -> tuple[ApprovedSharedResourceRequirementProfileEvidenceEntry, ...]:
+    return tuple(
+        ApprovedSharedResourceRequirementProfileEvidenceEntry(
+            profile_ref=record.profile_ref,
+            capability=record.capability,
+            execution_path=record.execution_path,
+            resource_dependency_mode=record.resource_dependency_mode,
+            required_capabilities=record.required_capabilities,
+            reference_adapters=record.reference_adapters,
+            shared_status=record.shared_status,
+            decision=record.decision,
+            evidence_refs=record.evidence_refs,
+        )
+        for record in records
+        if record.shared_status == "shared"
+    )
+
+
 def _load_formal_research_baseline() -> FormalResearchBaseline:
     if not _FORMAL_RESEARCH_PATH.is_file():
         raise ValueError("formal research registry must resolve to a real file")
@@ -866,12 +1147,15 @@ def _load_formal_research_baseline() -> FormalResearchBaseline:
     evidence_reference_entries = tuple(_parse_formal_research_evidence_reference_entries(research_text))
     approved_capability_entries = tuple(_parse_formal_research_approved_capability_entries(research_text))
     evidence_record_entries = tuple(_parse_formal_research_evidence_record_entries(research_text))
+    profile_evidence_record_entries = tuple(_parse_formal_research_profile_evidence_record_entries(research_text))
     if not evidence_reference_entries:
         raise ValueError("formal research registry must enumerate evidence reference entries")
     if not approved_capability_entries:
         raise ValueError("formal research registry must enumerate approved capabilities")
     if not evidence_record_entries:
         raise ValueError("formal research registry must enumerate evidence records")
+    if not profile_evidence_record_entries:
+        raise ValueError("formal research registry must enumerate profile evidence records")
     _require_unique_formal_research_rows(
         evidence_reference_entries,
         key_fn=lambda entry: entry.evidence_ref,
@@ -887,10 +1171,16 @@ def _load_formal_research_baseline() -> FormalResearchBaseline:
         key_fn=lambda entry: (entry.adapter_key, entry.candidate_abstract_capability),
         error_message="formal research evidence record table must not duplicate adapter/candidate rows",
     )
+    _require_unique_formal_research_rows(
+        profile_evidence_record_entries,
+        key_fn=lambda entry: entry.profile_ref,
+        error_message="formal research profile evidence table must not duplicate profile_ref rows",
+    )
     return FormalResearchBaseline(
         evidence_reference_entries=evidence_reference_entries,
         approved_capability_entries=approved_capability_entries,
         evidence_record_entries=evidence_record_entries,
+        profile_evidence_record_entries=profile_evidence_record_entries,
     )
 
 
@@ -953,6 +1243,29 @@ def _parse_formal_research_evidence_record_entries(
     return entries
 
 
+def _parse_formal_research_profile_evidence_record_entries(
+    research_text: str,
+) -> list[FormalResearchProfileEvidenceRecordEntry]:
+    entries: list[FormalResearchProfileEvidenceRecordEntry] = []
+    for cells in _read_markdown_table_cells(research_text, heading="## 冻结的 `v0.8.0` profile evidence truth"):
+        if len(cells) != 9:
+            raise ValueError("formal research profile evidence rows must keep nine columns")
+        entries.append(
+            FormalResearchProfileEvidenceRecordEntry(
+                profile_ref=_unwrap_inline_code(cells[0]),
+                capability=_unwrap_inline_code(cells[1]),
+                execution_path=_parse_execution_path_descriptor(_unwrap_inline_code(cells[2])),
+                resource_dependency_mode=_unwrap_inline_code(cells[3]),
+                required_capabilities=_parse_optional_inline_code_list(cells[4]),
+                reference_adapters=_parse_inline_code_list(cells[5]),
+                shared_status=_unwrap_inline_code(cells[6]),
+                decision=_unwrap_inline_code(cells[7]),
+                evidence_refs=_parse_inline_code_list(cells[8]),
+            )
+        )
+    return entries
+
+
 def _read_markdown_table_cells(research_text: str, *, heading: str) -> list[list[str]]:
     section_match = re.search(
         rf"{re.escape(heading)}\n\n(?P<table>(?:\|.*\n)+?)(?:\n## |\Z)",
@@ -985,6 +1298,12 @@ def _parse_inline_code_list(value: str) -> tuple[str, ...]:
     if not parts:
         raise ValueError("formal research registry evidence ref lists must not be empty")
     return tuple(_unwrap_inline_code(part) for part in parts)
+
+
+def _parse_optional_inline_code_list(value: str) -> tuple[str, ...]:
+    if value == "-":
+        return ()
+    return _parse_inline_code_list(value)
 
 
 def _parse_execution_path_descriptor(value: str) -> ExecutionPathDescriptor:

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 from syvert.registry import (
     AdapterRegistry,
     AdapterResourceRequirementDeclaration,
+    AdapterResourceRequirementDeclarationV2,
+    AdapterResourceRequirementProfile,
     RegistryError,
     RESOURCE_DEPENDENCY_MODE_NONE,
     approved_resource_requirement_evidence_refs_for,
@@ -230,7 +232,7 @@ class ResourceCapabilityMatcherInput:
     task_id: str
     adapter_key: str
     capability: str
-    requirement_declaration: AdapterResourceRequirementDeclaration
+    requirement_declaration: AdapterResourceRequirementDeclaration | AdapterResourceRequirementDeclarationV2
     available_resource_capabilities: tuple[str, ...]
 
 
@@ -669,7 +671,7 @@ def execute_task_internal(
                         "adapter_key": adapter_key,
                         "capability": capability_family,
                         "match_status": match_result.match_status,
-                        "required_capabilities": list(matcher_input.requirement_declaration.required_capabilities),
+                        **_resource_requirement_unmatched_details(matcher_input.requirement_declaration),
                         "available_resource_capabilities": list(matcher_input.available_resource_capabilities),
                     },
                 ),
@@ -699,6 +701,24 @@ def execute_task_internal(
         preserve_envelope_on_record_error=preserve_envelope_on_record_error,
         task_record_store=store,
     )
+
+
+def _resource_requirement_unmatched_details(
+    declaration: AdapterResourceRequirementDeclaration | AdapterResourceRequirementDeclarationV2,
+) -> dict[str, Any]:
+    if type(declaration) is AdapterResourceRequirementDeclarationV2:
+        return {
+            "resource_requirement_profiles": [
+                {
+                    "profile_key": profile.profile_key,
+                    "resource_dependency_mode": profile.resource_dependency_mode,
+                    "required_capabilities": list(profile.required_capabilities),
+                    "evidence_refs": list(profile.evidence_refs),
+                }
+                for profile in declaration.resource_requirement_profiles
+            ]
+        }
+    return {"required_capabilities": list(declaration.required_capabilities)}
 
 
 def execute_controlled_adapter_attempts(
@@ -2453,9 +2473,11 @@ def resolve_task_id(task_id_factory: Callable[[], str] | None) -> tuple[str, dic
 
 def match_resource_capabilities(input_value: ResourceCapabilityMatcherInput) -> ResourceCapabilityMatchResult:
     validated_input = validate_resource_capability_matcher_input(input_value)
-    required_capabilities = frozenset(validated_input.requirement_declaration.required_capabilities)
     available_resource_capabilities = frozenset(validated_input.available_resource_capabilities)
-    if required_capabilities.issubset(available_resource_capabilities):
+    if _requirement_declaration_is_satisfied(
+        validated_input.requirement_declaration,
+        available_resource_capabilities=available_resource_capabilities,
+    ):
         match_status = MATCH_STATUS_MATCHED
     else:
         match_status = MATCH_STATUS_UNMATCHED
@@ -2465,6 +2487,33 @@ def match_resource_capabilities(input_value: ResourceCapabilityMatcherInput) -> 
         capability=validated_input.capability,
         match_status=match_status,
     )
+
+
+def _requirement_declaration_is_satisfied(
+    declaration: AdapterResourceRequirementDeclaration | AdapterResourceRequirementDeclarationV2,
+    *,
+    available_resource_capabilities: frozenset[str],
+) -> bool:
+    if type(declaration) is AdapterResourceRequirementDeclarationV2:
+        return any(
+            _requirement_profile_is_satisfied(
+                profile,
+                available_resource_capabilities=available_resource_capabilities,
+            )
+            for profile in declaration.resource_requirement_profiles
+        )
+    required_capabilities = frozenset(declaration.required_capabilities)
+    return required_capabilities.issubset(available_resource_capabilities)
+
+
+def _requirement_profile_is_satisfied(
+    profile: AdapterResourceRequirementProfile,
+    *,
+    available_resource_capabilities: frozenset[str],
+) -> bool:
+    if profile.resource_dependency_mode == RESOURCE_DEPENDENCY_MODE_NONE:
+        return True
+    return frozenset(profile.required_capabilities).issubset(available_resource_capabilities)
 
 
 def validate_resource_capability_matcher_input(
@@ -3019,10 +3068,10 @@ def _validate_matcher_requirement_declaration(
     expected_adapter_key: str,
     expected_capability: str,
     task_id: str,
-) -> AdapterResourceRequirementDeclaration:
-    if type(raw_value) is not AdapterResourceRequirementDeclaration:
+) -> AdapterResourceRequirementDeclaration | AdapterResourceRequirementDeclarationV2:
+    if type(raw_value) not in {AdapterResourceRequirementDeclaration, AdapterResourceRequirementDeclarationV2}:
         raise ResourceCapabilityMatcherContractError(
-            "matcher requirement_declaration 必须是 AdapterResourceRequirementDeclaration",
+            "matcher requirement_declaration 必须是 canonical AdapterResourceRequirementDeclaration carrier",
             details={"task_id": task_id, "actual_type": type(raw_value).__name__},
         )
 
@@ -3051,6 +3100,14 @@ def _validate_matcher_requirement_declaration(
                 "expected_capability": expected_capability,
                 "actual_capability": capability,
             },
+        )
+
+    if type(raw_value) is AdapterResourceRequirementDeclarationV2:
+        return _validate_matcher_requirement_declaration_v2(
+            raw_value,
+            expected_adapter_key=expected_adapter_key,
+            expected_capability=expected_capability,
+            task_id=task_id,
         )
 
     resource_dependency_mode = _require_matcher_non_empty_string(
@@ -3129,6 +3186,47 @@ def _validate_matcher_requirement_declaration(
 
     validated_requirement = registry.lookup_resource_requirement(expected_adapter_key, expected_capability)
     if validated_requirement is None:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration 必须与当前 adapter/capability 上下文对齐",
+            details={
+                "task_id": task_id,
+                "adapter_key": expected_adapter_key,
+                "capability": expected_capability,
+            },
+        )
+    return validated_requirement
+
+
+def _validate_matcher_requirement_declaration_v2(
+    raw_value: AdapterResourceRequirementDeclarationV2,
+    *,
+    expected_adapter_key: str,
+    expected_capability: str,
+    task_id: str,
+) -> AdapterResourceRequirementDeclarationV2:
+    try:
+        registry = AdapterRegistry.from_mapping(
+            {
+                expected_adapter_key: _MatcherRequirementValidationAdapter(
+                    supported_capability=expected_capability,
+                    requirement_declaration=raw_value,
+                )
+            }
+        )
+    except RegistryError as error:
+        raise ResourceCapabilityMatcherContractError(
+            "matcher requirement_declaration 必须满足 FR-0027 canonical contract",
+            details={
+                "task_id": task_id,
+                "adapter_key": expected_adapter_key,
+                "capability": expected_capability,
+                "registry_error_code": error.code,
+                **error.details,
+            },
+        ) from error
+
+    validated_requirement = registry.lookup_resource_requirement(expected_adapter_key, expected_capability)
+    if type(validated_requirement) is not AdapterResourceRequirementDeclarationV2:
         raise ResourceCapabilityMatcherContractError(
             "matcher requirement_declaration 必须与当前 adapter/capability 上下文对齐",
             details={

--- a/tests/runtime/test_registry.py
+++ b/tests/runtime/test_registry.py
@@ -4,7 +4,13 @@ from collections.abc import Mapping
 import unittest
 from typing import Iterator, Tuple
 
-from syvert.registry import AdapterRegistry, RegistryError, baseline_required_resource_requirement_declaration
+from syvert.registry import (
+    AdapterRegistry,
+    AdapterResourceRequirementDeclarationV2,
+    AdapterResourceRequirementProfile,
+    RegistryError,
+    baseline_required_resource_requirement_declaration,
+)
 
 
 class SuccessfulAdapter:
@@ -68,6 +74,35 @@ class DeclarativeAdapter:
         baseline_required_resource_requirement_declaration(
             adapter_key="xhs",
             capability="content_detail",
+        ),
+    )
+
+    def execute(self) -> None:
+        raise AssertionError("registry tests must not execute adapters")
+
+
+class MultiProfileDeclarativeAdapter:
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = (
+        AdapterResourceRequirementDeclarationV2(
+            adapter_key="xhs",
+            capability="content_detail",
+            resource_requirement_profiles=(
+                AdapterResourceRequirementProfile(
+                    profile_key="account_proxy",
+                    resource_dependency_mode="required",
+                    required_capabilities=("account", "proxy"),
+                    evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account-proxy",),
+                ),
+                AdapterResourceRequirementProfile(
+                    profile_key="account",
+                    resource_dependency_mode="required",
+                    required_capabilities=("account",),
+                    evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account",),
+                ),
+            ),
         ),
     )
 
@@ -182,6 +217,47 @@ class RegistryTests(unittest.TestCase):
             registry.discover_resource_requirements("xhs"),
             (declaration,),
         )
+
+    def test_registry_materializes_v2_resource_requirement_declaration(self) -> None:
+        registry = AdapterRegistry.from_mapping({"xhs": MultiProfileDeclarativeAdapter()})
+
+        declaration = registry.lookup_resource_requirement("xhs", "content_detail")
+
+        self.assertIsInstance(declaration, AdapterResourceRequirementDeclarationV2)
+        assert isinstance(declaration, AdapterResourceRequirementDeclarationV2)
+        self.assertEqual(declaration.adapter_key, "xhs")
+        self.assertEqual(
+            [profile.profile_key for profile in declaration.resource_requirement_profiles],
+            ["account_proxy", "account"],
+        )
+
+    def test_registry_rejects_v2_profile_proof_that_does_not_cover_adapter(self) -> None:
+        class ExternalAdapter:
+            supported_capabilities = frozenset({"content_detail"})
+            supported_targets = frozenset({"url"})
+            supported_collection_modes = frozenset({"hybrid"})
+            resource_requirement_declarations = (
+                {
+                    "adapter_key": "external",
+                    "capability": "content_detail",
+                    "resource_requirement_profiles": (
+                        {
+                            "profile_key": "account",
+                            "resource_dependency_mode": "required",
+                            "required_capabilities": ("account",),
+                            "evidence_refs": ("fr-0027:profile:content-detail-by-url-hybrid:account",),
+                        },
+                    ),
+                },
+            )
+
+            def execute(self) -> None:
+                raise AssertionError("registry tests must not execute adapters")
+
+        with self.assertRaises(RegistryError) as context:
+            AdapterRegistry.from_mapping({"external": ExternalAdapter()})
+
+        self.assertEqual(context.exception.code, "invalid_adapter_resource_requirements")
 
     def test_registry_materializes_real_reference_adapters_without_provider_fields(self) -> None:
         from syvert.adapters.douyin import DouyinAdapter

--- a/tests/runtime/test_resource_capability_evidence.py
+++ b/tests/runtime/test_resource_capability_evidence.py
@@ -14,8 +14,10 @@ from syvert.real_adapter_regression import seed_reference_regression_resources
 from syvert import resource_capability_evidence
 from syvert.registry import AdapterRegistry, baseline_required_resource_requirement_declaration
 from syvert.resource_capability_evidence import (
+    approved_shared_resource_requirement_profile_evidence_entries,
     approved_resource_capability_ids,
     approved_resource_capability_vocabulary_entries,
+    frozen_resource_requirement_profile_evidence_records,
     frozen_dual_reference_resource_capability_evidence_records,
     frozen_evidence_reference_entries,
     validate_frozen_resource_capability_evidence_contract,
@@ -153,6 +155,64 @@ class ResourceCapabilityEvidenceTests(ResourceStoreEnvMixin, unittest.TestCase):
                     "fr-0015:runtime:content-detail-by-url-hybrid:requested-slots",
                     "fr-0015:regression:xhs:managed-proxy-seed",
                     "fr-0015:regression:douyin:managed-proxy-seed",
+                ),
+            },
+        )
+        self.assertEqual(
+            {entry.profile_ref for entry in approved_shared_resource_requirement_profile_evidence_entries()},
+            {
+                "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+                "fr-0027:profile:content-detail-by-url-hybrid:account",
+            },
+        )
+
+    def test_profile_evidence_records_freeze_shared_adapter_only_and_rejected_truth(self) -> None:
+        self.assertEqual(
+            {
+                record.profile_ref: (
+                    record.resource_dependency_mode,
+                    record.required_capabilities,
+                    record.reference_adapters,
+                    record.shared_status,
+                    record.decision,
+                )
+                for record in frozen_resource_requirement_profile_evidence_records()
+            },
+            {
+                "fr-0027:profile:content-detail-by-url-hybrid:account-proxy": (
+                    "required",
+                    ("account", "proxy"),
+                    ("xhs", "douyin"),
+                    "shared",
+                    "approve_profile_for_v0_8_0",
+                ),
+                "fr-0027:profile:content-detail-by-url-hybrid:account": (
+                    "required",
+                    ("account",),
+                    ("xhs", "douyin"),
+                    "shared",
+                    "approve_profile_for_v0_8_0",
+                ),
+                "fr-0027:profile:content-detail-by-url-hybrid:douyin-account-private-material": (
+                    "required",
+                    ("account", "verify_fp", "ms_token", "webid"),
+                    ("douyin",),
+                    "adapter_only",
+                    "keep_adapter_local",
+                ),
+                "fr-0027:profile:content-detail-by-url-hybrid:proxy": (
+                    "required",
+                    ("proxy",),
+                    ("xhs", "douyin"),
+                    "rejected",
+                    "reject_profile_for_v0_8_0",
+                ),
+                "fr-0027:profile:content-detail-by-url-hybrid:none": (
+                    "none",
+                    (),
+                    ("xhs", "douyin"),
+                    "rejected",
+                    "reject_profile_for_v0_8_0",
                 ),
             },
         )

--- a/tests/runtime/test_resource_capability_matcher.py
+++ b/tests/runtime/test_resource_capability_matcher.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import unittest
+from unittest import mock
 
+from syvert import registry
 from syvert.registry import (
     AdapterResourceRequirementDeclaration,
+    AdapterResourceRequirementDeclarationV2,
+    AdapterResourceRequirementProfile,
     baseline_required_resource_requirement_declaration,
+)
+from syvert.resource_capability_evidence import (
+    ApprovedSharedResourceRequirementProfileEvidenceEntry,
+    ExecutionPathDescriptor,
 )
 from syvert.runtime import (
     MATCH_STATUS_MATCHED,
@@ -16,6 +24,27 @@ from syvert.runtime import (
 
 
 class ResourceCapabilityMatcherTests(unittest.TestCase):
+    @staticmethod
+    def _multi_profile_declaration(adapter_key: str = "xhs") -> AdapterResourceRequirementDeclarationV2:
+        return AdapterResourceRequirementDeclarationV2(
+            adapter_key=adapter_key,
+            capability="content_detail",
+            resource_requirement_profiles=(
+                AdapterResourceRequirementProfile(
+                    profile_key="account_proxy",
+                    resource_dependency_mode="required",
+                    required_capabilities=("account", "proxy"),
+                    evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account-proxy",),
+                ),
+                AdapterResourceRequirementProfile(
+                    profile_key="account",
+                    resource_dependency_mode="required",
+                    required_capabilities=("account",),
+                    evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account",),
+                ),
+            ),
+        )
+
     def test_matcher_returns_matched_when_available_capabilities_cover_required_capabilities(self) -> None:
         result = match_resource_capabilities(
             ResourceCapabilityMatcherInput(
@@ -51,6 +80,133 @@ class ResourceCapabilityMatcherTests(unittest.TestCase):
         )
 
         self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
+
+    def test_matcher_returns_matched_when_any_v2_profile_is_satisfied(self) -> None:
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-match-v2-one-of",
+                adapter_key="xhs",
+                capability="content_detail",
+                requirement_declaration=self._multi_profile_declaration(),
+                available_resource_capabilities=("account",),
+            )
+        )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
+
+    def test_matcher_returns_unmatched_when_no_v2_profile_is_satisfied(self) -> None:
+        result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id="task-match-v2-unmatched",
+                adapter_key="xhs",
+                capability="content_detail",
+                requirement_declaration=self._multi_profile_declaration(),
+                available_resource_capabilities=("proxy",),
+            )
+        )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_UNMATCHED)
+
+    def test_matcher_rejects_v2_profile_without_approved_profile_proof(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-v2-unapproved-proof",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=AdapterResourceRequirementDeclarationV2(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_requirement_profiles=(
+                            AdapterResourceRequirementProfile(
+                                profile_key="proxy",
+                                resource_dependency_mode="required",
+                                required_capabilities=("proxy",),
+                                evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:proxy",),
+                            ),
+                        ),
+                    ),
+                    available_resource_capabilities=("proxy",),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+    def test_matcher_rejects_v2_semantically_duplicate_profiles(self) -> None:
+        with self.assertRaises(ResourceCapabilityMatcherContractError) as context:
+            match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-v2-duplicate-profile",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=AdapterResourceRequirementDeclarationV2(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_requirement_profiles=(
+                            AdapterResourceRequirementProfile(
+                                profile_key="account-a",
+                                resource_dependency_mode="required",
+                                required_capabilities=("account",),
+                                evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account",),
+                            ),
+                            AdapterResourceRequirementProfile(
+                                profile_key="account-b",
+                                resource_dependency_mode="required",
+                                required_capabilities=("account",),
+                                evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account",),
+                            ),
+                        ),
+                    ),
+                    available_resource_capabilities=("account",),
+                )
+            )
+
+        self.assertEqual(context.exception.code, "invalid_resource_requirement")
+
+    def test_matcher_keeps_none_profile_semantics_when_profile_has_approved_proof(self) -> None:
+        approved_none_profile = ApprovedSharedResourceRequirementProfileEvidenceEntry(
+            profile_ref="test:profile:none",
+            capability="content_detail",
+            execution_path=ExecutionPathDescriptor(
+                operation="content_detail_by_url",
+                target_type="url",
+                collection_mode="hybrid",
+            ),
+            resource_dependency_mode="none",
+            required_capabilities=(),
+            reference_adapters=("xhs", "douyin"),
+            shared_status="shared",
+            decision="approve_profile_for_v0_8_0",
+            evidence_refs=("test:evidence:none",),
+        )
+
+        with mock.patch.object(
+            registry,
+            "approved_shared_resource_requirement_profile_evidence_entries",
+            return_value=(approved_none_profile,),
+        ):
+            result = match_resource_capabilities(
+                ResourceCapabilityMatcherInput(
+                    task_id="task-match-v2-none-profile",
+                    adapter_key="xhs",
+                    capability="content_detail",
+                    requirement_declaration=AdapterResourceRequirementDeclarationV2(
+                        adapter_key="xhs",
+                        capability="content_detail",
+                        resource_requirement_profiles=(
+                            AdapterResourceRequirementProfile(
+                                profile_key="none",
+                                resource_dependency_mode="none",
+                                required_capabilities=(),
+                                evidence_refs=("test:profile:none",),
+                            ),
+                        ),
+                    ),
+                    available_resource_capabilities=(),
+                )
+            )
+
+        self.assertEqual(result.match_status, MATCH_STATUS_MATCHED)
 
     def test_matcher_keeps_none_mode_semantics_in_pure_matcher_layer(self) -> None:
         approved_evidence_refs = baseline_required_resource_requirement_declaration(

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -12,7 +12,11 @@ from unittest import mock
 import syvert.runtime as runtime_module
 from syvert.adapters.douyin import DouyinAdapter
 from syvert.adapters.xhs import XhsAdapter
-from syvert.registry import baseline_required_resource_requirement_declaration
+from syvert.registry import (
+    AdapterResourceRequirementDeclarationV2,
+    AdapterResourceRequirementProfile,
+    baseline_required_resource_requirement_declaration,
+)
 from syvert.resource_lifecycle import ResourceRecord
 from syvert.resource_lifecycle_store import LocalResourceLifecycleStore
 from syvert.resource_lifecycle_store import default_resource_lifecycle_store
@@ -468,6 +472,36 @@ class NoneModeResourceRequirementDeclarationAdapter:
                 capability="content_detail",
             ).evidence_refs,
         },
+    )
+
+    def execute(self, request: TaskRequest):
+        raise AssertionError("execute should not be called")
+
+
+class MultiProfileResourceRequirementAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_detail"})
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+    resource_requirement_declarations = (
+        AdapterResourceRequirementDeclarationV2(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="content_detail",
+            resource_requirement_profiles=(
+                AdapterResourceRequirementProfile(
+                    profile_key="account_proxy",
+                    resource_dependency_mode="required",
+                    required_capabilities=("account", "proxy"),
+                    evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account-proxy",),
+                ),
+                AdapterResourceRequirementProfile(
+                    profile_key="account",
+                    resource_dependency_mode="required",
+                    required_capabilities=("account",),
+                    evidence_refs=("fr-0027:profile:content-detail-by-url-hybrid:account",),
+                ),
+            ),
+        ),
     )
 
     def execute(self, request: TaskRequest):
@@ -1123,6 +1157,33 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             outcome.task_record.result.envelope["runtime_failure_signal"]["task_record_ref"],
             "task_record:task-unmatched-runtime-capabilities",
         )
+
+    def test_execute_task_maps_v2_unmatched_profiles_to_resource_unavailable(self) -> None:
+        with mock.patch.dict(
+            runtime_module.RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE,
+            {(runtime_module.CONTENT_DETAIL_BY_URL, runtime_module.LEGACY_COLLECTION_MODE): ("proxy",)},
+            clear=True,
+        ), mock.patch(
+            "syvert.runtime.acquire_runtime_resource_bundle",
+            side_effect=AssertionError("acquire should not run when matcher is unmatched"),
+        ):
+            outcome = execute_task_with_record(
+                TaskRequest(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="content_detail_by_url",
+                    input=TaskInput(url="https://example.com/posts/unmatched-v2-runtime-capabilities"),
+                ),
+                adapters={TEST_ADAPTER_KEY: MultiProfileResourceRequirementAdapter()},
+                task_id_factory=lambda: "task-unmatched-v2-runtime-capabilities",
+            )
+
+        self.assertEqual(outcome.envelope["status"], "failed")
+        self.assertEqual(outcome.envelope["error"]["category"], "runtime_contract")
+        self.assertEqual(outcome.envelope["error"]["code"], "resource_unavailable")
+        self.assertIn("resource_requirement_profiles", outcome.envelope["error"]["details"])
+        self.assertNotIn("required_capabilities", outcome.envelope["error"]["details"])
+        self.assertIsNotNone(outcome.task_record)
+        self.assertEqual(outcome.task_record.result.envelope["error"]["code"], "resource_unavailable")
 
     def test_execute_task_rejects_unsupported_capability(self) -> None:
         request = TaskRequest(


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：
- 主要改动：

## Issue 摘要

## Goal

交付目标：按新 formal spec 落地 `one-of` matcher 与多 profile runtime contract，使同一 capability 可对多个合法资源依赖 profile 做 fail-closed 判断。

验证方式：补充 matcher / runtime tests，验证 `matched` / `unmatched` / `invalid_resource_requirement` 与 `resource_unavailable` 的口径边界保持一致。

回滚方式：通过独立 revert PR 撤销 runtime 增量，恢复旧 matcher 逻辑，并回到 `#294` 重新评估 contract。

## Scope

- 实现多 profile requirement carrier 的 runtime consumption。
- 更新 matcher 逻辑与相关测试，验证 `one-of matched` 语义。
- 保持 `invalid_resource_requirement` 与 `resource_unavailable` 的错误边界不漂移。
- 不引入 profile 优先级、排序、自动 fallback、provider selector 或 provider offer 语义。

## Out of Scope

- 不迁移 reference adapter 声明本体；该部分由后续 Work Item 承接。
- 不新增共享能力词汇。
- 不引入 provider capability offer / compatibility decision runtime。
- 不关闭 `#294`。

## 关联事项

- Issue: #301
- item_key: `CHORE-0300-fr-0027-matcher-runtime-contract`
- item_type: `CHORE`
- release: `v0.8.0`
- sprint: `2026-S21`
- Closing: Fixes #301

## Review Artifacts

- Active exec-plan: `docs/exec-plans/CHORE-0300-fr-0027-matcher-runtime-contract.md`
- Governing spec / bootstrap contract: `docs/specs/FR-0027-multi-profile-resource-requirement-contract`
- Review artifact: `code_review.md`
- Validation evidence: `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-301-fr-0027-matcher-profile-runtime-contract`
## 风险

- 风险级别：`normal`
- 审查关注：

## 验证

- 已执行：
- 未执行：

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.
