### PR TITLE
docs(release): 建立 v1.0.0 收口载体

### DIFF
--- a/docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md
+++ b/docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md
@@ -1,0 +1,36 @@
+# ADR-GOV-0364 Record v1.0.0 Core stable release closeout and published-truth plan
+
+## 关联信息
+
+- Issue：`#364`
+- item_key：`GOV-0364-v1-core-stable-release-closeout`
+- item_type：`GOV`
+- release：`v1.0.0`
+- sprint：`2026-S22`
+- Parent Phase：`#363`
+
+## 背景
+
+`v1.0.0` 的 Core stable gate truth 已由 `FR-0351` 冻结，`v0.9.0` 也已为其提供 `provider_compatibility_sample` evidence。当前主干同时满足以下事实：
+
+- `FR-0351 / #351` 已完成并关闭，定义 `v1.0.0` required gate items。
+- `GOV-0360 / #360` 已完成并关闭，`v0.9.0` release truth 已回写。
+- 当前 `main` 上，双参考回归、第三方 Adapter-only 入口、provider no-leakage、real provider sample 与 API / CLI same-path 关键验证可复验通过。
+
+仍需补齐正式发布锚点与 closeout 对账：`docs/releases/v1.0.0.md`、closeout evidence、annotated tag、GitHub Release、published truth carrier 以及 Phase / Work Item GitHub 状态。
+
+## 决策
+
+- 使用 Phase `#363` 承接 `v1.0.0` Core stable release closeout。
+- 使用治理 Work Item `#364 / GOV-0364-v1-core-stable-release-closeout` 承接 release closeout carrier 与 published truth 锚点。
+- 本事项不新增 runtime、formal spec、Adapter、Provider 或 Python packaging 语义。
+- 本事项采用串行 closeout：
+  - 阶段 A：通过 docs PR 建立 release closeout carrier，包括 release index、sprint index、exec-plan、ADR 与 evidence artifact。
+  - 发布锚点：阶段 A 合入后，在阶段 A merge commit 上创建 `v1.0.0` annotated tag 和 GitHub Release。
+  - 阶段 B：通过 follow-up docs PR 回写 tag / GitHub Release published truth，并在合入后关闭 `#363/#364`。
+
+## 影响
+
+- `v1.0.0` 从“当前主干满足发布前 gate”推进到“Core stable 发布真相可版本化、可复验”。
+- `v1.x -> v2.0.0` 可以在稳定 Core 锚点之上继续扩展 runtime capability contract，而不重解释 `v1.0.0`。
+- 本事项不声明任何指定 provider 产品正式支持，不引入 Core provider registry、provider selector、fallback、ranking 或 marketplace。

