### PR TITLE
docs(release): 回写 v1.0.0 发布真相

### DIFF
--- a/docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
+++ b/docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
@@ -41,14 +41,15 @@
 - Phase `#363`：open。
 - FR `#351`：closed completed；作为 gate truth 被当前事项消费。
 - `v0.9.0` closeout链路已完成：`#355/#356/#358/#360` closed completed；PR `#357/#359/#361/#362` 已合入。
-- 当前主仓 `main == origin/main == 21b30c347c11fc3e576db444cfc073108f512a35`。
-- 当前 open PR 为空。
-- 当前不存在 `v1.0.0` tag 或 GitHub Release。
+- 阶段 A PR `#365` 已合入，merge commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- 当前主仓 `main == origin/main == 5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- `v1.0.0` annotated tag 已创建并推送，tag object `b8e9dc14d01599c3faad17c02392a4a8a3a19a98`，target commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- GitHub Release `v1.0.0` 已创建：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`。
 
 ## 下一步动作
 
-- 阶段 A：提交 release / sprint / closeout evidence carrier，开 docs PR，等待 checks 与 guardian，通过后受控合入。
-- 发布锚点：阶段 A carrier 合入后，在阶段 A merge commit 上创建 `v1.0.0` annotated tag 与 GitHub Release。
+- 阶段 A：已完成；PR `#365` 合入 main。
+- 发布锚点：已完成。
 - 阶段 B：通过 docs follow-up PR 回写 published truth carrier，并关闭 `#363/#364`。
 
 ## 当前 checkpoint 推进的 release 目标
@@ -82,6 +83,12 @@
   - 结果：通过。
 - `python3 scripts/docs_guard.py --mode ci`
   - 结果：通过。
+- `gh pr view 365 --json number,state,mergedAt,mergeCommit,headRefName,baseRefName,url`
+  - 结果：PR `#365` merged，merge commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`，`mergedAt=2026-05-08T08:59:18Z`。
+- `git rev-parse v1.0.0 && git rev-parse v1.0.0^{} && git cat-file -t v1.0.0`
+  - 结果：annotated tag object `b8e9dc14d01599c3faad17c02392a4a8a3a19a98`，target commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`，tag type=`tag`。
+- `gh release view v1.0.0 --repo MC-and-his-Agents/Syvert --json tagName,name,url,isDraft,isPrerelease,publishedAt,targetCommitish`
+  - 结果：`tagName=v1.0.0`，`name=v1.0.0`，`isDraft=false`，`isPrerelease=false`，`publishedAt=2026-05-08T09:01:54Z`，`targetCommitish=5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`，URL `https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`。
 
 ## 待验证项
 
@@ -113,3 +120,4 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - 发布前基线：`21b30c347c11fc3e576db444cfc073108f512a35`
+- 发布锚点：`5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`

--- a/docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
+++ b/docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
@@ -38,19 +38,21 @@
 
 ## 当前停点
 
-- Phase `#363`：open。
+- Phase `#363`：closed completed，`closed_at=2026-05-08T09:05:37Z`。
 - FR `#351`：closed completed；作为 gate truth 被当前事项消费。
 - `v0.9.0` closeout链路已完成：`#355/#356/#358/#360` closed completed；PR `#357/#359/#361/#362` 已合入。
 - 阶段 A PR `#365` 已合入，merge commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- 阶段 B PR `#366` 已创建，用于回写 published truth 与最终 closeout 对账。
 - 当前主仓 `main == origin/main == 5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
 - `v1.0.0` annotated tag 已创建并推送，tag object `b8e9dc14d01599c3faad17c02392a4a8a3a19a98`，target commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
 - GitHub Release `v1.0.0` 已创建：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`。
+- Work Item `#364`：closed completed，`closed_at=2026-05-08T09:05:36Z`。
 
 ## 下一步动作
 
 - 阶段 A：已完成；PR `#365` 合入 main。
 - 发布锚点：已完成。
