### PR TITLE
实现 FR-0024 Adapter requirement manifest 与 validator

### DIFF
--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -41,12 +41,11 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：PR `#329` 第二次 guardian review 返回 `REQUEST_CHANGES`，已继续收紧 string[] 类型、observability 泄漏、requirement evidence truth 与错误码口径，并通过目标测试与全 runtime discover；下一步补齐 PR carrier、提交、重跑门禁并复审。
+- 当前 checkpoint：PR `#329` 第二次 guardian review 返回 `REQUEST_CHANGES`，已继续收紧 string[] 类型、observability 泄漏、requirement evidence truth 与错误码口径，补齐 PR carrier，并通过目标测试、全 runtime discover 与门禁；下一步推送并复审。
 
 ## 下一步动作
 
-- 补齐 PR carrier 的审查输入。
-- 提交第二轮 guardian 修复，重跑门禁并推送 PR `#329` 新 head，重新运行 guardian。
+- 推送 PR `#329` 新 head，重新运行 guardian。
 - guardian 与 checks 通过后受控合并。
 - 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
 
@@ -187,10 +186,30 @@
   - 结果：通过，15 tests。
 - 第二轮 guardian 修复后 `python3 -m unittest discover tests/runtime`
   - 结果：通过，863 tests。
+- `gh pr edit 329 --body-file -`
+  - 结果：通过；补齐 PR carrier 的变更目的、主要改动、审查关注与已执行验证。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：通过，17 tests。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，10 tests。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 -m unittest tests.runtime.test_registry`
+  - 结果：通过，15 tests。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 scripts/governance_gate.py --mode ci ...`
+  - 结果：通过。
+- 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
 
 ## 待验证项
 
-- PR carrier update、第二轮 guardian 修复提交后的 governance gates、PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
+- PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
 
 ## 未决风险
 
@@ -210,3 +229,4 @@
 - validation follow-up checkpoint：`295f560bb1b21975b30701080b7aa4eb1a2c7774`
 - guardian fix checkpoint：`01c0bf982bfcfb45af4aa4d603e51c719556af7f`
 - main-sync checkpoint：`509d6e903b20e9ddd576f9023eda5b1059ce8f69`
+- second guardian fix checkpoint：`8acf2a70451f69fe23080fa3474944015d4dc8af`

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -41,12 +41,11 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：已新增独立 validator、fixture 与测试，并通过目标测试、指定 FR-0027 / registry 回归、全 runtime discover 与基础文档/流程门禁；下一步提交后运行基于 HEAD diff 的 governance / PR scope 门禁。
+- 当前 checkpoint：已新增独立 validator、fixture 与测试，并通过目标测试、指定 FR-0027 / registry 回归、全 runtime discover、基础文档/流程门禁、governance gate 与 implementation PR scope gate；下一步使用受控脚本开 PR。
 
 ## 下一步动作
 
-- 提交当前实现 checkpoint，并运行基于 HEAD diff 的 governance / PR scope 门禁。
-- 提交中文 Conventional Commit，使用受控脚本开 PR、等待 guardian、checks 通过后受控合并。
+- 使用受控脚本开 PR、等待 guardian、checks 通过后受控合并。
 - 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -91,11 +90,19 @@
   - 结果：通过。
 - 提交 `17c8f3d` 后重跑 `python3 scripts/docs_guard.py --mode ci`
   - 结果：首次未通过；原因是 exec-plan 的禁止范围表述引用了尚不存在的 `FR-0025` spec 路径。处理：改为非路径文本表述 `Provider capability offer formal spec 或实现`，避免把未来路径伪装为当前仓内真相。
+- `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：提交态重跑通过。
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：提交态重跑通过。
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：提交态重跑通过。
+- `BASE=$(git merge-base origin/main HEAD); HEAD_SHA=$(git rev-parse HEAD); python3 scripts/governance_gate.py --mode ci --base-sha "$BASE" --head-sha "$HEAD_SHA" --head-ref issue-314-fr-0024-adapter-requirement-manifest-validator`
+  - 结果：通过。
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
 
 ## 待验证项
 
-- `python3 scripts/governance_gate.py --mode ci --base-sha <base> --head-sha <head> --head-ref issue-314-fr-0024-adapter-requirement-manifest-validator`
-- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
 - guardian review、GitHub checks、受控 merge、closeout reconciliation。
 
 ## 未决风险
@@ -112,3 +119,5 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - 初始 implementation checkpoint：`589ea1e73ebce464ac16d292c180e08cee302ce5`
+- implementation checkpoint：`17c8f3d`
+- validation follow-up checkpoint：`295f560bb1b21975b30701080b7aa4eb1a2c7774`

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -41,7 +41,7 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：PR `#329` 首次 guardian review 返回 `REQUEST_CHANGES`，已修复两个阻断项并补充复现测试；修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 的目标测试与门禁已通过，下一步推送并重新运行 guardian。
+- 当前 checkpoint：PR `#329` 首次 guardian review 返回 `REQUEST_CHANGES`，已修复两个阻断项并补充复现测试；随后同步 `origin/main` 最新主干 `5cc4a6c4b12bfb74e852472705e8c3fb5d98ed93` 并重跑目标测试与门禁通过，下一步推送并重新运行 guardian。
 
 ## 下一步动作
 
@@ -143,6 +143,26 @@
   - 结果：通过。
 - guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
+- `git fetch origin main && git rebase origin/main`
+  - 结果：通过；同步主干到 `5cc4a6c4b12bfb74e852472705e8c3fb5d98ed93`，本分支提交已重放到该基线。
+- rebase 后 `python3 -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：通过，15 tests。
+- rebase 后 `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，10 tests。
+- rebase 后 `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- rebase 后 `python3 -m unittest tests.runtime.test_registry`
+  - 结果：通过，15 tests。
+- rebase 后 `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过。
+- rebase 后 `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- rebase 后 `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- rebase 后 `python3 scripts/governance_gate.py --mode ci ...`
+  - 结果：通过。
+- rebase 后 `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
 
 ## 待验证项
 
@@ -165,3 +185,4 @@
 - implementation checkpoint：`17c8f3d`
 - validation follow-up checkpoint：`295f560bb1b21975b30701080b7aa4eb1a2c7774`
 - guardian fix checkpoint：`01c0bf982bfcfb45af4aa4d603e51c719556af7f`
+- main-sync checkpoint：`509d6e903b20e9ddd576f9023eda5b1059ce8f69`

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -17,7 +17,7 @@
 
 - 基于已合入的 `FR-0024` formal spec，实现 `AdapterCapabilityRequirement` canonical carrier validator 与 manifest fixture 测试入口。
 - validator 必须消费 `FR-0027` 的 `AdapterResourceRequirementDeclarationV2` / approved shared profile proof truth，不复制 resource profile matcher 逻辑。
-- validator 输出稳定区分合法 requirement declared、合法但当前前提未满足的 unmatched、非法 carrier 的 `invalid_contract` / `invalid_resource_requirement`。
+- validator 输出稳定区分合法 requirement declared、合法但当前前提未满足的 unmatched；非法 carrier 统一映射为 `runtime_contract + invalid_resource_requirement`。
 
 ## 范围
 
@@ -41,11 +41,11 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：PR `#329` 第三次 guardian review 返回 `REQUEST_CHANGES`，阻断集中在核心对齐约束和 execution slice 的测试证据不足；已补充对应负向测试并通过目标测试与全 runtime discover，下一步提交、重跑门禁并复审。
+- 当前 checkpoint：PR `#329` 第四次 guardian review 返回 `REQUEST_CHANGES`，阻断集中在 requirement-level evidence ref 校验过度收紧和 exec-plan 状态漂移；已调整 evidence ref 校验为 FR-0024 证据类别边界，同步收敛本执行计划，并通过目标测试、全 runtime discover 与治理门禁。
 
 ## 下一步动作
 
-- 提交测试补充，重跑门禁并推送 PR `#329` 新 head，重新运行 guardian。
+- 提交第四轮 guardian 修复，重跑门禁并推送 PR `#329` 新 head，重新运行 guardian。
 - guardian 与 checks 通过后受控合并。
 - 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
 
@@ -225,10 +225,32 @@
   - 结果：通过，15 tests。
 - 第三轮 guardian 测试补充后 `python3 -m unittest discover tests/runtime`
   - 结果：通过，868 tests。
+- `python3 scripts/pr_guardian.py review 329 --post-review`
+  - 结果：第四次返回 `REQUEST_CHANGES`，`safe_to_merge=false`。阻断项：
+    - `capability_requirement_evidence_refs` 被实现收紧为固定字面量集合，和 FR-0024 只约束证据类别的合同边界漂移。
+    - exec-plan 仍保留旧的 `invalid_contract / invalid_resource_requirement` 双口径与过时推进状态。
+- 已处理第四轮 guardian 阻断：
+  - requirement-level evidence refs 改为允许 `FR-0024` formal spec / manifest fixture validator / reference adapter migration / parent closeout 四类证据 ref，避免实现维护固定 evidence truth。
+  - 补充允许未来同类 manifest fixture evidence ref 的回归，并保留 provider offer 类 ref 的 fail-closed 回归。
+  - 收敛 exec-plan 的非法 carrier 口径与当前 checkpoint / 下一步状态。
+- 第四轮 guardian 修复后 `python3 -m unittest tests.runtime.test_adapter_capability_requirement tests.runtime.test_adapter_resource_requirement_declaration tests.runtime.test_resource_capability_matcher tests.runtime.test_registry`
+  - 结果：通过，65 tests。
+- 第四轮 guardian 修复后 `python3 -m unittest discover tests/runtime`
+  - 结果：通过，869 tests。
+- 第四轮 guardian 修复后 `python3 scripts/spec_guard.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过。
+- 第四轮 guardian 修复后 `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- 第四轮 guardian 修复后 `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- 第四轮 guardian 修复后 `python3 scripts/governance_gate.py --mode ci ...`
+  - 结果：通过。
+- 第四轮 guardian 修复后 `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
 
 ## 待验证项
 
-- 第三轮 guardian 测试补充提交后的 governance gates、PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
+- 第四轮 guardian 修复提交后的 tests、governance gates、PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -41,11 +41,12 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：PR `#329` 首次 guardian review 返回 `REQUEST_CHANGES`，已修复两个阻断项并补充复现测试；随后同步 `origin/main` 最新主干 `5cc4a6c4b12bfb74e852472705e8c3fb5d98ed93` 并重跑目标测试与门禁通过，下一步推送并重新运行 guardian。
+- 当前 checkpoint：PR `#329` 第二次 guardian review 返回 `REQUEST_CHANGES`，已继续收紧 string[] 类型、observability 泄漏、requirement evidence truth 与错误码口径，并通过目标测试与全 runtime discover；下一步补齐 PR carrier、提交、重跑门禁并复审。
 
 ## 下一步动作
 
-- 推送 PR `#329` 新 head，重新运行 guardian。
+- 补齐 PR carrier 的审查输入。
+- 提交第二轮 guardian 修复，重跑门禁并推送 PR `#329` 新 head，重新运行 guardian。
 - guardian 与 checks 通过后受控合并。
 - 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
 