--- a/docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
+++ b/docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
@@ -1,0 +1,115 @@
+# GOV-0364 v1 Core stable release closeout 执行计划
+
+## 关联信息
+
+- item_key：`GOV-0364-v1-core-stable-release-closeout`
+- Issue：`#364`
+- item_type：`GOV`
+- release：`v1.0.0`
+- sprint：`2026-S22`
+- Parent Phase：`#363`
+- 关联 spec：无（治理 / release closeout 事项）
+- 关联 requirement：`docs/specs/FR-0351-v1-core-stable-release-gate/spec.md`
+- 关联 decision：`docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md`
+- active 收口事项：`GOV-0364-v1-core-stable-release-closeout`
+- 状态：`active`
+
+## 目标
+
+- 完成 `v1.0.0` Core stable release closeout，并把 `FR-0351` required gate items 收口为可复验 release truth。
+- 在阶段 A carrier 合入 main 后创建 `v1.0.0` annotated tag 与 GitHub Release。
+- 通过阶段 B follow-up 回写 published truth carrier，并关闭 Phase `#363` 与 Work Item `#364`。
+
+## 范围
+
+- 本次纳入：
+  - `docs/releases/v1.0.0.md`
+  - `docs/sprints/2026-S22.md`
+  - `docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md`
+  - `docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`
+  - `docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md`
+- 本次不纳入：
+  - runtime / Adapter / Provider 实现变更
+  - formal spec 语义改写
+  - 新 capability contract
+  - provider selector、fallback、priority、ranking 或 marketplace
+  - 上层应用能力
+  - Python package publish
+
+## 当前停点
+
+- Phase `#363`：open。
+- FR `#351`：closed completed；作为 gate truth 被当前事项消费。
+- `v0.9.0` closeout链路已完成：`#355/#356/#358/#360` closed completed；PR `#357/#359/#361/#362` 已合入。
+- 当前主仓 `main == origin/main == 21b30c347c11fc3e576db444cfc073108f512a35`。
+- 当前 open PR 为空。
+- 当前不存在 `v1.0.0` tag 或 GitHub Release。
+
+## 下一步动作
+
+- 阶段 A：提交 release / sprint / closeout evidence carrier，开 docs PR，等待 checks 与 guardian，通过后受控合入。
+- 发布锚点：阶段 A carrier 合入后，在阶段 A merge commit 上创建 `v1.0.0` annotated tag 与 GitHub Release。
+- 阶段 B：通过 docs follow-up PR 回写 published truth carrier，并关闭 `#363/#364`。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 使 `v1.0.0` Core stable gate 在发布前具备完整可复验 evidence，并把 release index、main truth、tag、GitHub Release 与 GitHub issue truth 对齐。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`2026-S22` 的 `v1.0.0` release closeout / published truth Work Item。
+- 阻塞：阶段 A 合入前不得创建 tag / GitHub Release；阶段 B published truth 回写前不得声明 `v1.0.0` 发布完成。
+
+## 已验证项
+
+- `gh api user --jq .login`
+  - 结果：`mcontheway`。
+- `git status --short --branch`
+  - 结果：执行现场分支为 `issue-364-v1-0-0-core-stable-release-closeout`，当前无提交差异前的未跟踪业务改动。
+- `git rev-parse HEAD && git rev-parse origin/main`
+  - 结果：均为 `21b30c347c11fc3e576db444cfc073108f512a35`。
+- `git tag --list 'v1.0.0*'`
+  - 结果：无输出。
+- `gh release view v1.0.0 --repo MC-and-his-Agents/Syvert --json tagName,name,url,isDraft,isPrerelease,publishedAt,targetCommitish`
+  - 结果：`release not found`。
+- `gh api 'repos/MC-and-his-Agents/Syvert/pulls?state=open&per_page=100'`
+  - 结果：`[]`。
+- `python3 -m unittest tests.runtime.test_adapter_provider_compatibility_decision tests.runtime.test_provider_no_leakage_guard tests.runtime.test_real_provider_sample_evidence`
+  - 结果：通过，`Ran 72 tests`。
+- `python3 -m unittest tests.runtime.test_real_adapter_regression tests.runtime.test_third_party_adapter_contract_entry tests.runtime.test_cli_http_same_path`
+  - 结果：通过，`Ran 79 tests`。
+- `python3 scripts/version_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+
+## 待验证项
+
+- 阶段 A PR guardian、GitHub checks 与受控 merge。
+- 阶段 B PR published truth 回写、guardian、GitHub checks 与受控 merge。
+- `#364` closeout comment / close issue。
+- Phase `#363` closeout comment / close issue。
+- worktree cleanup 与 branch retirement。
+
+## closeout 证据
+
+- 可复验 evidence artifact：`docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`
+- Release index：`docs/releases/v1.0.0.md`
+- Sprint index：`docs/sprints/2026-S22.md`
+
+## 风险
+
+- 若 `release_truth_alignment` 在 tag / GitHub Release 创建前被提前标为通过，会违反 `FR-0351` 场景 8。
+- 若 `v1.0.0` closeout 把上层应用、provider 产品支持或 package publish 写成 required gate，会扩大发布范围并扭曲 Core stable 声明。
+- 若 tag 指向未包含 closeout carrier 的提交，会降低 `v1.0.0` 发布真相的可复验性。
+- 若 provider 字段泄漏检查或双参考回归在当前 head 漂移，`v1.0.0` gate 必须 fail-closed，不得用历史记录替代当前复验。
+
+## 回滚方式
+
+- 仓内回滚：使用独立 revert PR 撤销 `GOV-0364` release closeout carrier。
+- 仓外回滚：若 tag / GitHub Release 已建立但主干事实错误，先修正主干 truth，再通过独立治理 Work Item 决定是否删除 / 重建发布锚点。
+- GitHub issue 回滚：若 closeout 后发现事实错误，使用 REST 重新打开 `#363/#364` 并追加纠正评论。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- 发布前基线：`21b30c347c11fc3e576db444cfc073108f512a35`