-- 阶段 B：通过 docs follow-up PR 回写 published truth carrier，并关闭 `#363/#364`。
+- 阶段 B：通过 docs follow-up PR 回写 published truth carrier，并完成最终 GitHub truth 对账。
 
 ## 当前 checkpoint 推进的 release 目标
 
@@ -94,8 +96,6 @@
 
 - 阶段 A PR guardian、GitHub checks 与受控 merge。
 - 阶段 B PR published truth 回写、guardian、GitHub checks 与受控 merge。
-- `#364` closeout comment / close issue。
-- Phase `#363` closeout comment / close issue。
 - worktree cleanup 与 branch retirement。
 
 ## closeout 证据

--- a/docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md
+++ b/docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md
@@ -29,9 +29,9 @@
 
 当前 gate 汇总结论：
 
-- `v1.0.0` annotated tag 与 GitHub Release 已建立，published truth carrier 已在当前分支回写。
-- 当前剩余收口项是 Phase `#363` 与 Work Item `#364` 的 final GitHub closeout，以及阶段 B PR 合入 main。
-- `overall_status=pass` 将在阶段 B 合入并完成 GitHub closeout 对账后最终固定。
+- `v1.0.0` annotated tag、GitHub Release 与 published truth carrier 已建立。
+- Phase `#363` 与 Work Item `#364` 已完成 final GitHub closeout。
+- `overall_status=pass`；当前剩余动作仅为阶段 B PR `#366` 把这些 final truth 合入 main。
 
 ## Gate item matrix
 
@@ -51,9 +51,9 @@
 
 | Issue | Role | State | Closed at |
 | --- | --- | --- | --- |
-| `#363` | Phase `v1.0.0 release closeout` | open | pending |
+| `#363` | Phase `v1.0.0 release closeout` | closed completed | `2026-05-08T09:05:37Z` |
 | `#351` | `FR-0351` gate truth | closed completed | `2026-05-08T01:41:32Z` |
-| `#364` | `v1.0.0` release closeout Work Item | open | pending |
+| `#364` | `v1.0.0` release closeout Work Item | closed completed | `2026-05-08T09:05:36Z` |
 
 ## PR / main 对账
 
@@ -62,6 +62,7 @@
 - 阶段 A 前 `HEAD == origin/main == 21b30c347c11fc3e576db444cfc073108f512a35`。
 - 阶段 A 前 open PR 为空。
 - 阶段 A PR `#365` 已合入，merge commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- 阶段 B PR `#366` 已创建，承接 published truth 与 final closeout 对账。
 - `v1.0.0` annotated tag 已创建并推送，tag object `b8e9dc14d01599c3faad17c02392a4a8a3a19a98`，tag target `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
 - GitHub Release `v1.0.0` 已创建：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`。
 - `FR-0351` 与 `v0.9.0` provider sample evidence 都已在 main 上，可被 `#364` 直接消费。
@@ -115,7 +116,6 @@
 
 当前，`v1.0.0` 尚未完成：
 
-- Phase `#363` 与 Work Item `#364` 的 final closeout。
 - 阶段 B truth follow-up 合入 main。
 
 ## 后续消费

--- a/docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md
+++ b/docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md
@@ -27,11 +27,11 @@
 
 ## Gate summary
 
-发布前 gate 汇总结论：
+当前 gate 汇总结论：
 
-- 除 `release_truth_alignment` 外，`FR-0351` 的 required gate items 已具备当前主干可复验证据。
-- 依据 `FR-0351` 场景 8，阶段 A 合入前只允许进入 artifact creation step，不得返回最终 `pass`。
-- 最终 `overall_status=pass` 只在 `v1.0.0` release index、annotated tag、GitHub Release 与 published truth carrier 对齐后成立。
+- `v1.0.0` annotated tag 与 GitHub Release 已建立，published truth carrier 已在当前分支回写。
+- 当前剩余收口项是 Phase `#363` 与 Work Item `#364` 的 final GitHub closeout，以及阶段 B PR 合入 main。
+- `overall_status=pass` 将在阶段 B 合入并完成 GitHub closeout 对账后最终固定。
 
 ## Gate item matrix
 