@@ -163,10 +164,33 @@
   - 结果：通过。
 - rebase 后 `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
+- `python3 scripts/pr_guardian.py review 329 --post-review`
+  - 结果：第二次返回 `REQUEST_CHANGES`，`safe_to_merge=false`。阻断项：
+    - `string[]` 字段会错误接受 mapping。
+    - observability 泄漏检测可被 camelCase / 冒号分隔绕过。
+    - `capability_requirement_evidence_refs` 只做前缀校验，伪造 approved-looking ref 仍可通过。
+    - 错误码口径与 `FR-0024` formal truth 漂移，需统一到 `runtime_contract + invalid_resource_requirement`。
+    - PR carrier 缺少 review-critical validation context。
+- 已处理第二轮 guardian 阻断：
+  - `_normalize_string_tuple` 显式拒绝 `Mapping`。
+  - observability 禁止 token 使用 substring fail-closed，覆盖 camelCase、冒号分隔与连写词。
+  - requirement-level evidence refs 改为 exact approved ref set。
+  - `ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT` 对齐为 `invalid_resource_requirement`，避免与 formal truth 漂移。
+  - 新增 mapping string[]、伪造 evidence、camelCase / 冒号 observability 泄漏测试。
+- 第二轮 guardian 修复后 `python3 -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：通过，17 tests。
+- 第二轮 guardian 修复后 `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，10 tests。
+- 第二轮 guardian 修复后 `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- 第二轮 guardian 修复后 `python3 -m unittest tests.runtime.test_registry`
+  - 结果：通过，15 tests。
+- 第二轮 guardian 修复后 `python3 -m unittest discover tests/runtime`
+  - 结果：通过，863 tests。
 
 ## 待验证项
 
-- PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
+- PR carrier update、第二轮 guardian 修复提交后的 governance gates、PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -41,11 +41,11 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：PR `#329` 首次 guardian review 返回 `REQUEST_CHANGES`，已修复两个阻断项并补充复现测试；下一步提交修复、推送并重新运行门禁与 guardian。
+- 当前 checkpoint：PR `#329` 首次 guardian review 返回 `REQUEST_CHANGES`，已修复两个阻断项并补充复现测试；修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 的目标测试与门禁已通过，下一步推送并重新运行 guardian。
 
 ## 下一步动作
 
-- 提交 guardian 修复，推送 PR `#329` 新 head，重新运行门禁与 guardian。
+- 推送 PR `#329` 新 head，重新运行 guardian。
 - guardian 与 checks 通过后受控合并。
 - 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
 
@@ -125,10 +125,28 @@
   - 结果：通过，15 tests。
 - guardian 修复后 `python3 -m unittest discover tests/runtime`
   - 结果：通过，861 tests。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：通过，15 tests。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，10 tests。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 -m unittest tests.runtime.test_registry`
+  - 结果：通过，15 tests。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 scripts/governance_gate.py --mode ci ...`
+  - 结果：通过。
+- guardian 修复提交 `01c0bf982bfcfb45af4aa4d603e51c719556af7f` 后 `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+  - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
 
 ## 待验证项
 
-- guardian 修复提交后的 governance gates、PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
+- PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
 
 ## 未决风险
 
@@ -146,3 +164,4 @@
 - 初始 implementation checkpoint：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - implementation checkpoint：`17c8f3d`
 - validation follow-up checkpoint：`295f560bb1b21975b30701080b7aa4eb1a2c7774`
+- guardian fix checkpoint：`01c0bf982bfcfb45af4aa4d603e51c719556af7f`

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -41,11 +41,11 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：PR `#329` 第二次 guardian review 返回 `REQUEST_CHANGES`，已继续收紧 string[] 类型、observability 泄漏、requirement evidence truth 与错误码口径，补齐 PR carrier，并通过目标测试、全 runtime discover 与门禁；下一步推送并复审。
+- 当前 checkpoint：PR `#329` 第三次 guardian review 返回 `REQUEST_CHANGES`，阻断集中在核心对齐约束和 execution slice 的测试证据不足；已补充对应负向测试并通过目标测试与全 runtime discover，下一步提交、重跑门禁并复审。
 
 ## 下一步动作
 
-- 推送 PR `#329` 新 head，重新运行 guardian。
+- 提交测试补充，重跑门禁并推送 PR `#329` 新 head，重新运行 guardian。
 - guardian 与 checks 通过后受控合并。
 - 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
 
@@ -206,10 +206,29 @@
   - 结果：通过。
 - 第二轮 guardian 修复提交 `8acf2a70451f69fe23080fa3474944015d4dc8af` 后 `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
+- `python3 scripts/pr_guardian.py review 329 --post-review`
+  - 结果：第三次返回 `REQUEST_CHANGES`，`safe_to_merge=false`。实现无新增阻断，测试证据不足：
+    - 缺少 `evidence.resource_profile_evidence_refs` 与 profile proofs 对齐回归。
+    - 缺少 `observability.profile_keys`、`observability.proof_refs`、`observability.admission_outcome_fields` 对齐 / 冻结回归。
+    - 缺少 `execution_requirement.operation/target_type/collection_mode` approved slice 越界回归。
+- 已处理第三轮 guardian 阻断：
+  - 补充 resource profile evidence refs 与 profile proofs 不一致负向测试。
+  - 补充 observability profile keys、proof refs、admission outcome fields 漂移负向测试。
+  - 补充 execution requirement 三字段越界负向测试。
+- 第三轮 guardian 测试补充后 `python3 -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：通过，22 tests。
+- 第三轮 guardian 测试补充后 `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，10 tests。
+- 第三轮 guardian 测试补充后 `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- 第三轮 guardian 测试补充后 `python3 -m unittest tests.runtime.test_registry`
+  - 结果：通过，15 tests。
+- 第三轮 guardian 测试补充后 `python3 -m unittest discover tests/runtime`
+  - 结果：通过，868 tests。
 
 ## 待验证项
 
-- PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
+- 第三轮 guardian 测试补充提交后的 governance gates、PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -1,0 +1,112 @@
+# CHORE-0314-fr-0024-manifest-fixture-validator 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0314-fr-0024-manifest-fixture-validator`
+- Issue：`#314`
+- item_type：`CHORE`
+- release：`v0.8.0`
+- sprint：`2026-S21`
+- 关联 spec：`docs/specs/FR-0024-adapter-capability-requirement-contract/`
+- 关联 decision：
+- 关联 PR：
+- active 收口事项：`CHORE-0314-fr-0024-manifest-fixture-validator`
+- 状态：`active`
+
+## 目标
+
+- 基于已合入的 `FR-0024` formal spec，实现 `AdapterCapabilityRequirement` canonical carrier validator 与 manifest fixture 测试入口。
+- validator 必须消费 `FR-0027` 的 `AdapterResourceRequirementDeclarationV2` / approved shared profile proof truth，不复制 resource profile matcher 逻辑。
+- validator 输出稳定区分合法 requirement declared、合法但当前前提未满足的 unmatched、非法 carrier 的 `invalid_contract` / `invalid_resource_requirement`。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/adapter_capability_requirement.py`
+  - `tests/runtime/adapter_capability_requirement_fixtures.py`
+  - `tests/runtime/test_adapter_capability_requirement.py`
+  - `docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md`
+- 本次不纳入：
+  - `docs/specs/FR-0024-adapter-capability-requirement-contract/**`
+  - `docs/specs/FR-0025-provider-capability-offer-contract/**`
+  - `tests/runtime/contract_harness/**`
+  - `syvert/runtime.py` / `syvert/registry.py` 大范围改动
+  - Provider offer、compatibility decision、selector、priority、fallback carrier
+  - reference adapter requirement migration
+  - 关闭父 FR `#296`
+
+## 当前停点
+
+- worktree：`/Users/mc/code/worktrees/syvert/issue-314-fr-0024-adapter-requirement-manifest-validator`
+- 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
+- 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
+- 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
+- 当前 checkpoint：已新增独立 validator、fixture 与测试，并通过目标测试、指定 FR-0027 / registry 回归、全 runtime discover 与基础文档/流程门禁；下一步提交后运行基于 HEAD diff 的 governance / PR scope 门禁。
+
+## 下一步动作
+
+- 提交当前实现 checkpoint，并运行基于 HEAD diff 的 governance / PR scope 门禁。
+- 提交中文 Conventional Commit，使用受控脚本开 PR、等待 guardian、checks 通过后受控合并。
+- 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v0.8.0` 把 `FR-0024` Adapter capability requirement 从 formal carrier 推进为可执行 validator / fixture truth，供后续 reference adapter migration 与父 FR closeout 消费。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`2026-S21` 中 `FR-0024` 的 manifest fixture validator implementation Work Item。
+- 阻塞：
+  - `#315` reference adapter requirement migration 需要本 validator 作为迁移前的 manifest truth。
+  - `#316` 父 FR closeout 需要本 validator 与 migration 主干事实。
+  - 后续 Provider offer / compatibility decision 需要稳定 requirement input，不得反向改写本 carrier。
+
+## 已验证项
+
+- `python3 scripts/create_worktree.py --issue 314 --class implementation`
+  - 结果：通过；创建 worktree `/Users/mc/code/worktrees/syvert/issue-314-fr-0024-adapter-requirement-manifest-validator`，分支 `issue-314-fr-0024-adapter-requirement-manifest-validator`，基线 `589ea1e73ebce464ac16d292c180e08cee302ce5`。
+- `gh api user --jq .login`
+  - 结果：通过；确认本机 `gh` keyring 可用，未全局导出 `GH_TOKEN` / `GITHUB_TOKEN`。
+- `gh api repos/:owner/:repo/issues/314 --jq '{number,title,state,body,labels:[.labels[].name],assignees:[.assignees[].login],milestone:(.milestone.title // null)}'`
+  - 结果：通过；确认 `#314` open，item_key=`CHORE-0314-fr-0024-manifest-fixture-validator`，item_type=`CHORE`，release=`v0.8.0`，sprint=`2026-S21`，integration fields 为 `none/no/local_only`。
+- 已核对 `FR-0024` formal spec 与 data model，确认字段、禁止字段、declared / unmatched / invalid 语义。
+- 已核对 `syvert/registry.py` 与 `syvert/runtime.py` 的 `FR-0027` truth，确认 resource requirement validation 通过 `AdapterRegistry.from_mapping` 与 `match_resource_capabilities` 消费。
+- `python -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：未运行；本机没有 `python` 命令。
+- `python3 -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：通过，13 tests。
+- `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，10 tests。
+- `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- `python3 -m unittest tests.runtime.test_registry`
+  - 结果：通过，15 tests。
+- `python3 -m unittest discover tests/runtime`
+  - 结果：通过，859 tests。
+- `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过。
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+
+## 待验证项
+
+- `python3 scripts/governance_gate.py --mode ci --base-sha <base> --head-sha <head> --head-ref issue-314-fr-0024-adapter-requirement-manifest-validator`
+- `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
+- guardian review、GitHub checks、受控 merge、closeout reconciliation。
+
+## 未决风险
+
+- 若 validator 后续复制 `FR-0027` matcher 规则，会形成 resource requirement second truth。
+- 若合法 requirement 输出被解释为 Provider compatible，会提前越过 Provider offer / compatibility decision 边界。
+- 若 observability / lifecycle 接受 provider、selector、fallback 或浏览器技术字段，会污染 Adapter capability requirement canonical surface。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销本次新增 validator、fixture、测试与 exec-plan。
+- 若发现 `FR-0024` carrier 本身不足，必须回到 formal spec Work Item 更新规约，不在 implementation PR 中隐式改写。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- 初始 implementation checkpoint：`589ea1e73ebce464ac16d292c180e08cee302ce5`

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -41,11 +41,12 @@
 - 分支：`issue-314-fr-0024-adapter-requirement-manifest-validator`
 - 原始 worktree 创建基线：`589ea1e73ebce464ac16d292c180e08cee302ce5`
 - 已核对 `AGENTS.md`、`WORKFLOW.md`、`#314` GitHub truth 与 `FR-0024` formal spec。
-- 当前 checkpoint：已新增独立 validator、fixture 与测试，并通过目标测试、指定 FR-0027 / registry 回归、全 runtime discover、基础文档/流程门禁、governance gate 与 implementation PR scope gate；下一步使用受控脚本开 PR。
+- 当前 checkpoint：PR `#329` 首次 guardian review 返回 `REQUEST_CHANGES`，已修复两个阻断项并补充复现测试；下一步提交修复、推送并重新运行门禁与 guardian。
 
 ## 下一步动作
 
-- 使用受控脚本开 PR、等待 guardian、checks 通过后受控合并。
+- 提交 guardian 修复，推送 PR `#329` 新 head，重新运行门禁与 guardian。
+- guardian 与 checks 通过后受控合并。
 - 合并后确认 `#314` closeout、更新父 FR `#296` comment、清理 worktree 并退役分支。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -100,10 +101,34 @@
   - 结果：通过。
 - `python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`
   - 结果：通过，PR class=`implementation`，变更类别=`docs, implementation`。
+- `python3 scripts/open_pr.py --class implementation --issue 314 ...`
+  - 结果：首次未通过；原因是受控脚本不负责推送，本地分支尚无同名远端 head。处理：执行 `git push -u origin issue-314-fr-0024-adapter-requirement-manifest-validator` 后重试。
+- `git push -u origin issue-314-fr-0024-adapter-requirement-manifest-validator`
+  - 结果：通过，远端分支创建。
+- `python3 scripts/open_pr.py --class implementation --issue 314 ...`
+  - 结果：通过，创建 PR `#329`。
+- `python3 scripts/pr_guardian.py review 329 --post-review`
+  - 结果：`REQUEST_CHANGES`，`safe_to_merge=false`。阻断项：
+    - canonical dataclass 输入中的 raw `resource_requirement` 未归一化，可能抛出 `AttributeError` 而非稳定返回 `invalid_resource_requirement`。
+    - `capability_requirement_evidence_refs` 只校验非空/去重，任意字符串可冒充 requirement 级 evidence。
+- 已处理 guardian 阻断：
+  - `AdapterCapabilityRequirement` dataclass 输入现在会重新归一化 nested execution/evidence/lifecycle/observability 与 `resource_requirement`，非法资源声明稳定返回 `invalid_resource_requirement`。
+  - `capability_requirement_evidence_refs` 现在限制为 `FR-0024` formal spec / manifest fixture / migration / closeout evidence 前缀。
+  - 新增对应复现测试。
+- guardian 修复后 `python3 -m unittest tests.runtime.test_adapter_capability_requirement`
+  - 结果：通过，15 tests。
+- guardian 修复后 `python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`
+  - 结果：通过，10 tests。
+- guardian 修复后 `python3 -m unittest tests.runtime.test_resource_capability_matcher`
+  - 结果：通过，17 tests。
+- guardian 修复后 `python3 -m unittest tests.runtime.test_registry`
+  - 结果：通过，15 tests。
+- guardian 修复后 `python3 -m unittest discover tests/runtime`
+  - 结果：通过，861 tests。
 
 ## 待验证项
 
-- guardian review、GitHub checks、受控 merge、closeout reconciliation。
+- guardian 修复提交后的 governance gates、PR push、guardian review、GitHub checks、受控 merge、closeout reconciliation。
 
 ## 未决风险
 

--- a/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
+++ b/docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md
@@ -28,7 +28,7 @@
   - `docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md`
 - 本次不纳入：
   - `docs/specs/FR-0024-adapter-capability-requirement-contract/**`
-  - `docs/specs/FR-0025-provider-capability-offer-contract/**`
+  - Provider capability offer formal spec 或实现
   - `tests/runtime/contract_harness/**`
   - `syvert/runtime.py` / `syvert/registry.py` 大范围改动
   - Provider offer、compatibility decision、selector、priority、fallback carrier
@@ -89,6 +89,8 @@
   - 结果：通过。
 - `python3 scripts/workflow_guard.py --mode ci`
   - 结果：通过。
+- 提交 `17c8f3d` 后重跑 `python3 scripts/docs_guard.py --mode ci`
+  - 结果：首次未通过；原因是 exec-plan 的禁止范围表述引用了尚不存在的 `FR-0025` spec 路径。处理：改为非路径文本表述 `Provider capability offer formal spec 或实现`，避免把未来路径伪装为当前仓内真相。
 
 ## 待验证项
 

--- a/syvert/adapter_capability_requirement.py
+++ b/syvert/adapter_capability_requirement.py
@@ -22,8 +22,8 @@ ADAPTER_REQUIREMENT_STATUS_DECLARED = "declared"
 ADAPTER_REQUIREMENT_STATUS_UNMATCHED = "unmatched"
 ADAPTER_REQUIREMENT_STATUS_INVALID = "invalid"
 
-ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT = "invalid_contract"
 ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT = "invalid_resource_requirement"
+ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT = ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT
 
 APPROVED_ADAPTER_CAPABILITY = "content_detail"
 APPROVED_EXECUTION_REQUIREMENT = {
@@ -50,12 +50,13 @@ EVIDENCE_FIELDS = frozenset(
         "capability_requirement_evidence_refs",
     }
 )
-APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES = (
-    "fr-0024:formal-spec:",
-    "fr-0024:manifest-fixture-validator:",
-    "fr-0024:reference-adapter-migration:",
-    "fr-0024:parent-closeout:",
-    "fr-0024:closeout:",
+APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REFS = frozenset(
+    {
+        "fr-0024:formal-spec:adapter-capability-requirement-contract",
+        "fr-0024:manifest-fixture-validator:content-detail-by-url-hybrid",
+        "fr-0024:reference-adapter-migration:xhs-douyin-content-detail",
+        "fr-0024:parent-closeout:fr-0024",
+    }
 )
 LIFECYCLE_FIELDS = frozenset(
     {
@@ -689,7 +690,7 @@ def _validate_capability_requirement_evidence_refs(evidence_refs: tuple[str, ...
     unsupported_refs = tuple(
         evidence_ref
         for evidence_ref in evidence_refs
-        if not evidence_ref.startswith(APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES)
+        if evidence_ref not in APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REFS
     )
     if unsupported_refs:
         raise AdapterCapabilityRequirementContractError(
@@ -697,7 +698,9 @@ def _validate_capability_requirement_evidence_refs(evidence_refs: tuple[str, ...
             "evidence.capability_requirement_evidence_refs must point to approved FR-0024 requirement evidence",
             details={
                 "unsupported_capability_requirement_evidence_refs": unsupported_refs,
-                "allowed_prefixes": APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES,
+                "approved_capability_requirement_evidence_refs": tuple(
+                    sorted(APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REFS)
+                ),
             },
         )
 
@@ -724,7 +727,7 @@ def _reject_observability_leakage(observability: AdapterCapabilityObservabilityE
 
 def _contains_forbidden_observability_token(value: str) -> bool:
     normalized = value.lower().replace("-", "_")
-    return any(token in normalized.split("_") for token in FORBIDDEN_OBSERVABILITY_TOKENS)
+    return any(token in normalized for token in FORBIDDEN_OBSERVABILITY_TOKENS)
 
 
 def _require_exact_fields(
@@ -810,6 +813,12 @@ def _normalize_string_tuple(raw_values: Any, *, field_name: str, allow_empty: bo
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
             f"{field_name} must be a deduplicated string collection",
+            details={"actual_type": type(raw_values).__name__},
+        )
+    if isinstance(raw_values, Mapping):
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{field_name} must be a string array, not a mapping",
             details={"actual_type": type(raw_values).__name__},
         )
     try:

--- a/syvert/adapter_capability_requirement.py
+++ b/syvert/adapter_capability_requirement.py
@@ -1,0 +1,747 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from syvert.registry import (
+    AdapterRegistry,
+    AdapterResourceRequirementDeclarationV2,
+    RegistryError,
+)
+from syvert.runtime import (
+    MATCH_STATUS_MATCHED,
+    MATCH_STATUS_UNMATCHED,
+    ResourceCapabilityMatcherContractError,
+    ResourceCapabilityMatcherInput,
+    match_resource_capabilities,
+)
+
+
+ADAPTER_REQUIREMENT_STATUS_DECLARED = "declared"
+ADAPTER_REQUIREMENT_STATUS_UNMATCHED = "unmatched"
+ADAPTER_REQUIREMENT_STATUS_INVALID = "invalid"
+
+ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT = "invalid_contract"
+ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT = "invalid_resource_requirement"
+
+APPROVED_ADAPTER_CAPABILITY = "content_detail"
+APPROVED_EXECUTION_REQUIREMENT = {
+    "operation": "content_detail_by_url",
+    "target_type": "url",
+    "collection_mode": "hybrid",
+}
+REQUIRED_REQUIREMENT_FIELDS = frozenset(
+    {
+        "adapter_key",
+        "capability",
+        "execution_requirement",
+        "resource_requirement",
+        "evidence",
+        "lifecycle",
+        "observability",
+        "fail_closed",
+    }
+)
+EXECUTION_REQUIREMENT_FIELDS = frozenset(APPROVED_EXECUTION_REQUIREMENT)
+EVIDENCE_FIELDS = frozenset(
+    {
+        "resource_profile_evidence_refs",
+        "capability_requirement_evidence_refs",
+    }
+)
+LIFECYCLE_FIELDS = frozenset(
+    {
+        "requires_core_resource_bundle",
+        "resource_profiles_drive_admission",
+        "uses_existing_disposition_hint",
+    }
+)
+OBSERVABILITY_FIELDS = frozenset(
+    {
+        "requirement_id",
+        "profile_keys",
+        "proof_refs",
+        "admission_outcome_fields",
+    }
+)
+REQUIRED_ADMISSION_OUTCOME_FIELDS = (
+    "match_status",
+    "error_code",
+    "failure_category",
+)
+FORBIDDEN_REQUIREMENT_FIELDS = frozenset(
+    {
+        "provider_offer",
+        "provider_key",
+        "provider_selection",
+        "provider_selector",
+        "provider_priority",
+        "provider_routing",
+        "provider_capability_offer",
+        "compatibility_decision",
+        "compatibility_status",
+        "priority",
+        "fallback",
+        "fallback_order",
+        "fallback_outcome",
+        "preferred_profile",
+        "preferred_profiles",
+        "optional_capabilities",
+        "external_provider_ref",
+        "resource_provider",
+        "native_provider",
+    }
+)
+FORBIDDEN_OBSERVABILITY_TOKENS = frozenset(
+    {
+        "provider",
+        "selector",
+        "fallback",
+        "priority",
+        "playwright",
+        "cdp",
+        "chromium",
+        "browser",
+        "network",
+        "transport",
+    }
+)
+
+
+@dataclass(frozen=True)
+class AdapterCapabilityExecutionRequirement:
+    operation: str
+    target_type: str
+    collection_mode: str
+
+
+@dataclass(frozen=True)
+class AdapterCapabilityRequirementEvidence:
+    resource_profile_evidence_refs: tuple[str, ...]
+    capability_requirement_evidence_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AdapterCapabilityLifecycleExpectation:
+    requires_core_resource_bundle: bool
+    resource_profiles_drive_admission: bool
+    uses_existing_disposition_hint: bool
+
+
+@dataclass(frozen=True)
+class AdapterCapabilityObservabilityExpectation:
+    requirement_id: str
+    profile_keys: tuple[str, ...]
+    proof_refs: tuple[str, ...]
+    admission_outcome_fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AdapterCapabilityRequirement:
+    adapter_key: str
+    capability: str
+    execution_requirement: AdapterCapabilityExecutionRequirement
+    resource_requirement: AdapterResourceRequirementDeclarationV2
+    evidence: AdapterCapabilityRequirementEvidence
+    lifecycle: AdapterCapabilityLifecycleExpectation
+    observability: AdapterCapabilityObservabilityExpectation
+    fail_closed: bool
+
+
+@dataclass(frozen=True)
+class AdapterCapabilityRequirementValidationInput:
+    requirement: AdapterCapabilityRequirement | Mapping[str, Any]
+    available_resource_capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AdapterCapabilityRequirementValidationResult:
+    adapter_key: str | None
+    capability: str | None
+    status: str
+    failure_category: str | None = None
+    error_code: str | None = None
+    message: str | None = None
+    details: Mapping[str, Any] | None = None
+
+
+class AdapterCapabilityRequirementContractError(Exception):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = dict(details or {})
+
+
+class _RequirementValidationAdapter:
+    supported_targets = frozenset({"url"})
+    supported_collection_modes = frozenset({"hybrid"})
+
+    def __init__(
+        self,
+        *,
+        supported_capability: str,
+        resource_requirement: Any,
+    ) -> None:
+        self.supported_capabilities = frozenset({supported_capability})
+        self.resource_requirement_declarations = (resource_requirement,)
+
+    def execute(self) -> None:
+        raise AssertionError("requirement validation must not execute adapters")
+
+
+def validate_adapter_capability_requirement(
+    input_value: AdapterCapabilityRequirementValidationInput | AdapterCapabilityRequirement | Mapping[str, Any],
+) -> AdapterCapabilityRequirementValidationResult:
+    validation_input = _normalize_validation_input(input_value)
+    try:
+        requirement = _normalize_requirement(validation_input.requirement)
+        _validate_requirement_contract(requirement)
+        match_result = match_resource_capabilities(
+            ResourceCapabilityMatcherInput(
+                task_id=_requirement_id(requirement),
+                adapter_key=requirement.adapter_key,
+                capability=requirement.capability,
+                requirement_declaration=requirement.resource_requirement,
+                available_resource_capabilities=validation_input.available_resource_capabilities,
+            )
+        )
+    except AdapterCapabilityRequirementContractError as error:
+        return AdapterCapabilityRequirementValidationResult(
+            adapter_key=_best_effort_string(validation_input.requirement, "adapter_key"),
+            capability=_best_effort_string(validation_input.requirement, "capability"),
+            status=ADAPTER_REQUIREMENT_STATUS_INVALID,
+            failure_category="runtime_contract",
+            error_code=error.code,
+            message=error.message,
+            details=error.details,
+        )
+    except ResourceCapabilityMatcherContractError as error:
+        return AdapterCapabilityRequirementValidationResult(
+            adapter_key=_best_effort_string(validation_input.requirement, "adapter_key"),
+            capability=_best_effort_string(validation_input.requirement, "capability"),
+            status=ADAPTER_REQUIREMENT_STATUS_INVALID,
+            failure_category="runtime_contract",
+            error_code=ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+            message=error.message,
+            details=error.details,
+        )
+
+    if match_result.match_status == MATCH_STATUS_UNMATCHED:
+        return AdapterCapabilityRequirementValidationResult(
+            adapter_key=requirement.adapter_key,
+            capability=requirement.capability,
+            status=ADAPTER_REQUIREMENT_STATUS_UNMATCHED,
+            details={
+                "match_status": MATCH_STATUS_UNMATCHED,
+                "requirement_id": _requirement_id(requirement),
+            },
+        )
+    if match_result.match_status != MATCH_STATUS_MATCHED:
+        return AdapterCapabilityRequirementValidationResult(
+            adapter_key=requirement.adapter_key,
+            capability=requirement.capability,
+            status=ADAPTER_REQUIREMENT_STATUS_INVALID,
+            failure_category="runtime_contract",
+            error_code=ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+            message="resource matcher returned an unsupported match status",
+            details={"match_status": match_result.match_status},
+        )
+    return AdapterCapabilityRequirementValidationResult(
+        adapter_key=requirement.adapter_key,
+        capability=requirement.capability,
+        status=ADAPTER_REQUIREMENT_STATUS_DECLARED,
+        details={
+            "match_status": MATCH_STATUS_MATCHED,
+            "requirement_id": _requirement_id(requirement),
+        },
+    )
+
+
+def _normalize_validation_input(
+    input_value: AdapterCapabilityRequirementValidationInput | AdapterCapabilityRequirement | Mapping[str, Any],
+) -> AdapterCapabilityRequirementValidationInput:
+    if type(input_value) is AdapterCapabilityRequirementValidationInput:
+        available_capabilities = _normalize_string_tuple(
+            input_value.available_resource_capabilities,
+            field_name="available_resource_capabilities",
+            allow_empty=True,
+        )
+        return AdapterCapabilityRequirementValidationInput(
+            requirement=input_value.requirement,
+            available_resource_capabilities=available_capabilities,
+        )
+    return AdapterCapabilityRequirementValidationInput(requirement=input_value)
+
+
+def _normalize_requirement(raw_value: AdapterCapabilityRequirement | Mapping[str, Any]) -> AdapterCapabilityRequirement:
+    if type(raw_value) is AdapterCapabilityRequirement:
+        return raw_value
+    if not isinstance(raw_value, Mapping):
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "AdapterCapabilityRequirement carrier must be a mapping or canonical dataclass",
+            details={"actual_type": type(raw_value).__name__},
+        )
+
+    raw_keys = _require_string_keys(raw_value, carrier_name="AdapterCapabilityRequirement")
+    forbidden_fields = _find_forbidden_fields(raw_value)
+    if forbidden_fields:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "AdapterCapabilityRequirement must not contain provider, priority, fallback, or decision fields",
+            details={"forbidden_fields": forbidden_fields},
+        )
+    _require_exact_fields(
+        raw_keys,
+        required_fields=REQUIRED_REQUIREMENT_FIELDS,
+        carrier_name="AdapterCapabilityRequirement",
+    )
+
+    adapter_key = _require_non_empty_string(raw_value["adapter_key"], field_name="adapter_key")
+    capability = _require_non_empty_string(raw_value["capability"], field_name="capability")
+    execution_requirement = _normalize_execution_requirement(raw_value["execution_requirement"])
+    evidence = _normalize_evidence(raw_value["evidence"])
+    lifecycle = _normalize_lifecycle(raw_value["lifecycle"])
+    observability = _normalize_observability(raw_value["observability"])
+    fail_closed = raw_value["fail_closed"]
+    if type(fail_closed) is not bool:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "AdapterCapabilityRequirement.fail_closed must be a boolean",
+            details={"actual_type": type(fail_closed).__name__},
+        )
+    _validate_top_level_slice(
+        capability=capability,
+        execution_requirement=execution_requirement,
+        fail_closed=fail_closed,
+    )
+    resource_requirement = _normalize_resource_requirement(
+        raw_value["resource_requirement"],
+        adapter_key=adapter_key,
+        capability=capability,
+    )
+
+    return AdapterCapabilityRequirement(
+        adapter_key=adapter_key,
+        capability=capability,
+        execution_requirement=execution_requirement,
+        resource_requirement=resource_requirement,
+        evidence=evidence,
+        lifecycle=lifecycle,
+        observability=observability,
+        fail_closed=fail_closed,
+    )
+
+
+def _normalize_execution_requirement(raw_value: Any) -> AdapterCapabilityExecutionRequirement:
+    if type(raw_value) is AdapterCapabilityExecutionRequirement:
+        return raw_value
+    if not isinstance(raw_value, Mapping):
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "execution_requirement must be a mapping or canonical dataclass",
+            details={"actual_type": type(raw_value).__name__},
+        )
+    raw_keys = _require_string_keys(raw_value, carrier_name="execution_requirement")
+    _require_exact_fields(
+        raw_keys,
+        required_fields=EXECUTION_REQUIREMENT_FIELDS,
+        carrier_name="execution_requirement",
+    )
+    return AdapterCapabilityExecutionRequirement(
+        operation=_require_non_empty_string(raw_value["operation"], field_name="execution_requirement.operation"),
+        target_type=_require_non_empty_string(raw_value["target_type"], field_name="execution_requirement.target_type"),
+        collection_mode=_require_non_empty_string(
+            raw_value["collection_mode"],
+            field_name="execution_requirement.collection_mode",
+        ),
+    )
+
+
+def _normalize_resource_requirement(
+    raw_value: Any,
+    *,
+    adapter_key: str,
+    capability: str,
+) -> AdapterResourceRequirementDeclarationV2:
+    try:
+        registry = AdapterRegistry.from_mapping(
+            {
+                adapter_key: _RequirementValidationAdapter(
+                    supported_capability=capability,
+                    resource_requirement=raw_value,
+                )
+            }
+        )
+    except RegistryError as error:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+            "resource_requirement must satisfy FR-0027 AdapterResourceRequirementDeclarationV2",
+            details={"registry_error_code": error.code, **error.details},
+        ) from error
+    resource_requirement = registry.lookup_resource_requirement(adapter_key, capability)
+    if type(resource_requirement) is not AdapterResourceRequirementDeclarationV2:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+            "resource_requirement must use AdapterResourceRequirementDeclarationV2",
+            details={"actual_type": type(resource_requirement).__name__},
+        )
+    return resource_requirement
+
+
+def _normalize_evidence(raw_value: Any) -> AdapterCapabilityRequirementEvidence:
+    if type(raw_value) is AdapterCapabilityRequirementEvidence:
+        return raw_value
+    if not isinstance(raw_value, Mapping):
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "evidence must be a mapping or canonical dataclass",
+            details={"actual_type": type(raw_value).__name__},
+        )
+    raw_keys = _require_string_keys(raw_value, carrier_name="evidence")
+    _require_exact_fields(raw_keys, required_fields=EVIDENCE_FIELDS, carrier_name="evidence")
+    return AdapterCapabilityRequirementEvidence(
+        resource_profile_evidence_refs=_normalize_string_tuple(
+            raw_value["resource_profile_evidence_refs"],
+            field_name="evidence.resource_profile_evidence_refs",
+            allow_empty=False,
+        ),
+        capability_requirement_evidence_refs=_normalize_string_tuple(
+            raw_value["capability_requirement_evidence_refs"],
+            field_name="evidence.capability_requirement_evidence_refs",
+            allow_empty=False,
+        ),
+    )
+
+
+def _normalize_lifecycle(raw_value: Any) -> AdapterCapabilityLifecycleExpectation:
+    if type(raw_value) is AdapterCapabilityLifecycleExpectation:
+        return raw_value
+    if not isinstance(raw_value, Mapping):
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "lifecycle must be a mapping or canonical dataclass",
+            details={"actual_type": type(raw_value).__name__},
+        )
+    raw_keys = _require_string_keys(raw_value, carrier_name="lifecycle")
+    _require_exact_fields(raw_keys, required_fields=LIFECYCLE_FIELDS, carrier_name="lifecycle")
+    return AdapterCapabilityLifecycleExpectation(
+        requires_core_resource_bundle=_require_bool(
+            raw_value["requires_core_resource_bundle"],
+            field_name="lifecycle.requires_core_resource_bundle",
+        ),
+        resource_profiles_drive_admission=_require_bool(
+            raw_value["resource_profiles_drive_admission"],
+            field_name="lifecycle.resource_profiles_drive_admission",
+        ),
+        uses_existing_disposition_hint=_require_bool(
+            raw_value["uses_existing_disposition_hint"],
+            field_name="lifecycle.uses_existing_disposition_hint",
+        ),
+    )
+
+
+def _normalize_observability(raw_value: Any) -> AdapterCapabilityObservabilityExpectation:
+    if type(raw_value) is AdapterCapabilityObservabilityExpectation:
+        return raw_value
+    if not isinstance(raw_value, Mapping):
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "observability must be a mapping or canonical dataclass",
+            details={"actual_type": type(raw_value).__name__},
+        )
+    raw_keys = _require_string_keys(raw_value, carrier_name="observability")
+    _require_exact_fields(raw_keys, required_fields=OBSERVABILITY_FIELDS, carrier_name="observability")
+    return AdapterCapabilityObservabilityExpectation(
+        requirement_id=_require_non_empty_string(
+            raw_value["requirement_id"],
+            field_name="observability.requirement_id",
+        ),
+        profile_keys=_normalize_string_tuple(
+            raw_value["profile_keys"],
+            field_name="observability.profile_keys",
+            allow_empty=False,
+        ),
+        proof_refs=_normalize_string_tuple(
+            raw_value["proof_refs"],
+            field_name="observability.proof_refs",
+            allow_empty=False,
+        ),
+        admission_outcome_fields=_normalize_string_tuple(
+            raw_value["admission_outcome_fields"],
+            field_name="observability.admission_outcome_fields",
+            allow_empty=False,
+        ),
+    )
+
+
+def _validate_requirement_contract(requirement: AdapterCapabilityRequirement) -> None:
+    _validate_top_level_slice(
+        capability=requirement.capability,
+        execution_requirement=requirement.execution_requirement,
+        fail_closed=requirement.fail_closed,
+    )
+    if requirement.resource_requirement.adapter_key != requirement.adapter_key:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+            "resource_requirement.adapter_key must match AdapterCapabilityRequirement.adapter_key",
+            details={
+                "adapter_key": requirement.adapter_key,
+                "resource_requirement_adapter_key": requirement.resource_requirement.adapter_key,
+            },
+        )
+    if requirement.resource_requirement.capability != requirement.capability:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+            "resource_requirement.capability must match AdapterCapabilityRequirement.capability",
+            details={
+                "capability": requirement.capability,
+                "resource_requirement_capability": requirement.resource_requirement.capability,
+            },
+        )
+
+    resource_profile_evidence_refs = tuple(
+        evidence_ref
+        for profile in requirement.resource_requirement.resource_requirement_profiles
+        for evidence_ref in profile.evidence_refs
+    )
+    if requirement.evidence.resource_profile_evidence_refs != resource_profile_evidence_refs:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+            "evidence.resource_profile_evidence_refs must align with resource_requirement profile proofs",
+            details={
+                "expected_resource_profile_evidence_refs": resource_profile_evidence_refs,
+                "actual_resource_profile_evidence_refs": requirement.evidence.resource_profile_evidence_refs,
+            },
+        )
+    if not requirement.lifecycle.resource_profiles_drive_admission:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "lifecycle.resource_profiles_drive_admission must be true",
+        )
+
+    profile_keys = tuple(
+        profile.profile_key
+        for profile in requirement.resource_requirement.resource_requirement_profiles
+    )
+    if requirement.observability.profile_keys != profile_keys:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "observability.profile_keys must align with resource_requirement profile keys",
+            details={
+                "expected_profile_keys": profile_keys,
+                "actual_profile_keys": requirement.observability.profile_keys,
+            },
+        )
+    if requirement.observability.proof_refs != requirement.evidence.resource_profile_evidence_refs:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "observability.proof_refs must align with evidence.resource_profile_evidence_refs",
+            details={
+                "expected_proof_refs": requirement.evidence.resource_profile_evidence_refs,
+                "actual_proof_refs": requirement.observability.proof_refs,
+            },
+        )
+    if requirement.observability.admission_outcome_fields != REQUIRED_ADMISSION_OUTCOME_FIELDS:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "observability.admission_outcome_fields must stay frozen to approved public outcome fields",
+            details={
+                "expected_admission_outcome_fields": REQUIRED_ADMISSION_OUTCOME_FIELDS,
+                "actual_admission_outcome_fields": requirement.observability.admission_outcome_fields,
+            },
+        )
+    _reject_observability_leakage(requirement.observability)
+
+
+def _validate_top_level_slice(
+    *,
+    capability: str,
+    execution_requirement: AdapterCapabilityExecutionRequirement,
+    fail_closed: bool,
+) -> None:
+    if capability != APPROVED_ADAPTER_CAPABILITY:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "AdapterCapabilityRequirement.capability is outside the approved FR-0024 slice",
+            details={"capability": capability},
+        )
+    if execution_requirement.__dict__ != APPROVED_EXECUTION_REQUIREMENT:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "execution_requirement must stay frozen to content_detail_by_url + url + hybrid",
+            details={
+                "expected_execution_requirement": APPROVED_EXECUTION_REQUIREMENT,
+                "actual_execution_requirement": dict(execution_requirement.__dict__),
+            },
+        )
+    if not fail_closed:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "AdapterCapabilityRequirement.fail_closed must be true",
+            details={"fail_closed": fail_closed},
+        )
+
+
+def _reject_observability_leakage(observability: AdapterCapabilityObservabilityExpectation) -> None:
+    inspected_values = (
+        observability.requirement_id,
+        *observability.profile_keys,
+        *observability.proof_refs,
+        *observability.admission_outcome_fields,
+    )
+    leaked_values = tuple(
+        value
+        for value in inspected_values
+        if _contains_forbidden_observability_token(value)
+    )
+    if leaked_values:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "observability must not expose provider, selector, fallback, browser, or transport fields",
+            details={"leaked_values": leaked_values},
+        )
+
+
+def _contains_forbidden_observability_token(value: str) -> bool:
+    normalized = value.lower().replace("-", "_")
+    return any(token in normalized.split("_") for token in FORBIDDEN_OBSERVABILITY_TOKENS)
+
+
+def _require_exact_fields(
+    actual_fields: frozenset[str],
+    *,
+    required_fields: frozenset[str],
+    carrier_name: str,
+) -> None:
+    missing_fields = tuple(sorted(required_fields - actual_fields))
+    extra_fields = tuple(sorted(actual_fields - required_fields))
+    if missing_fields or extra_fields:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{carrier_name} must keep the canonical field set",
+            details={
+                "missing_fields": missing_fields,
+                "extra_fields": extra_fields,
+            },
+        )
+
+
+def _require_string_keys(raw_value: Mapping[Any, Any], *, carrier_name: str) -> frozenset[str]:
+    raw_keys = frozenset(raw_value)
+    invalid_keys = tuple(sorted(str(key) for key in raw_keys if not isinstance(key, str)))
+    if invalid_keys:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{carrier_name} field names must be strings",
+            details={"invalid_keys": invalid_keys},
+        )
+    return frozenset(key for key in raw_keys if isinstance(key, str))
+
+
+def _find_forbidden_fields(raw_value: Any) -> tuple[str, ...]:
+    found: set[str] = set()
+
+    def visit(value: Any) -> None:
+        if isinstance(value, Mapping):
+            for key, nested_value in value.items():
+                if isinstance(key, str) and key in FORBIDDEN_REQUIREMENT_FIELDS:
+                    found.add(key)
+                visit(nested_value)
+        elif not isinstance(value, (str, bytes)):
+            try:
+                iterator = iter(value)
+            except TypeError:
+                return
+            for nested_value in iterator:
+                visit(nested_value)
+
+    visit(raw_value)
+    return tuple(sorted(found))
+
+
+def _require_non_empty_string(raw_value: Any, *, field_name: str) -> str:
+    if not isinstance(raw_value, str) or not raw_value:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{field_name} must be a non-empty string",
+            details={"field_name": field_name, "actual_type": type(raw_value).__name__},
+        )
+    return raw_value
+
+
+def _require_bool(raw_value: Any, *, field_name: str) -> bool:
+    if type(raw_value) is not bool:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{field_name} must be a boolean",
+            details={"field_name": field_name, "actual_type": type(raw_value).__name__},
+        )
+    return raw_value
+
+
+def _normalize_string_tuple(raw_values: Any, *, field_name: str, allow_empty: bool) -> tuple[str, ...]:
+    if raw_values is None:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{field_name} must be a deduplicated string collection",
+            details={"actual_type": "NoneType"},
+        )
+    if isinstance(raw_values, (str, bytes)):
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{field_name} must be a deduplicated string collection",
+            details={"actual_type": type(raw_values).__name__},
+        )
+    try:
+        iterator: Iterable[Any] = iter(raw_values)
+    except TypeError as error:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{field_name} must be a deduplicated string collection",
+            details={"actual_type": type(raw_values).__name__},
+        ) from error
+
+    values: list[str] = []
+    seen: set[str] = set()
+    for raw_value in iterator:
+        if not isinstance(raw_value, str) or not raw_value:
+            raise AdapterCapabilityRequirementContractError(
+                ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+                f"{field_name} values must be non-empty strings",
+                details={"invalid_value": raw_value},
+            )
+        if raw_value in seen:
+            raise AdapterCapabilityRequirementContractError(
+                ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+                f"{field_name} must not contain duplicate values",
+                details={"duplicate_value": raw_value},
+            )
+        seen.add(raw_value)
+        values.append(raw_value)
+    if not allow_empty and not values:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            f"{field_name} must not be empty",
+        )
+    return tuple(values)
+
+
+def _requirement_id(requirement: AdapterCapabilityRequirement) -> str:
+    return requirement.observability.requirement_id
+
+
+def _best_effort_string(raw_value: Any, field_name: str) -> str | None:
+    if isinstance(raw_value, Mapping):
+        value = raw_value.get(field_name)
+        return value if isinstance(value, str) else None
+    value = getattr(raw_value, field_name, None)
+    return value if isinstance(value, str) else None

--- a/syvert/adapter_capability_requirement.py
+++ b/syvert/adapter_capability_requirement.py
@@ -50,6 +50,13 @@ EVIDENCE_FIELDS = frozenset(
         "capability_requirement_evidence_refs",
     }
 )
+APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES = (
+    "fr-0024:formal-spec:",
+    "fr-0024:manifest-fixture-validator:",
+    "fr-0024:reference-adapter-migration:",
+    "fr-0024:parent-closeout:",
+    "fr-0024:closeout:",
+)
 LIFECYCLE_FIELDS = frozenset(
     {
         "requires_core_resource_bundle",
@@ -283,7 +290,39 @@ def _normalize_validation_input(
 
 def _normalize_requirement(raw_value: AdapterCapabilityRequirement | Mapping[str, Any]) -> AdapterCapabilityRequirement:
     if type(raw_value) is AdapterCapabilityRequirement:
-        return raw_value
+        adapter_key = _require_non_empty_string(raw_value.adapter_key, field_name="adapter_key")
+        capability = _require_non_empty_string(raw_value.capability, field_name="capability")
+        execution_requirement = _normalize_execution_requirement(raw_value.execution_requirement)
+        evidence = _normalize_evidence(raw_value.evidence)
+        lifecycle = _normalize_lifecycle(raw_value.lifecycle)
+        observability = _normalize_observability(raw_value.observability)
+        fail_closed = raw_value.fail_closed
+        if type(fail_closed) is not bool:
+            raise AdapterCapabilityRequirementContractError(
+                ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+                "AdapterCapabilityRequirement.fail_closed must be a boolean",
+                details={"actual_type": type(fail_closed).__name__},
+            )
+        _validate_top_level_slice(
+            capability=capability,
+            execution_requirement=execution_requirement,
+            fail_closed=fail_closed,
+        )
+        resource_requirement = _normalize_resource_requirement(
+            raw_value.resource_requirement,
+            adapter_key=adapter_key,
+            capability=capability,
+        )
+        return AdapterCapabilityRequirement(
+            adapter_key=adapter_key,
+            capability=capability,
+            execution_requirement=execution_requirement,
+            resource_requirement=resource_requirement,
+            evidence=evidence,
+            lifecycle=lifecycle,
+            observability=observability,
+            fail_closed=fail_closed,
+        )
     if not isinstance(raw_value, Mapping):
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
@@ -343,7 +382,14 @@ def _normalize_requirement(raw_value: AdapterCapabilityRequirement | Mapping[str
 
 def _normalize_execution_requirement(raw_value: Any) -> AdapterCapabilityExecutionRequirement:
     if type(raw_value) is AdapterCapabilityExecutionRequirement:
-        return raw_value
+        return AdapterCapabilityExecutionRequirement(
+            operation=_require_non_empty_string(raw_value.operation, field_name="execution_requirement.operation"),
+            target_type=_require_non_empty_string(raw_value.target_type, field_name="execution_requirement.target_type"),
+            collection_mode=_require_non_empty_string(
+                raw_value.collection_mode,
+                field_name="execution_requirement.collection_mode",
+            ),
+        )
     if not isinstance(raw_value, Mapping):
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
@@ -399,7 +445,20 @@ def _normalize_resource_requirement(
 
 def _normalize_evidence(raw_value: Any) -> AdapterCapabilityRequirementEvidence:
     if type(raw_value) is AdapterCapabilityRequirementEvidence:
-        return raw_value
+        capability_requirement_evidence_refs = _normalize_string_tuple(
+            raw_value.capability_requirement_evidence_refs,
+            field_name="evidence.capability_requirement_evidence_refs",
+            allow_empty=False,
+        )
+        _validate_capability_requirement_evidence_refs(capability_requirement_evidence_refs)
+        return AdapterCapabilityRequirementEvidence(
+            resource_profile_evidence_refs=_normalize_string_tuple(
+                raw_value.resource_profile_evidence_refs,
+                field_name="evidence.resource_profile_evidence_refs",
+                allow_empty=False,
+            ),
+            capability_requirement_evidence_refs=capability_requirement_evidence_refs,
+        )
     if not isinstance(raw_value, Mapping):
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
@@ -408,23 +467,38 @@ def _normalize_evidence(raw_value: Any) -> AdapterCapabilityRequirementEvidence:
         )
     raw_keys = _require_string_keys(raw_value, carrier_name="evidence")
     _require_exact_fields(raw_keys, required_fields=EVIDENCE_FIELDS, carrier_name="evidence")
+    capability_requirement_evidence_refs = _normalize_string_tuple(
+        raw_value["capability_requirement_evidence_refs"],
+        field_name="evidence.capability_requirement_evidence_refs",
+        allow_empty=False,
+    )
+    _validate_capability_requirement_evidence_refs(capability_requirement_evidence_refs)
     return AdapterCapabilityRequirementEvidence(
         resource_profile_evidence_refs=_normalize_string_tuple(
             raw_value["resource_profile_evidence_refs"],
             field_name="evidence.resource_profile_evidence_refs",
             allow_empty=False,
         ),
-        capability_requirement_evidence_refs=_normalize_string_tuple(
-            raw_value["capability_requirement_evidence_refs"],
-            field_name="evidence.capability_requirement_evidence_refs",
-            allow_empty=False,
-        ),
+        capability_requirement_evidence_refs=capability_requirement_evidence_refs,
     )
 
 
 def _normalize_lifecycle(raw_value: Any) -> AdapterCapabilityLifecycleExpectation:
     if type(raw_value) is AdapterCapabilityLifecycleExpectation:
-        return raw_value
+        return AdapterCapabilityLifecycleExpectation(
+            requires_core_resource_bundle=_require_bool(
+                raw_value.requires_core_resource_bundle,
+                field_name="lifecycle.requires_core_resource_bundle",
+            ),
+            resource_profiles_drive_admission=_require_bool(
+                raw_value.resource_profiles_drive_admission,
+                field_name="lifecycle.resource_profiles_drive_admission",
+            ),
+            uses_existing_disposition_hint=_require_bool(
+                raw_value.uses_existing_disposition_hint,
+                field_name="lifecycle.uses_existing_disposition_hint",
+            ),
+        )
     if not isinstance(raw_value, Mapping):
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
@@ -451,7 +525,27 @@ def _normalize_lifecycle(raw_value: Any) -> AdapterCapabilityLifecycleExpectatio
 
 def _normalize_observability(raw_value: Any) -> AdapterCapabilityObservabilityExpectation:
     if type(raw_value) is AdapterCapabilityObservabilityExpectation:
-        return raw_value
+        return AdapterCapabilityObservabilityExpectation(
+            requirement_id=_require_non_empty_string(
+                raw_value.requirement_id,
+                field_name="observability.requirement_id",
+            ),
+            profile_keys=_normalize_string_tuple(
+                raw_value.profile_keys,
+                field_name="observability.profile_keys",
+                allow_empty=False,
+            ),
+            proof_refs=_normalize_string_tuple(
+                raw_value.proof_refs,
+                field_name="observability.proof_refs",
+                allow_empty=False,
+            ),
+            admission_outcome_fields=_normalize_string_tuple(
+                raw_value.admission_outcome_fields,
+                field_name="observability.admission_outcome_fields",
+                allow_empty=False,
+            ),
+        )
     if not isinstance(raw_value, Mapping):
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
@@ -588,6 +682,23 @@ def _validate_top_level_slice(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
             "AdapterCapabilityRequirement.fail_closed must be true",
             details={"fail_closed": fail_closed},
+        )
+
+
+def _validate_capability_requirement_evidence_refs(evidence_refs: tuple[str, ...]) -> None:
+    unsupported_refs = tuple(
+        evidence_ref
+        for evidence_ref in evidence_refs
+        if not evidence_ref.startswith(APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES)
+    )
+    if unsupported_refs:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "evidence.capability_requirement_evidence_refs must point to approved FR-0024 requirement evidence",
+            details={
+                "unsupported_capability_requirement_evidence_refs": unsupported_refs,
+                "allowed_prefixes": APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES,
+            },
         )
 
 

--- a/syvert/adapter_capability_requirement.py
+++ b/syvert/adapter_capability_requirement.py
@@ -50,13 +50,11 @@ EVIDENCE_FIELDS = frozenset(
         "capability_requirement_evidence_refs",
     }
 )
-APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REFS = frozenset(
-    {
-        "fr-0024:formal-spec:adapter-capability-requirement-contract",
-        "fr-0024:manifest-fixture-validator:content-detail-by-url-hybrid",
-        "fr-0024:reference-adapter-migration:xhs-douyin-content-detail",
-        "fr-0024:parent-closeout:fr-0024",
-    }
+CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES = (
+    "fr-0024:formal-spec:",
+    "fr-0024:manifest-fixture-validator:",
+    "fr-0024:reference-adapter-migration:",
+    "fr-0024:parent-closeout:",
 )
 LIFECYCLE_FIELDS = frozenset(
     {
@@ -690,19 +688,24 @@ def _validate_capability_requirement_evidence_refs(evidence_refs: tuple[str, ...
     unsupported_refs = tuple(
         evidence_ref
         for evidence_ref in evidence_refs
-        if evidence_ref not in APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REFS
+        if not _is_capability_requirement_evidence_ref(evidence_ref)
     )
     if unsupported_refs:
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
-            "evidence.capability_requirement_evidence_refs must point to approved FR-0024 requirement evidence",
+            "evidence.capability_requirement_evidence_refs must point to FR-0024 requirement evidence",
             details={
                 "unsupported_capability_requirement_evidence_refs": unsupported_refs,
-                "approved_capability_requirement_evidence_refs": tuple(
-                    sorted(APPROVED_CAPABILITY_REQUIREMENT_EVIDENCE_REFS)
-                ),
+                "allowed_capability_requirement_evidence_ref_prefixes": CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES,
             },
         )
+
+
+def _is_capability_requirement_evidence_ref(evidence_ref: str) -> bool:
+    for prefix in CAPABILITY_REQUIREMENT_EVIDENCE_REF_PREFIXES:
+        if evidence_ref.startswith(prefix) and evidence_ref != prefix:
+            return True
+    return False
 
 
 def _reject_observability_leakage(observability: AdapterCapabilityObservabilityExpectation) -> None:

--- a/tests/runtime/adapter_capability_requirement_fixtures.py
+++ b/tests/runtime/adapter_capability_requirement_fixtures.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+CAPABILITY_REQUIREMENT_EVIDENCE_REF = "fr-0024:manifest-fixture-validator:content-detail-by-url-hybrid"
+
+
+def valid_adapter_capability_requirement(
+    *,
+    adapter_key: str = "xhs",
+) -> dict[str, Any]:
+    return {
+        "adapter_key": adapter_key,
+        "capability": "content_detail",
+        "execution_requirement": {
+            "operation": "content_detail_by_url",
+            "target_type": "url",
+            "collection_mode": "hybrid",
+        },
+        "resource_requirement": valid_resource_requirement(adapter_key=adapter_key),
+        "evidence": {
+            "resource_profile_evidence_refs": [
+                "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+                "fr-0027:profile:content-detail-by-url-hybrid:account",
+            ],
+            "capability_requirement_evidence_refs": [CAPABILITY_REQUIREMENT_EVIDENCE_REF],
+        },
+        "lifecycle": {
+            "requires_core_resource_bundle": True,
+            "resource_profiles_drive_admission": True,
+            "uses_existing_disposition_hint": True,
+        },
+        "observability": {
+            "requirement_id": f"{adapter_key}:content_detail:content_detail_by_url:url:hybrid",
+            "profile_keys": ["account_proxy", "account"],
+            "proof_refs": [
+                "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+                "fr-0027:profile:content-detail-by-url-hybrid:account",
+            ],
+            "admission_outcome_fields": [
+                "match_status",
+                "error_code",
+                "failure_category",
+            ],
+        },
+        "fail_closed": True,
+    }
+
+
+def valid_resource_requirement(
+    *,
+    adapter_key: str = "xhs",
+) -> dict[str, Any]:
+    return {
+        "adapter_key": adapter_key,
+        "capability": "content_detail",
+        "resource_requirement_profiles": [
+            {
+                "profile_key": "account_proxy",
+                "resource_dependency_mode": "required",
+                "required_capabilities": ["account", "proxy"],
+                "evidence_refs": ["fr-0027:profile:content-detail-by-url-hybrid:account-proxy"],
+            },
+            {
+                "profile_key": "account",
+                "resource_dependency_mode": "required",
+                "required_capabilities": ["account"],
+                "evidence_refs": ["fr-0027:profile:content-detail-by-url-hybrid:account"],
+            },
+        ],
+    }
+
+
+def copy_requirement(requirement: dict[str, Any] | None = None) -> dict[str, Any]:
+    return deepcopy(requirement if requirement is not None else valid_adapter_capability_requirement())

--- a/tests/runtime/test_adapter_capability_requirement.py
+++ b/tests/runtime/test_adapter_capability_requirement.py
@@ -8,6 +8,11 @@ from syvert.adapter_capability_requirement import (
     ADAPTER_REQUIREMENT_STATUS_DECLARED,
     ADAPTER_REQUIREMENT_STATUS_INVALID,
     ADAPTER_REQUIREMENT_STATUS_UNMATCHED,
+    AdapterCapabilityExecutionRequirement,
+    AdapterCapabilityLifecycleExpectation,
+    AdapterCapabilityObservabilityExpectation,
+    AdapterCapabilityRequirement,
+    AdapterCapabilityRequirementEvidence,
     AdapterCapabilityRequirementValidationInput,
     validate_adapter_capability_requirement,
 )
@@ -118,6 +123,54 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
         result = validate_adapter_capability_requirement(requirement)
 
         self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_canonical_dataclass_with_raw_resource_requirement_without_crashing(self) -> None:
+        raw_requirement = copy_requirement()
+        raw_requirement["resource_requirement"]["resource_requirement_profiles"][0]["evidence_refs"] = [
+            "fr-0027:profile:content-detail-by-url-hybrid:proxy"
+        ]
+        requirement = AdapterCapabilityRequirement(
+            adapter_key=raw_requirement["adapter_key"],
+            capability=raw_requirement["capability"],
+            execution_requirement=AdapterCapabilityExecutionRequirement(
+                **raw_requirement["execution_requirement"],
+            ),
+            resource_requirement=raw_requirement["resource_requirement"],  # type: ignore[arg-type]
+            evidence=AdapterCapabilityRequirementEvidence(
+                resource_profile_evidence_refs=tuple(
+                    raw_requirement["evidence"]["resource_profile_evidence_refs"],
+                ),
+                capability_requirement_evidence_refs=tuple(
+                    raw_requirement["evidence"]["capability_requirement_evidence_refs"],
+                ),
+            ),
+            lifecycle=AdapterCapabilityLifecycleExpectation(
+                **raw_requirement["lifecycle"],
+            ),
+            observability=AdapterCapabilityObservabilityExpectation(
+                requirement_id=raw_requirement["observability"]["requirement_id"],
+                profile_keys=tuple(raw_requirement["observability"]["profile_keys"]),
+                proof_refs=tuple(raw_requirement["observability"]["proof_refs"]),
+                admission_outcome_fields=tuple(raw_requirement["observability"]["admission_outcome_fields"]),
+            ),
+            fail_closed=raw_requirement["fail_closed"],
+        )
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_unapproved_requirement_level_evidence(self) -> None:
+        requirement = copy_requirement()
+        requirement["evidence"]["capability_requirement_evidence_refs"] = ["tmp:runtime-log"]
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(
+            result.details["unsupported_capability_requirement_evidence_refs"],
+            ("tmp:runtime-log",),
+        )
 
     def test_validator_rejects_lifecycle_boundary_violation(self) -> None:
         requirement = copy_requirement()

--- a/tests/runtime/test_adapter_capability_requirement.py
+++ b/tests/runtime/test_adapter_capability_requirement.py
@@ -172,6 +172,38 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
             ("tmp:runtime-log",),
         )
 
+    def test_validator_rejects_fabricated_requirement_level_evidence_with_approved_prefix(self) -> None:
+        requirement = copy_requirement()
+        requirement["evidence"]["capability_requirement_evidence_refs"] = [
+            "fr-0024:manifest-fixture-validator:not-real"
+        ]
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+        self.assertEqual(
+            result.details["unsupported_capability_requirement_evidence_refs"],
+            ("fr-0024:manifest-fixture-validator:not-real",),
+        )
+
+    def test_validator_rejects_mapping_payloads_for_string_array_fields(self) -> None:
+        cases = (
+            ("evidence", "resource_profile_evidence_refs"),
+            ("evidence", "capability_requirement_evidence_refs"),
+            ("observability", "profile_keys"),
+            ("observability", "proof_refs"),
+            ("observability", "admission_outcome_fields"),
+        )
+        for section, field_name in cases:
+            with self.subTest(section=section, field_name=field_name):
+                requirement = copy_requirement()
+                requirement[section][field_name] = {"account": True}
+
+                result = validate_adapter_capability_requirement(requirement)
+
+                self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+                self.assertEqual(result.details["actual_type"], "dict")
+
     def test_validator_rejects_lifecycle_boundary_violation(self) -> None:
         requirement = copy_requirement()
         requirement["lifecycle"]["resource_profiles_drive_admission"] = False
@@ -190,12 +222,15 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
         self.assertEqual(result.details["extra_fields"], ("acquire_strategy",))
 
     def test_validator_rejects_observability_technical_field_leakage(self) -> None:
-        requirement = copy_requirement()
-        requirement["observability"]["admission_outcome_fields"].append("browser_profile")
+        leaked_values = ("browser_profile", "browserProfile", "networkTier", "providerKey", "xhs:provider:native")
+        for leaked_value in leaked_values:
+            with self.subTest(leaked_value=leaked_value):
+                requirement = copy_requirement()
+                requirement["observability"]["requirement_id"] = leaked_value
 
-        result = validate_adapter_capability_requirement(requirement)
+                result = validate_adapter_capability_requirement(requirement)
 
-        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+                self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
 
     def test_validator_rejects_provider_priority_and_fallback_fields(self) -> None:
         requirement = copy_requirement()

--- a/tests/runtime/test_adapter_capability_requirement.py
+++ b/tests/runtime/test_adapter_capability_requirement.py
@@ -117,7 +117,12 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
                 requirement = copy_requirement()
                 requirement["execution_requirement"][field_name] = value
 
-                result = validate_adapter_capability_requirement(requirement)
+                result = validate_adapter_capability_requirement(
+                    AdapterCapabilityRequirementValidationInput(
+                        requirement=requirement,
+                        available_resource_capabilities=("account",),
+                    )
+                )
 
                 self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
 
@@ -198,10 +203,32 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
             ("tmp:runtime-log",),
         )
 
-    def test_validator_rejects_fabricated_requirement_level_evidence_with_approved_prefix(self) -> None:
+    def test_validator_accepts_requirement_level_evidence_categories_without_fixed_allowlist(self) -> None:
+        allowed_refs = (
+            "fr-0024:formal-spec:adapter-capability-requirement-contract",
+            "fr-0024:manifest-fixture-validator:content-detail-by-url-hybrid",
+            "fr-0024:reference-adapter-migration:xhs-douyin-content-detail",
+            "fr-0024:parent-closeout:fr-0024",
+            "fr-0024:manifest-fixture-validator:future-approved-fixture",
+        )
+        for evidence_ref in allowed_refs:
+            with self.subTest(evidence_ref=evidence_ref):
+                requirement = copy_requirement()
+                requirement["evidence"]["capability_requirement_evidence_refs"] = [evidence_ref]
+
+                result = validate_adapter_capability_requirement(
+                    AdapterCapabilityRequirementValidationInput(
+                        requirement=requirement,
+                        available_resource_capabilities=("account",),
+                    )
+                )
+
+                self.assertEqual(result.status, ADAPTER_REQUIREMENT_STATUS_DECLARED)
+
+    def test_validator_rejects_requirement_level_evidence_outside_fr0024_categories(self) -> None:
         requirement = copy_requirement()
         requirement["evidence"]["capability_requirement_evidence_refs"] = [
-            "fr-0024:manifest-fixture-validator:not-real"
+            "fr-0024:provider-offer:content-detail"
         ]
 
         result = validate_adapter_capability_requirement(requirement)
@@ -209,7 +236,7 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
         self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
         self.assertEqual(
             result.details["unsupported_capability_requirement_evidence_refs"],
-            ("fr-0024:manifest-fixture-validator:not-real",),
+            ("fr-0024:provider-offer:content-detail",),
         )
 
     def test_validator_rejects_mapping_payloads_for_string_array_fields(self) -> None:

--- a/tests/runtime/test_adapter_capability_requirement.py
+++ b/tests/runtime/test_adapter_capability_requirement.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import unittest
+
+from syvert.adapter_capability_requirement import (
+    ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+    ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT,
+    ADAPTER_REQUIREMENT_STATUS_DECLARED,
+    ADAPTER_REQUIREMENT_STATUS_INVALID,
+    ADAPTER_REQUIREMENT_STATUS_UNMATCHED,
+    AdapterCapabilityRequirementValidationInput,
+    validate_adapter_capability_requirement,
+)
+from tests.runtime.adapter_capability_requirement_fixtures import (
+    copy_requirement,
+    valid_adapter_capability_requirement,
+)
+
+
+class AdapterCapabilityRequirementTests(unittest.TestCase):
+    def test_validator_accepts_legal_requirement_as_declared_when_resource_profiles_are_satisfied(self) -> None:
+        result = validate_adapter_capability_requirement(
+            AdapterCapabilityRequirementValidationInput(
+                requirement=valid_adapter_capability_requirement(),
+                available_resource_capabilities=("account",),
+            )
+        )
+
+        self.assertEqual(result.status, ADAPTER_REQUIREMENT_STATUS_DECLARED)
+        self.assertEqual(result.adapter_key, "xhs")
+        self.assertEqual(result.capability, "content_detail")
+        self.assertEqual(result.error_code, None)
+        self.assertEqual(
+            result.details,
+            {
+                "match_status": "matched",
+                "requirement_id": "xhs:content_detail:content_detail_by_url:url:hybrid",
+            },
+        )
+
+    def test_validator_returns_unmatched_for_legal_requirement_when_no_profile_is_satisfied(self) -> None:
+        result = validate_adapter_capability_requirement(
+            AdapterCapabilityRequirementValidationInput(
+                requirement=valid_adapter_capability_requirement(),
+                available_resource_capabilities=("proxy",),
+            )
+        )
+
+        self.assertEqual(result.status, ADAPTER_REQUIREMENT_STATUS_UNMATCHED)
+        self.assertEqual(result.error_code, None)
+        self.assertEqual(
+            result.details,
+            {
+                "match_status": "unmatched",
+                "requirement_id": "xhs:content_detail:content_detail_by_url:url:hybrid",
+            },
+        )
+
+    def test_validator_rejects_missing_required_field_as_invalid_contract(self) -> None:
+        requirement = copy_requirement()
+        del requirement["execution_requirement"]
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(result.details["missing_fields"], ("execution_requirement",))
+
+    def test_validator_rejects_fail_closed_not_true_as_invalid_contract(self) -> None:
+        requirement = copy_requirement()
+        requirement["fail_closed"] = False
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(result.details["fail_closed"], False)
+
+    def test_validator_rejects_legacy_single_declaration_resource_carrier(self) -> None:
+        requirement = copy_requirement()
+        requirement["resource_requirement"] = {
+            "adapter_key": "xhs",
+            "capability": "content_detail",
+            "resource_dependency_mode": "required",
+            "required_capabilities": ["account", "proxy"],
+            "evidence_refs": [
+                "fr-0015:runtime:content-detail-by-url-hybrid:requested-slots",
+                "fr-0015:xhs:content-detail:url:hybrid:account-material",
+                "fr-0015:regression:xhs:managed-proxy-seed",
+            ],
+        }
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_unknown_capability_as_invalid_contract(self) -> None:
+        requirement = copy_requirement()
+        requirement["capability"] = "search"
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(result.details["capability"], "search")
+
+    def test_validator_rejects_profile_proof_mismatch_as_invalid_resource_requirement(self) -> None:
+        requirement = copy_requirement()
+        profile = requirement["resource_requirement"]["resource_requirement_profiles"][0]
+        profile["required_capabilities"] = ["proxy"]
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_missing_profile_proof_as_invalid_resource_requirement(self) -> None:
+        requirement = copy_requirement()
+        profile = requirement["resource_requirement"]["resource_requirement_profiles"][0]
+        profile["evidence_refs"] = []
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_lifecycle_boundary_violation(self) -> None:
+        requirement = copy_requirement()
+        requirement["lifecycle"]["resource_profiles_drive_admission"] = False
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+
+    def test_validator_rejects_lifecycle_runtime_fields(self) -> None:
+        requirement = copy_requirement()
+        requirement["lifecycle"]["acquire_strategy"] = "adapter_pool"
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(result.details["extra_fields"], ("acquire_strategy",))
+
+    def test_validator_rejects_observability_technical_field_leakage(self) -> None:
+        requirement = copy_requirement()
+        requirement["observability"]["admission_outcome_fields"].append("browser_profile")
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+
+    def test_validator_rejects_provider_priority_and_fallback_fields(self) -> None:
+        requirement = copy_requirement()
+        requirement["provider_offer"] = {"provider_key": "native"}
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(result.details["forbidden_fields"], ("provider_key", "provider_offer"))
+
+        requirement = copy_requirement()
+        requirement["resource_requirement"]["resource_requirement_profiles"][0]["priority"] = 1
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(result.details["forbidden_fields"], ("priority",))
+
+        requirement = copy_requirement()
+        requirement["resource_requirement"]["fallback"] = "account"
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
+        self.assertEqual(result.details["forbidden_fields"], ("fallback",))
+
+    def test_legal_requirement_does_not_emit_provider_compatibility_fields(self) -> None:
+        result = validate_adapter_capability_requirement(
+            AdapterCapabilityRequirementValidationInput(
+                requirement=valid_adapter_capability_requirement(adapter_key="douyin"),
+                available_resource_capabilities=("account", "proxy"),
+            )
+        )
+
+        self.assertEqual(result.status, ADAPTER_REQUIREMENT_STATUS_DECLARED)
+        self.assertNotIn("provider_key", result.details)
+        self.assertNotIn("compatibility_decision", result.details)
+
+    def assert_invalid(self, result, error_code: str) -> None:
+        self.assertEqual(result.status, ADAPTER_REQUIREMENT_STATUS_INVALID)
+        self.assertEqual(result.failure_category, "runtime_contract")
+        self.assertEqual(result.error_code, error_code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_adapter_capability_requirement.py
+++ b/tests/runtime/test_adapter_capability_requirement.py
@@ -106,6 +106,21 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
         self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT)
         self.assertEqual(result.details["capability"], "search")
 
+    def test_validator_rejects_execution_requirement_outside_approved_slice(self) -> None:
+        cases = (
+            ("operation", "search_by_keyword"),
+            ("target_type", "keyword"),
+            ("collection_mode", "api_only"),
+        )
+        for field_name, value in cases:
+            with self.subTest(field_name=field_name, value=value):
+                requirement = copy_requirement()
+                requirement["execution_requirement"][field_name] = value
+
+                result = validate_adapter_capability_requirement(requirement)
+
+                self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
     def test_validator_rejects_profile_proof_mismatch_as_invalid_resource_requirement(self) -> None:
         requirement = copy_requirement()
         profile = requirement["resource_requirement"]["resource_requirement_profiles"][0]
@@ -119,6 +134,17 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
         requirement = copy_requirement()
         profile = requirement["resource_requirement"]["resource_requirement_profiles"][0]
         profile["evidence_refs"] = []
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_resource_profile_evidence_refs_that_do_not_match_profile_proofs(self) -> None:
+        requirement = copy_requirement()
+        requirement["evidence"]["resource_profile_evidence_refs"] = [
+            "fr-0027:profile:content-detail-by-url-hybrid:account",
+            "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+        ]
 
         result = validate_adapter_capability_requirement(requirement)
 
@@ -203,6 +229,40 @@ class AdapterCapabilityRequirementTests(unittest.TestCase):
 
                 self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
                 self.assertEqual(result.details["actual_type"], "dict")
+
+    def test_validator_rejects_observability_profile_keys_that_do_not_match_resource_profiles(self) -> None:
+        requirement = copy_requirement()
+        requirement["observability"]["profile_keys"] = ["account", "account_proxy"]
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_observability_proof_refs_that_do_not_match_requirement_evidence(self) -> None:
+        requirement = copy_requirement()
+        requirement["observability"]["proof_refs"] = [
+            "fr-0027:profile:content-detail-by-url-hybrid:account",
+            "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+        ]
+
+        result = validate_adapter_capability_requirement(requirement)
+
+        self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
+
+    def test_validator_rejects_observability_admission_outcome_field_drift(self) -> None:
+        cases = (
+            ["match_status", "error_code"],
+            ["match_status", "error_code", "failure_category", "provider_key"],
+            ["error_code", "match_status", "failure_category"],
+        )
+        for admission_outcome_fields in cases:
+            with self.subTest(admission_outcome_fields=admission_outcome_fields):
+                requirement = copy_requirement()
+                requirement["observability"]["admission_outcome_fields"] = admission_outcome_fields
+
+                result = validate_adapter_capability_requirement(requirement)
+
+                self.assert_invalid(result, ADAPTER_REQUIREMENT_ERROR_INVALID_RESOURCE_REQUIREMENT)
 
     def test_validator_rejects_lifecycle_boundary_violation(self) -> None:
         requirement = copy_requirement()


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：实现 `FR-0024` AdapterCapabilityRequirement manifest / fixture / validator，使 Adapter requirement carrier 可被稳定判定为 declared、unmatched 或 fail-closed invalid。
- 主要改动：新增 `syvert/adapter_capability_requirement.py` 独立 validator；新增 runtime fixture 与测试；更新 `CHORE-0314` exec-plan，记录 guardian 修复、主干同步和验证证据。

## Issue 摘要

## Goal

交付目标：基于已批准的 `FR-0024` formal spec，落地 Adapter requirement manifest / fixture / validator。

验证方式：运行 runtime / contract tests，验证合法 requirement 与非法 carrier 的 fail-closed 行为。

回滚方式：通过独立 revert PR 撤销 manifest / validator 实现增量；若发现规约不足，回到 formal spec Work Item 处理。

## Scope

- 实现 Adapter capability requirement manifest / fixture / validator。
- 验证 `FR-0027` resource profiles / evidence refs 可被 requirement carrier 正确消费。
- 覆盖非法字段、缺失 profile proof、未知 capability、错误 lifecycle / evidence 约束等 fail-closed 场景。
- 保持 registry / runtime 不引入 provider offer 语义。

## Out of Scope

- 不定义 Provider offer。
- 不实现 compatibility decision。
- 不迁移 reference adapter requirement 声明。
- 不关闭 `#296`。

## 关联事项

- Issue: #314
- item_key: `CHORE-0314-fr-0024-manifest-fixture-validator`
- item_type: `CHORE`
- release: `v0.8.0`
- sprint: `2026-S21`
- Closing: Fixes #314

## Review Artifacts

- Active exec-plan: `docs/exec-plans/CHORE-0314-fr-0024-manifest-fixture-validator.md`
- Governing spec / bootstrap contract: `docs/specs/FR-0024-adapter-capability-requirement-contract`
- Review artifact: `code_review.md`
- Validation evidence: `python3 scripts/governance_gate.py --mode ci --base-sha 5cc4a6c4b12bfb74e852472705e8c3fb5d98ed93 --head-sha 5f620f69660bade92f3385c6f9bba96cd7aa43dc --head-ref issue-314-fr-0024-adapter-requirement-manifest-validator`

## 风险

- 风险级别：`normal`
- 审查关注：确认 validator 只消费 `FR-0027` 的 `AdapterResourceRequirementDeclarationV2` / matcher truth，不复制 profile matcher 规则；确认合法 requirement 仅代表 declared，不推出 Provider compatible；确认 provider / priority / fallback / browser / network / transport 字段全部 fail-closed。

## 验证

- 已执行：`python3 -m unittest tests.runtime.test_adapter_capability_requirement`；`python3 -m unittest tests.runtime.test_adapter_resource_requirement_declaration`；`python3 -m unittest tests.runtime.test_resource_capability_matcher`；`python3 -m unittest tests.runtime.test_registry`；`python3 -m unittest discover tests/runtime`；`python3 scripts/spec_guard.py --mode ci --all`；`python3 scripts/docs_guard.py --mode ci`；`python3 scripts/workflow_guard.py --mode ci`；`python3 scripts/governance_gate.py --mode ci --base-sha 5cc4a6c4b12bfb74e852472705e8c3fb5d98ed93 --head-sha 5f620f69660bade92f3385c6f9bba96cd7aa43dc --head-ref issue-314-fr-0024-adapter-requirement-manifest-validator`；`python3 scripts/pr_scope_guard.py --class implementation --base-ref origin/main --head-ref HEAD`。
- 未执行：无。

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.