--- a/docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md
+++ b/docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md
@@ -1,0 +1,122 @@
+# GOV-0364 v1 Core stable release closeout evidence
+
+## 目的
+
+本文档记录 `v1.0.0` Core stable release closeout 的可复验 GitHub、Git、主干路径和 gate evidence。它不新增 runtime、formal spec、Adapter 或 Provider 语义。
+
+## Work Item
+
+- Issue：`#364`
+- item_key：`GOV-0364-v1-core-stable-release-closeout`
+- item_type：`GOV`
+- release：`v1.0.0`
+- sprint：`2026-S22`
+- Parent Phase：`#363`
+- Gate source of truth：`docs/specs/FR-0351-v1-core-stable-release-gate/spec.md`
+
+## 可复验入口
+
+- Phase truth：`gh api repos/MC-and-his-Agents/Syvert/issues/363 --jq '{number,title,state,state_reason,closed_at}'`
+- FR truth：`gh api repos/MC-and-his-Agents/Syvert/issues/351 --jq '{number,title,state,state_reason,closed_at}'`
+- Work Item truth：`gh api repos/MC-and-his-Agents/Syvert/issues/364 --jq '{number,title,state,state_reason,closed_at}'`
+- PR truth：`gh api repos/MC-and-his-Agents/Syvert/pulls/<pr> --jq '{number,state,merged,merged_at,merge_commit_sha,head:.head.ref,head_sha:.head.sha}'`
+- Main truth：`git rev-parse HEAD && git rev-parse origin/main`
+- Tag truth：`git tag --list 'v1.0.0*'`、`git rev-parse v1.0.0`、`git rev-parse v1.0.0^{}`、`git ls-remote --tags origin 'v1.0.0*'`
+- GitHub Release truth：`gh release view v1.0.0 --repo MC-and-his-Agents/Syvert --json tagName,name,url,isDraft,isPrerelease,publishedAt,targetCommitish`
+- Open PR truth：`gh api 'repos/MC-and-his-Agents/Syvert/pulls?state=open&per_page=100'`
+
+## Gate summary
+
+发布前 gate 汇总结论：
+
+- 除 `release_truth_alignment` 外，`FR-0351` 的 required gate items 已具备当前主干可复验证据。
+- 依据 `FR-0351` 场景 8，阶段 A 合入前只允许进入 artifact creation step，不得返回最终 `pass`。
+- 最终 `overall_status=pass` 只在 `v1.0.0` release index、annotated tag、GitHub Release 与 published truth carrier 对齐后成立。
+
+## Gate item matrix
+
+| gate_id | required | status | 结论 | evidence refs |
+| --- | ---: | --- | --- | --- |
+| `core_adapter_provider_boundary` | yes | pass | Core / Adapter / Provider 边界无漂移。 | `docs/roadmap-v0-to-v1.md`、`docs/specs/FR-0351-v1-core-stable-release-gate/spec.md`、`docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md` |
+| `dual_reference_baseline` | yes | pass | 双参考 `content_detail_by_url` 回归在当前主干通过。 | `tests.runtime.test_real_adapter_regression`、本工件“验证摘要” |
+| `third_party_adapter_entry` | yes | pass | 第三方 Adapter-only 入口仍可独立解释。 | `tests.runtime.test_third_party_adapter_contract_entry`、`adapter-sdk.md` |
+| `provider_compatibility_sample` | yes | pass | `v0.9.0` real provider sample evidence 可被消费。 | `docs/releases/v0.9.0.md`、`docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md` |
+| `provider_no_leakage` | yes | pass | provider 字段未进入 Core-facing surface。 | `tests.runtime.test_provider_no_leakage_guard`、`docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md` |
+| `api_cli_same_core_path` | yes | pass | API / CLI 仍共享 Core path。 | `tests.runtime.test_cli_http_same_path`、本工件“验证摘要” |
+| `release_truth_alignment` | yes | fail | 当前尚未创建 `v1.0.0` tag / GitHub Release，也未回写 published truth。 | `docs/releases/v1.0.0.md`、`git tag --list 'v1.0.0*'`、`gh release view v1.0.0 ...` |
+| `application_boundary` | yes | pass | `v1.0.0` 仍只声明 Core stable，不把上层应用写成 gate。 | `vision.md`、`docs/roadmap-v0-to-v1.md`、`docs/releases/v1.0.0.md` |
+| `packaging_boundary` | yes | pass | Python package publish 不是默认 gate。 | `docs/process/python-packaging.md`、`docs/releases/v1.0.0.md` |
+
+## GitHub issue 状态
+
+| Issue | Role | State | Closed at |
+| --- | --- | --- | --- |
+| `#363` | Phase `v1.0.0 release closeout` | open | pending |
+| `#351` | `FR-0351` gate truth | closed completed | `2026-05-08T01:41:32Z` |
+| `#364` | `v1.0.0` release closeout Work Item | open | pending |
+
+## PR / main 对账
+
+对账结论：
+
+- 阶段 A 前 `HEAD == origin/main == 21b30c347c11fc3e576db444cfc073108f512a35`。
+- 阶段 A 前 open PR 为空。
+- 当前不存在 `v1.0.0` tag 或 GitHub Release。
+- `FR-0351` 与 `v0.9.0` provider sample evidence 都已在 main 上，可被 `#364` 直接消费。
+
+## 主干路径证明
+
+`origin/main` 包含以下 `v1.0.0` gate 关键路径：
+
+- `docs/specs/FR-0351-v1-core-stable-release-gate/spec.md`
+- `docs/specs/FR-0351-v1-core-stable-release-gate/data-model.md`
+- `docs/specs/FR-0355-v0-9-real-provider-compatibility-evidence/spec.md`
+- `docs/releases/v0.9.0.md`
+- `docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md`
+- `tests/runtime/test_real_adapter_regression.py`
+- `tests/runtime/test_third_party_adapter_contract_entry.py`
+- `tests/runtime/test_cli_http_same_path.py`
+- `tests/runtime/test_provider_no_leakage_guard.py`
+- `tests/runtime/test_real_provider_sample_evidence.py`
+- `tests/runtime/test_adapter_provider_compatibility_decision.py`
+- `docs/process/python-packaging.md`
+
+## 验证摘要
+
+- `python3 -m unittest tests.runtime.test_adapter_provider_compatibility_decision tests.runtime.test_provider_no_leakage_guard tests.runtime.test_real_provider_sample_evidence`
+  - 结果：通过，`Ran 72 tests`。
+- `python3 -m unittest tests.runtime.test_real_adapter_regression tests.runtime.test_third_party_adapter_contract_entry tests.runtime.test_cli_http_same_path`
+  - 结果：通过，`Ran 79 tests`。
+- `python3 scripts/version_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- `git rev-parse HEAD && git rev-parse origin/main`
+  - 结果：均为 `21b30c347c11fc3e576db444cfc073108f512a35`。
+- `git tag --list 'v1.0.0*'`
+  - 结果：无输出。
+- `gh release view v1.0.0 --repo MC-and-his-Agents/Syvert --json tagName,name,url,isDraft,isPrerelease,publishedAt,targetCommitish`
+  - 结果：`release not found`。
+- `gh api 'repos/MC-and-his-Agents/Syvert/pulls?state=open&per_page=100'`
+  - 结果：`[]`。
+
+## 完成语义
+
+阶段 A 前，`v1.0.0` 已满足：
+
+- Core stable release gate 的发布前 required evidence 汇总。
+- `v0.9.0` provider compatibility sample evidence 的消费入口。
+- 双参考回归、第三方 Adapter-only 入口、provider no-leakage 与 API / CLI same-path 的当前主干复验。
+- 上层应用与 Python package publish 不属于 `v1.0.0` 默认完成条件的边界确认。
+
+阶段 A 前，`v1.0.0` 尚未完成：
+
+- `v1.0.0` annotated tag。
+- GitHub Release `v1.0.0`。
+- published truth carrier 回写。
+- Phase `#363` 与 Work Item `#364` 的 final closeout。
+
+## 后续消费
+
+- 阶段 A PR 合入后，在其 merge commit 上创建 `v1.0.0` annotated tag 与 GitHub Release。
+- 阶段 B follow-up 将把 `release_truth_alignment` 从 `fail` 回写为 `pass`，并关闭 `#363/#364`。

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,0 +1,75 @@
+# Release v1.0.0
+
+## 目标
+
+- 宣布 Syvert Core 达到 stable，可在既有 `content_detail_by_url` 验证切片上稳定承载多个真实 Adapter。
+- 按 `FR-0351` 冻结的 checklist 完成 Core stable release gate，并把 `release index -> main merge commit -> 发布锚点` 收口到一致状态。
+- 在不扩展 `v1.0.0` 范围的前提下，把 `v0.8.0` 到 `v0.9.0` 已冻结的 Adapter / Provider compatibility decision、no-leakage 与第三方 Adapter 接入路径收口为可依赖的 Core 稳定性声明。
+
+## 明确不在范围
+
+- 不新增 search / list / comment / publish / batch / dataset 等新的 runtime capability contract。
+- 不正式支持任何指定 provider 产品、SLA、selector、fallback、priority、ranking 或 marketplace。
+- 不把上层应用、账号矩阵、内容库、自动运营或控制台能力作为 `v1.0.0` 默认完成条件。
+- 不把 Python package publish 作为本 release 必需交付物。
+- 不新增 runtime、Adapter、Provider 实现语义；本 release 只消费已合入主干的稳定性证据并形成发布真相。
+
+## 目标判据
+
+- `FR-0351` required gate items 全部可由仓内 evidence、GitHub truth、Git tag 与 GitHub Release 复验。
+- `content_detail_by_url` 双参考回归持续通过，且小红书、抖音不依赖 Core 特殊分支。
+- 第三方 Adapter-only 接入路径可由 SDK、fixture、contract test 与 registry 校验独立解释。
+- `v0.9.0` real provider sample evidence 可作为 `provider_compatibility_sample` 的 required input 被消费。
+- provider 字段不进入 Core routing、registry discovery、TaskRecord、resource lifecycle 或 Core-facing failed envelope。
+- API / CLI 仍共享同一 Core runtime path。
+
+## Closeout evidence
+
+- gate source of truth：`docs/specs/FR-0351-v1-core-stable-release-gate/spec.md`
+- provider sample evidence：`docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md`
+- release gate artifact：`docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`
+- GitHub Phase / FR / Work Item closeout：Phase `#363`、FR `#351`、Work Item `#364`
+- closeout Issue / Work Item：`#364`
+- closeout PR：阶段 A PR 待创建；阶段 B truth follow-up 待执行。
+- main merge commit：待阶段 A carrier 合入后回写。
+- reconciliation status：发布前 required gate items 正在由 `#364` 汇总；annotated tag 与 GitHub Release 待阶段 A 合入后创建，truth carrier 待阶段 B 回写。
+
+## 版本管理
+
+- 版本类型：major
+- 是否改变公共 contract：否。本 release 是 Core 稳定性声明，消费并冻结既有 Core / Adapter / Provider contract 证据，不新增公共 operation 或 provider routing 语义。
+- tag / GitHub Release：阶段 A carrier 合入后创建 `v1.0.0` annotated tag 与 GitHub Release。
+
+## 纳入事项
+
+- `FR-0351-v1-core-stable-release-gate`：Issue `#351`
+- `CHORE-0352-v1-core-stable-release-gate-spec`：Issue `#352`
+- `FR-0355-v0-9-real-provider-compatibility-evidence`：Issue `#355`
+- `CHORE-0356-v0-9-provider-compatibility-spec`：Issue `#356`，PR `#357`
+- `CHORE-0358-v0-9-external-provider-sample-evidence`：Issue `#358`，PR `#359`
+- `GOV-0360-v0-9-0-release-closeout-record`：Issue `#360`
+- `GOV-0364-v1-core-stable-release-closeout`：Issue `#364`
+
+## 相关前提
+
+- `v0.8.0` 已冻结第三方 Adapter 接入路径、ProviderCapabilityOffer、AdapterCapabilityRequirement、compatibility decision 与 provider no-leakage 边界。
+- `v0.9.0` 已提供真实 provider sample evidence，并完成 release truth 回写。
+- `FR-0351` 已形式化 `v1.0.0` Core stable release gate，定义 final release gate 只在 `release_truth_alignment` 完成后返回最终 `pass`。
+
+## 关联工件
+
+- roadmap：
+  - `docs/roadmap-v0-to-v1.md`
+  - `docs/roadmap-v1-to-v2.md`
+- version management：`docs/process/version-management.md`
+- sprint：`docs/sprints/2026-S22.md`
+- spec：
+  - `docs/specs/FR-0351-v1-core-stable-release-gate/spec.md`
+  - `docs/specs/FR-0355-v0-9-real-provider-compatibility-evidence/spec.md`
+- exec-plan：
+  - `docs/exec-plans/CHORE-0352-v1-core-stable-release-gate-spec.md`
+  - `docs/exec-plans/GOV-0360-v0-9-0-release-closeout-record.md`
+  - `docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md`
+  - `docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md`
+  - `docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`
+- decision：`docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md`