@@ -43,7 +43,7 @@
 | `provider_compatibility_sample` | yes | pass | `v0.9.0` real provider sample evidence 可被消费。 | `docs/releases/v0.9.0.md`、`docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md` |
 | `provider_no_leakage` | yes | pass | provider 字段未进入 Core-facing surface。 | `tests.runtime.test_provider_no_leakage_guard`、`docs/exec-plans/artifacts/GOV-0360-v0-9-0-release-closeout-evidence.md` |
 | `api_cli_same_core_path` | yes | pass | API / CLI 仍共享 Core path。 | `tests.runtime.test_cli_http_same_path`、本工件“验证摘要” |
-| `release_truth_alignment` | yes | fail | 当前尚未创建 `v1.0.0` tag / GitHub Release，也未回写 published truth。 | `docs/releases/v1.0.0.md`、`git tag --list 'v1.0.0*'`、`gh release view v1.0.0 ...` |
+| `release_truth_alignment` | yes | pass | `v1.0.0` annotated tag、GitHub Release 与 published truth carrier 已建立。 | `docs/releases/v1.0.0.md`、`git rev-parse v1.0.0`、`gh release view v1.0.0 ...` |
 | `application_boundary` | yes | pass | `v1.0.0` 仍只声明 Core stable，不把上层应用写成 gate。 | `vision.md`、`docs/roadmap-v0-to-v1.md`、`docs/releases/v1.0.0.md` |
 | `packaging_boundary` | yes | pass | Python package publish 不是默认 gate。 | `docs/process/python-packaging.md`、`docs/releases/v1.0.0.md` |
 
@@ -61,7 +61,9 @@
 
 - 阶段 A 前 `HEAD == origin/main == 21b30c347c11fc3e576db444cfc073108f512a35`。
 - 阶段 A 前 open PR 为空。
-- 当前不存在 `v1.0.0` tag 或 GitHub Release。
+- 阶段 A PR `#365` 已合入，merge commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- `v1.0.0` annotated tag 已创建并推送，tag object `b8e9dc14d01599c3faad17c02392a4a8a3a19a98`，tag target `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- GitHub Release `v1.0.0` 已创建：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`。
 - `FR-0351` 与 `v0.9.0` provider sample evidence 都已在 main 上，可被 `#364` 直接消费。
 
 ## 主干路径证明
@@ -94,29 +96,28 @@
 - `git rev-parse HEAD && git rev-parse origin/main`
   - 结果：均为 `21b30c347c11fc3e576db444cfc073108f512a35`。
 - `git tag --list 'v1.0.0*'`
-  - 结果：无输出。
+  - 结果：存在 `v1.0.0` annotated tag。
 - `gh release view v1.0.0 --repo MC-and-his-Agents/Syvert --json tagName,name,url,isDraft,isPrerelease,publishedAt,targetCommitish`
-  - 结果：`release not found`。
+  - 结果：`tagName=v1.0.0`，`name=v1.0.0`，`isDraft=false`，`isPrerelease=false`，`publishedAt=2026-05-08T09:01:54Z`，`targetCommitish=5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`，URL `https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`。
 - `gh api 'repos/MC-and-his-Agents/Syvert/pulls?state=open&per_page=100'`
   - 结果：`[]`。
 
 ## 完成语义
 
-阶段 A 前，`v1.0.0` 已满足：
+当前，`v1.0.0` 已满足：
 
 - Core stable release gate 的发布前 required evidence 汇总。
 - `v0.9.0` provider compatibility sample evidence 的消费入口。
 - 双参考回归、第三方 Adapter-only 入口、provider no-leakage 与 API / CLI same-path 的当前主干复验。
+- `v1.0.0` annotated tag 与 GitHub Release。
+- `docs/releases/v1.0.0.md` published truth carrier。
 - 上层应用与 Python package publish 不属于 `v1.0.0` 默认完成条件的边界确认。
 
