### PR TITLE
Decouple roadmap phase from release minor

### DIFF
--- a/.loom/shadow/closeout-repo.json
+++ b/.loom/shadow/closeout-repo.json
@@ -13,7 +13,7 @@
     "WORKFLOW.md": "fbe5787e913d2844cdb30c1e79bcc759568ab34bdb68feaf2602d40ca62fbb4c",
     "docs/exec-plans/GOV-0038-loom-official-adoption.md": "8ae08b8791942383f54dc1b4bfdf382a490e0b44d1bac94204f43025bfdfc74a",
     "docs/process/delivery-funnel.md": "50df775c96610a07c536b433e7662a4b57c9443b8ade88d843492d61f684f65f",
-    "docs/process/version-management.md": "c67c887f07984127a729c9ec942017a7a6d865281eb015121898b5413e2f3733"
+    "docs/process/version-management.md": "09b28d4cbe04afe2daf43689d9d544dbd1cf76b0e0072c8bc67acc1a588d53f7"
   },
   "source_semantics": "Closeout parity requires merged delivery state, reconciled status or progress truth, and parent closeout evidence after execution completes.",
   "evidence_body": {

--- a/docs/decisions/ADR-GOV-0401-decouple-roadmap-phase-from-release-minor.md
+++ b/docs/decisions/ADR-GOV-0401-decouple-roadmap-phase-from-release-minor.md
@@ -1,0 +1,34 @@
+# ADR-GOV-0401 Decouple Roadmap Phase From Release Minor
+
+## 关联信息
+
+- Issue：`#401`
+- item_key：`GOV-0401-decouple-roadmap-phase-from-release-minor`
+- item_type：`GOV`
+- release：`v1.x`
+- sprint：`2026-S24`
+
+## Status
+
+Accepted
+
+## Decision
+
+Treat roadmap capability-track naming and release minor numbering as explicitly decoupled governance axes.
+
+This decision requires:
+
+- `docs/roadmap-v1-to-v2.md` to stop using numbered `Phase N` capability headings.
+- `docs/process/version-management.md` to state that capability track, GitHub `Phase`, FR, and Work Item cannot implicitly bind to `MINOR`.
+- `scripts/version_guard.py` and governance tests to reject reintroduction of numbered roadmap phase headings and loss of track-versus-minor semantics.
+- Existing `v1.1.0` and `v1.2.0` published release truth to remain unchanged as historical releases, not future mapping rules.
+
+## Rationale
+
+The roadmap already states that `v1.x` is not a countdown from `v1.1.0` to `v2.0.0`, and that capability streams define dependency ordering rather than release numbering. Keeping numbered `Phase N` headings leaves a persistent inference path for agents and reviewers to misread roadmap structure as a minor-version sequence. The safer governance fix is to rename the roadmap headings, strengthen the version rule, and add a mechanical guard.
+
+## Consequences
+
+- Future roadmap work cannot justify `Phase N -> v1.N` by title shape alone.
+- Release numbering stays a closeout decision, not a roadmap-heading side effect.
+- Historical `v1.1.0` and `v1.2.0` releases remain published truth without being elevated into a standing mapping convention.

--- a/docs/exec-plans/GOV-0401-decouple-roadmap-phase-from-release-minor.md
+++ b/docs/exec-plans/GOV-0401-decouple-roadmap-phase-from-release-minor.md
@@ -1,0 +1,52 @@
+# GOV-0401 Decouple Roadmap Phase From Release Minor
+
+## 关联信息
+
+- Issue：`#401`
+- item_key：`GOV-0401-decouple-roadmap-phase-from-release-minor`
+- item_type：`GOV`
+- release：`v1.x`
+- sprint：`2026-S24`
+- 关联 decision：`docs/decisions/ADR-GOV-0401-decouple-roadmap-phase-from-release-minor.md`
+- active 收口事项：`GOV-0401-decouple-roadmap-phase-from-release-minor`
+- 状态：`active`
+
+## 目标
+
+- 切断 roadmap capability track 与 release minor 的隐式编号映射。
+- 把现有 roadmap / version rule / CI guard 对齐到同一语义。
+- 保留 `v1.1.0`、`v1.2.0` 作为历史 release truth，不把它们上升为未来规则。
+
+## 范围
+
+- 本次纳入：
+  - `docs/roadmap-v1-to-v2.md`
+  - `docs/process/version-management.md`
+  - `scripts/version_guard.py`
+  - `tests/governance/test_version_guard.py`
+  - 当前 GOV bootstrap contract 与 active exec-plan
+- 本次不纳入：
+  - 新 capability FR 或 implementation
+  - 已发布 release truth rewrite
+  - 新 release closeout
+
+## 计划
+
+- 把 roadmap 的 numbered phase capability headings 改成 `Capability Track: ...`。
+- 在版本管理文档中写死 `track / Phase / FR / Work Item` 不得隐式映射到 `MINOR`。
+- 在 `version_guard.py` 中新增 CI 级旧标题回归门禁，并要求保留解耦语义。
+- 在治理测试中补齐正反向用例，覆盖标题回归和语义缺失。
+
+## 验证
+
+- `python3 -m unittest tests.governance.test_version_guard`
+- `python3 scripts/version_guard.py --mode ci`
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- base：`f6c101e2befe38dffb6194b8b715e40c759b0c16`
+- 当前回合尚未记录新 checkpoint head；live review head 以后续 PR `headRefOid` 与 guardian / merge gate 为准。
+
+## 回滚方式
+
+- 如本事项判断或文档表述有误，使用独立 revert PR 回滚本次治理改动。

--- a/docs/exec-plans/GOV-0401-decouple-roadmap-phase-from-release-minor.md
+++ b/docs/exec-plans/GOV-0401-decouple-roadmap-phase-from-release-minor.md
@@ -40,7 +40,13 @@
 ## 验证
 
 - `python3 -m unittest tests.governance.test_version_guard`
+  - 结果：通过，`Ran 20 tests`
 - `python3 scripts/version_guard.py --mode ci`
+  - 结果：通过，`version-guard 通过。`
+- `python3 .loom/bin/loom_flow.py shadow-parity --target . --blocking`
+  - 结果：通过，所有 declared surfaces `match`
+- `python3 scripts/governance_gate.py --mode ci --base-sha f6c101e2befe38dffb6194b8b715e40c759b0c16 --head-sha HEAD --head-ref issue-401-decouple-roadmap-phase-from-release-minor`
+  - 结果：通过，`governance-gate 通过。`
 
 ## 最近一次 checkpoint 对应的 head SHA
 

--- a/docs/process/version-management.md
+++ b/docs/process/version-management.md
@@ -22,9 +22,10 @@ Syvert 同时存在多个版本层次，它们不能互相替代：
 
 - 对外 release、roadmap milestone 与 tag 使用 `vMAJOR.MINOR.PATCH`。
 - `MAJOR` 表示一组底座契约成熟度声明，不由 minor 数字自然滚动触发。
-- `MINOR` 表示一个受控能力阶段或一组兼容扩展完成。
+- `MINOR` 表示一个受控能力阶段或一组兼容扩展完成，不是 roadmap `Phase` 或 capability `Track` 的编号映射。
 - `PATCH` 表示不改变公共 contract 的修复、回写、发布真相同步或兼容性修补。
 - Sprint、Phase、FR、Work Item 不得被当作版本号使用。
+- roadmap capability track、GitHub `Phase`、FR、Work Item 不得隐式映射到 `MINOR`，`MINOR` 仅能由 release planning、release index 或 closeout decision 显式绑定。
 - `v1.x` 表示一组 minor 序列，不表示最多只能走到 `v1.9.0`。
 - 可以存在 `v1.10.0`、`v1.11.0` 等版本；只有满足 major gate 时才进入下一个 major。
 

--- a/docs/roadmap-v1-to-v2.md
+++ b/docs/roadmap-v1-to-v2.md
@@ -74,8 +74,9 @@ Syvert 主仓继续聚焦：
 | Stabilization | 何时可以宣布扩展能力契约稳定 | 全部关键能力流的成熟度 gate |
 
 任何能力流进入执行前，都必须通过 GitHub Phase / FR / Work Item 与正式规约流程确认。路线图只定义方向和依赖，不直接创建 backlog truth。
+能力流（track）是实现顺序提示，不是 `MINOR` 映射依据。`MINOR` 只由 release planning、release index 与 closeout 决策显式绑定。
 
-## Phase 1 Operation Taxonomy
+## Capability Track: Operation Taxonomy
 
 ### 目标
 
@@ -133,7 +134,7 @@ Syvert 主仓继续聚焦：
 - 平台私有业务对象直接进入 Core
 - provider selector / fallback / marketplace
 
-## Phase 2 Resource Governance
+## Capability Track: Resource Governance
 
 ### 目标
 
@@ -189,7 +190,7 @@ Syvert 主仓继续聚焦：
 - 平台账号画像产品模型
 - 平台私有风控策略进入 Core
 
-## Phase 3 Read-Side Capabilities
+## Capability Track: Read-Side Capabilities
 
 ### 目标
 
@@ -248,7 +249,7 @@ Syvert 主仓继续聚焦：
 - 数据分析产品
 - 选题策略或运营策略
 
-## Phase 4 Batch And Dataset
+## Capability Track: Batch And Dataset
 
 ### 目标
 
@@ -296,7 +297,7 @@ Syvert 主仓继续聚焦：
 - BI / 报表 / 监控看板
 - 上层采集任务配置 UI
 
-## Phase 5 Scheduled Execution
+## Capability Track: Scheduled Execution
 
 ### 目标
 
@@ -344,7 +345,7 @@ Syvert 主仓继续聚焦：
 - 多步骤业务 workflow DSL
 - 产品级任务编排 UI
 
-## Phase 6 Write-Side Capabilities
+## Capability Track: Write-Side Capabilities
 
 ### 目标
 
@@ -403,7 +404,7 @@ Syvert 主仓继续聚焦：
 - 平台运营策略
 - 未经安全门禁的自动写入
 
-## Phase 7 Ecosystem Boundary
+## Capability Track: Ecosystem Boundary
 
 ### 目标
 

--- a/scripts/version_guard.py
+++ b/scripts/version_guard.py
@@ -36,6 +36,11 @@ FORBIDDEN_POSITIONING_PHRASES = (
     "Syvert Application Platform GA",
     "应用平台 GA",
 )
+ROADMAP_PHASE_HEADING_RE = re.compile(r"^##\s+Phase\s+\d+\b", re.MULTILINE | re.IGNORECASE)
+ROADMAP_TRACK_MINOR_HINTS = (
+    "能力流（track）是实现顺序提示，不是 `MINOR` 映射依据。",
+    "`MINOR` 只由 release planning、release index 与 closeout 决策显式绑定。",
+)
 
 
 def read_text(path: Path) -> str:
@@ -214,6 +219,7 @@ def validate_version_management_doc(repo_root: Path) -> list[str]:
     content = read_text(path)
     required = (
         "vMAJOR.MINOR.PATCH",
+        "不得隐式映射到 `MINOR`",
         "v1.10.0",
         "v1.9.0",
         "GitHub Release",
@@ -264,9 +270,29 @@ def validate_roadmap_refs(repo_root: Path) -> list[str]:
 
     if roadmap_v1.exists():
         content = read_text(roadmap_v1)
-        for item in ("docs/process/version-management.md", "Stabilization Gate", "v1.10.0", "runtime capability contract"):
+        for item in (
+            "docs/process/version-management.md",
+            "Stabilization Gate",
+            "v1.10.0",
+            "runtime capability contract",
+            *ROADMAP_TRACK_MINOR_HINTS,
+        ):
             if item not in content:
                 errors.append(f"`docs/roadmap-v1-to-v2.md` 缺少 v1.x 到 v2.0.0 关键语义：`{item}`")
+
+    return errors
+
+
+def validate_roadmap_track_title_guard(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+    roadmap_v1 = require_file(repo_root, "docs/roadmap-v1-to-v2.md", errors)
+    if not roadmap_v1.exists():
+        return errors
+
+    content = read_text(roadmap_v1)
+    for match in ROADMAP_PHASE_HEADING_RE.finditer(content):
+        heading = match.group(0).strip()
+        errors.append(f"`docs/roadmap-v1-to-v2.md` 不得出现旧版 `Phase N` 能力标题：`{heading}`")
 
     return errors
 
@@ -313,7 +339,7 @@ def validate_forbidden_positioning(repo_root: Path) -> list[str]:
     return errors
 
 
-def validate_repository(repo_root: Path) -> list[str]:
+def validate_repository(repo_root: Path, strict_ci: bool = False) -> list[str]:
     errors: list[str] = []
     errors.extend(validate_version_management_doc(repo_root))
     errors.extend(validate_python_packaging_doc(repo_root))
@@ -321,6 +347,8 @@ def validate_repository(repo_root: Path) -> list[str]:
     errors.extend(validate_release_docs(repo_root))
     errors.extend(validate_workflow(repo_root))
     errors.extend(validate_forbidden_positioning(repo_root))
+    if strict_ci:
+        errors.extend(validate_roadmap_track_title_guard(repo_root))
     return errors
 
 
@@ -334,7 +362,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     repo_root = Path(args.repo_root).resolve()
-    errors = validate_repository(repo_root)
+    errors = validate_repository(repo_root, strict_ci=args.mode == "ci")
     if errors:
         for error in errors:
             print(error, file=sys.stderr)

--- a/tests/governance/test_version_guard.py
+++ b/tests/governance/test_version_guard.py
@@ -17,6 +17,7 @@ def write_valid_version_fixture(repo: Path) -> None:
         repo / "docs/process/version-management.md",
         """# Syvert Version Management
 
+不得隐式映射到 `MINOR`
 vMAJOR.MINOR.PATCH
 v1.10.0
 v1.9.0
@@ -60,6 +61,8 @@ docs/process/version-management.md
 Stabilization Gate
 v1.10.0
 runtime capability contract
+能力流（track）是实现顺序提示，不是 `MINOR` 映射依据。
+`MINOR` 只由 release planning、release index 与 closeout 决策显式绑定。
 """,
     )
     write(
@@ -174,6 +177,58 @@ class VersionGuardTests(unittest.TestCase):
             errors = validate_repository(repo)
 
         self.assertTrue(any("docs/process/python-packaging.md" in error for error in errors))
+
+    def test_version_management_must_state_minors_are_explicitly_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            write_valid_version_fixture(repo)
+            content = (repo / "docs/process/version-management.md").read_text(encoding="utf-8")
+            content = content.replace("不得隐式映射到 `MINOR`\n", "")
+            (repo / "docs/process/version-management.md").write_text(content, encoding="utf-8")
+
+            errors = validate_repository(repo)
+
+        self.assertTrue(any("不得隐式映射到 `MINOR`" in error for error in errors))
+
+    def test_roadmap_must_preserve_track_minor_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            write_valid_version_fixture(repo)
+            content = (repo / "docs/roadmap-v1-to-v2.md").read_text(encoding="utf-8")
+            content = content.replace(
+                "能力流（track）是实现顺序提示，不是 `MINOR` 映射依据。\n"
+                "`MINOR` 只由 release planning、release index 与 closeout 决策显式绑定。\n",
+                "",
+            )
+            (repo / "docs/roadmap-v1-to-v2.md").write_text(content, encoding="utf-8")
+
+            errors = validate_repository(repo, strict_ci=True)
+
+        self.assertTrue(any("缺少 v1.x 到 v2.0.0 关键语义" in error for error in errors))
+
+    def test_ci_mode_rejects_phase_headings(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            write_valid_version_fixture(repo)
+            content = (repo / "docs/roadmap-v1-to-v2.md").read_text(encoding="utf-8")
+            content = content + "\n\n## Phase 1 Operation Taxonomy\n"
+            (repo / "docs/roadmap-v1-to-v2.md").write_text(content, encoding="utf-8")
+
+            errors = validate_repository(repo, strict_ci=True)
+
+        self.assertTrue(any("Phase 1" in error or "Phase N" in error for error in errors))
+
+    def test_ci_mode_allows_capability_track_headings(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            write_valid_version_fixture(repo)
+            content = (repo / "docs/roadmap-v1-to-v2.md").read_text(encoding="utf-8")
+            content = content + "\n\n## Capability Track: Operation Taxonomy\n"
+            (repo / "docs/roadmap-v1-to-v2.md").write_text(content, encoding="utf-8")
+
+            errors = validate_repository(repo, strict_ci=True)
+
+        self.assertEqual(errors, [])
 
     def test_template_style_release_index_does_not_require_truth_carrier(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## 摘要

- PR Class: `governance`
- 变更目的：
- 主要改动：

## Issue 摘要

## Goal

Decouple roadmap capability track ordering from release minor numbering so agents cannot infer `Phase N -> v1.N` from roadmap structure alone.

## Scope

- Rename roadmap capability headings away from numbered `Phase N` titles.
- Strengthen version management rules so capability track / GitHub Phase / FR / Work Item cannot implicitly bind to `MINOR`.
- Extend `version_guard.py` and governance tests to reject reintroduction of numbered roadmap phase headings and missing track-vs-minor semantics.

## Acceptance

- `docs/roadmap-v1-to-v2.md` no longer uses `## Phase N` capability headings.
- `docs/process/version-management.md` explicitly forbids implicit capability-track / Phase to `MINOR` mapping.
- `python3 scripts/version_guard.py --mode ci` rejects reintroducing `## Phase 1` style headings in `docs/roadmap-v1-to-v2.md`.
- Existing `v1.1.0` and `v1.2.0` release truth remains unchanged.

## Out of Scope

- Read-side capability implementation.
- Release history rewrite.
- New release closeout work.

## Dependency

- `docs/roadmap-v1-to-v2.md`
- `docs/process/version-management.md`
- `scripts/version_guard.py`
- `tests/governance/test_version_guard.py`

## 关联事项

- Issue: #401
- item_key: `GOV-0401-decouple-roadmap-phase-from-release-minor`
- item_type: `GOV`
- release: `v1.x`
- sprint: `2026-S24`
- Closing: Fixes #401

## Review Artifacts

- Active exec-plan: `docs/exec-plans/GOV-0401-decouple-roadmap-phase-from-release-minor.md`
- Governing spec / bootstrap contract: `docs/decisions/ADR-GOV-0401-decouple-roadmap-phase-from-release-minor.md`
- Review artifact: `code_review.md`
- Validation evidence: `python3.11 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref issue-401-decouple-roadmap-phase-from-release-minor`
## 风险

- 风险级别：`high`
- 审查关注：

## 验证

- 已执行：
- 未执行：

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: none
- shared_contract_changed: no
- integration_ref: none
- external_dependency: none
- merge_gate: local_only
- contract_surface: none
- joint_acceptance_needed: no
- integration_status_checked_before_pr: no
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.