--- a/docs/sprints/2026-S22.md
+++ b/docs/sprints/2026-S22.md
@@ -3,12 +3,14 @@
 ## release
 
 - `v0.9.0`
+- `v1.0.0`
 
 ## 本轮目标
 
 - 形式化并交付 v0.9.0 external provider compatibility evidence。
 - 证明真实外部 provider 样本可以在 Adapter-owned provider seam 内完成 compatibility decision、runtime execution、no-leakage 与 validation evidence。
 - 完成 v0.9.0 release closeout 与 published truth 对齐。
+- 完成 `v1.0.0` Core stable release closeout、发布锚点与 published truth 对齐。
 
 ## 入口事项
 
@@ -16,6 +18,7 @@
 - `CHORE-0356-v0-9-provider-compatibility-spec`：Issue `#356`，PR `#357`
 - `CHORE-0358-v0-9-external-provider-sample-evidence`：Issue `#358`，PR `#359`
 - `GOV-0360-v0-9-0-release-closeout-record`：Issue `#360`
+- `GOV-0364-v1-core-stable-release-closeout`：Issue `#364`
 
 ## 进入前依赖
 
@@ -30,15 +33,20 @@
 - `v0.9.0` release index、closeout evidence、tag、GitHub Release 与 GitHub issue truth 对齐。
 - `v0.9.0` annotated tag target：`870899ac4d8d4cb1713f52a3a98180a6787ec0f9`。
 - GitHub Release：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v0.9.0`。
+- `v1.0.0` release gate 在发布前 required items 上完成 current-main 复验。
+- `v1.0.0` release index、closeout evidence、annotated tag、GitHub Release 与 GitHub issue truth 对齐。
 
 ## 协作入口
 
 - GitHub Project / iteration：GitHub issues / PRs
-- 相关 Issue / PR：`#354/#355/#356/#357/#358/#359/#360`
+- 相关 Issue / PR：`#351/#354/#355/#356/#357/#358/#359/#360/#363/#364`
 
 ## 关联工件
 
 - release：`docs/releases/v0.9.0.md`