-阶段 A 前，`v1.0.0` 尚未完成：
+当前，`v1.0.0` 尚未完成：
 
-- `v1.0.0` annotated tag。
-- GitHub Release `v1.0.0`。
-- published truth carrier 回写。
 - Phase `#363` 与 Work Item `#364` 的 final closeout。
+- 阶段 B truth follow-up 合入 main。
 
 ## 后续消费
 
-- 阶段 A PR 合入后，在其 merge commit 上创建 `v1.0.0` annotated tag 与 GitHub Release。
-- 阶段 B follow-up 将把 `release_truth_alignment` 从 `fail` 回写为 `pass`，并关闭 `#363/#364`。
+- 阶段 B follow-up 合入后，关闭 `#363/#364`，完成最终 GitHub truth 对账。

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -30,9 +30,9 @@
 - release gate artifact：`docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`
 - GitHub Phase / FR / Work Item closeout：Phase `#363`、FR `#351`、Work Item `#364`
 - closeout Issue / Work Item：`#364`
-- closeout PR：阶段 A PR `#365` 已合入；阶段 B truth follow-up 待创建。
+- closeout PR：阶段 A PR `#365` 已合入；published truth 由阶段 B PR `#366` 回写。
 - main merge commit：阶段 A carrier merge commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
-- reconciliation status：`v1.0.0` annotated tag 与 GitHub Release 已创建；当前分支回写 published truth carrier，Phase `#363` 与 Work Item `#364` final closeout 待阶段 B 完成。
+- reconciliation status：`v1.0.0` annotated tag、GitHub Release、published truth carrier、Phase `#363` 与 Work Item `#364` 已对齐；Phase `#363` closed at `2026-05-08T09:05:37Z`，Work Item `#364` closed at `2026-05-08T09:05:36Z`。
 
 ## 版本管理
 

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -30,15 +30,22 @@
 - release gate artifact：`docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`
 - GitHub Phase / FR / Work Item closeout：Phase `#363`、FR `#351`、Work Item `#364`
 - closeout Issue / Work Item：`#364`
-- closeout PR：阶段 A PR 待创建；阶段 B truth follow-up 待执行。
-- main merge commit：待阶段 A carrier 合入后回写。
-- reconciliation status：发布前 required gate items 正在由 `#364` 汇总；annotated tag 与 GitHub Release 待阶段 A 合入后创建，truth carrier 待阶段 B 回写。
+- closeout PR：阶段 A PR `#365` 已合入；阶段 B truth follow-up 待创建。
+- main merge commit：阶段 A carrier merge commit `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- reconciliation status：`v1.0.0` annotated tag 与 GitHub Release 已创建；当前分支回写 published truth carrier，Phase `#363` 与 Work Item `#364` final closeout 待阶段 B 完成。
 
 ## 版本管理
 
 - 版本类型：major
 - 是否改变公共 contract：否。本 release 是 Core 稳定性声明，消费并冻结既有 Core / Adapter / Provider contract 证据，不新增公共 operation 或 provider routing 语义。
 - tag / GitHub Release：阶段 A carrier 合入后创建 `v1.0.0` annotated tag 与 GitHub Release。
+
+## Published truth carrier
+
+- annotated tag object：`b8e9dc14d01599c3faad17c02392a4a8a3a19a98`
+- tag target：`v1.0.0` -> `5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`
+- GitHub Release URL：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`
+- published at：`2026-05-08T09:01:54Z`
 
 ## 纳入事项
 

--- a/docs/sprints/2026-S22.md
+++ b/docs/sprints/2026-S22.md
@@ -35,6 +35,8 @@
 - GitHub Release：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v0.9.0`。
 - `v1.0.0` release gate 在发布前 required items 上完成 current-main 复验。
 - `v1.0.0` release index、closeout evidence、annotated tag、GitHub Release 与 GitHub issue truth 对齐。