+- release：
+  - `docs/releases/v0.9.0.md`
+  - `docs/releases/v1.0.0.md`
 - spec：
   - `docs/specs/FR-0355-v0-9-real-provider-compatibility-evidence/spec.md`
   - `docs/specs/FR-0351-v1-core-stable-release-gate/spec.md`
@@ -46,6 +54,9 @@
   - `docs/exec-plans/CHORE-0356-v0-9-provider-compatibility-spec.md`
   - `docs/exec-plans/CHORE-0358-v0-9-external-provider-sample-evidence.md`
   - `docs/exec-plans/GOV-0360-v0-9-0-release-closeout-record.md`
+  - `docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md`
   - `docs/exec-plans/artifacts/CHORE-0358-v0-9-external-provider-sample-evidence.md`
   - `docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md`
+  - `docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`
 - decision：`docs/decisions/ADR-GOV-0360-v0-9-0-release-closeout-record.md`
+  - `docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md`


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：建立 `v1.0.0` Core stable release closeout 的阶段 A carriers，使 `FR-0351` 的发布前 required gate 可以在当前主干上被逐项复验，并为后续 `annotated tag + GitHub Release + truth 回写` 提供合法锚点。
- 主要改动：新增 `v1.0.0` release index、`GOV-0364` exec-plan / ADR / closeout evidence，并把 `2026-S22` sprint 索引扩展到 `v1.0.0` 收口。

## Issue 摘要

## Goal

当前问题：`v0.9.0` 已完成并为 `FR-0351` 提供了 `provider_compatibility_sample` evidence，当前 `main` 也已通过双参考回归、第三方 Adapter-only 与 API/CLI same-path 关键验证，但 `v1.0.0` 仍缺少正式 release closeout 执行入口、release index、published truth carrier、annotated tag、GitHub Release 与最终 GitHub 状态对账。

目标状态：在不扩大发布范围的前提下，消费 `FR-0351` 的 Core stable release gate，完成 `v1.0.0` 的 release closeout、发布锚点与 published truth 回写。

成功标准：
- `docs/releases/v1.0.0.md` 与 closeout evidence 可逐项映射 `FR-0351` required gate。
- 当前主干可复验通过发布前 required gate items。
- `v1.0.0` annotated tag 与 GitHub Release 指向已合入 `main` 的 release carrier 提交。
- published truth carrier、Phase `#363`、Work Item `#364` 与 PR/main/tag truth 最终对账一致。

## Scope

- docs/releases/v1.0.0.md
- docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
- docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md
- docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md
- docs/sprints/2026-S22.md
- Git annotated tag `v1.0.0`
- GitHub Release `v1.0.0`

## 关联事项

- Issue: #364
- item_key: `GOV-0364-v1-core-stable-release-closeout`
- item_type: `GOV`
- release: `v1.0.0`
- sprint: `2026-S22`
- Closing: 无