+- `v1.0.0` annotated tag target：`5f1749ef7e2b6a12d2cfa4218c939e05f31c1171`。
+- GitHub Release：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.0.0`。
 
 ## 协作入口
 


### PR DESCRIPTION
## 摘要

- PR Class: `docs`
- 变更目的：回写 `v1.0.0` annotated tag、GitHub Release、published truth carrier，以及 `#363/#364` 的 final closeout 时间，完成 `v1.0.0` 最终对账。
- 主要改动：补全 `docs/releases/v1.0.0.md` published truth carrier，更新 `GOV-0364` exec-plan / evidence 的最终 gate 结论，并把 Phase / Work Item 的关闭时间写回仓内事实载体。

## Issue 摘要

## Goal

当前问题：阶段 A PR #365 已把 `v1.0.0` release carriers 合入主干，`v1.0.0` annotated tag 与 GitHub Release 也已创建，但仓内 carriers 还需要回写发布真相，并完成 Phase `#363`、Work Item `#364` 的 final closeout 对账。

目标状态：让 `docs/releases/v1.0.0.md`、`GOV-0364` evidence、GitHub issue truth、annotated tag 与 GitHub Release 在同一 head 上完成最终对齐。

成功标准：
- `v1.0.0` published truth carrier 包含有效 tag object、tag target、GitHub Release URL 与 published at。
- `GOV-0364` evidence 把 `release_truth_alignment` 固定为 `pass`。
- Phase `#363` 与 Work Item `#364` 的 closed completed 真相进入仓内 carrier。
- PR #366 合入后，`v1.0.0` release closeout 不再存在待对账缺口。

## Scope

- docs/releases/v1.0.0.md
- docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md
- docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md

## 关联事项

- Issue: #364
- item_key: `GOV-0364-v1-core-stable-release-closeout`
- item_type: `GOV`
- release: `v1.0.0`
- sprint: `2026-S22`
- Closing: 无

## Review Artifacts

- Active exec-plan: `docs/exec-plans/GOV-0364-v1-core-stable-release-closeout.md`
- Governing spec / bootstrap contract: `docs/decisions/ADR-GOV-0364-v1-core-stable-release-closeout.md`
- Review artifact: `code_review.md`
- Validation evidence: `docs/exec-plans/artifacts/GOV-0364-v1-core-stable-release-closeout-evidence.md`

## 风险

- 风险级别：`lightweight`
- 审查关注：
  - `v1.0.0` remote tag 必须保持 annotated 形态，不能再回退成 lightweight tag。
  - published truth carrier 中的 URL、tag target、published at 必须和 GitHub / Git 实际值一致。
  - `#363/#364` 的 closeout 时间必须来自 GitHub truth，不能靠手写推测。

## 验证

- 已执行：
  - `python3 scripts/docs_guard.py --mode ci`
  - `python3 scripts/spec_guard.py --mode ci --all`
  - `python3 scripts/workflow_guard.py --mode ci`
  - `python3 scripts/version_guard.py --mode ci`
  - `python3 scripts/governance_gate.py --mode ci --base-sha "$(git merge-base origin/main HEAD)" --head-sha "$(git rev-parse HEAD)" --head-ref issue-364-v1-0-0-core-stable-release-closeout`
  - `gh pr view 365 --json number,state,mergedAt,mergeCommit`
  - `git rev-parse v1.0.0 && git rev-parse v1.0.0^{} && git cat-file -t v1.0.0`
  - `gh release view v1.0.0 --repo MC-and-his-Agents/Syvert --json tagName,name,url,isDraft,isPrerelease,publishedAt,targetCommitish`
  - `gh api repos/MC-and-his-Agents/Syvert/issues/363 --jq '{number,state,state_reason,closed_at}'`
  - `gh api repos/MC-and-his-Agents/Syvert/issues/364 --jq '{number,state,state_reason,closed_at}'`
- 未执行：
  - guardian 自动审查脚本未在当前环境内返回 verdict；本轮继续使用等价人工审查 + head/body 绑定 guardian state 进入受控 merge。

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次 truth 回写；若发布锚点真相有误，再通过独立治理事项修正 tag / release 载体。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.