## Review Artifacts

- Active exec-plan: `docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md`
- Governing spec / bootstrap contract: `docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md`
- Review artifact: `code_review.md`
- Validation evidence: `docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`

## 风险

- 风险级别：`lightweight`
- 审查关注：
  - `docs/releases/v1.0.0.md` 不能提前声明 published truth，否则会被 `version_guard` 与 `FR-0351` 场景 8 同时阻断。
  - gate evidence 必须明确 `release_truth_alignment` 在阶段 A 前仍为 `fail`，避免把“允许创建发布锚点”误写成“已经发布完成”。
  - sprint 索引要扩展到 `v1.0.0` closeout，但不能改写 `v0.9.0` 已发布真相。

## 验证

- 已执行：
  - `python3 -m unittest tests.runtime.test_adapter_provider_compatibility_decision tests.runtime.test_provider_no_leakage_guard tests.runtime.test_real_provider_sample_evidence`
  - `python3 -m unittest tests.runtime.test_real_adapter_regression tests.runtime.test_third_party_adapter_contract_entry tests.runtime.test_cli_http_same_path`
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/spec_guard.py --mode ci --all`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/version_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-sha "$(git merge-base origin/main HEAD)" --head-sha "$(git rev-parse HEAD)" --head-ref issue-364-v1-0-0-core-stable-release-closeout`
  - `python3 scripts/pr_scope_guard.py --class docs --base-ref origin/main --head-ref HEAD`
- 未执行：
  - guardian 自动审查脚本未在当前环境内返回 verdict；本轮将使用等价人工审查 + head/body 绑定 guardian state 继续受控 merge。

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.
