### PR TITLE
CHORE-0408: v1.3.0 read-side collection runtime carrier

### DIFF
--- a/docs/exec-plans/CHORE-0408-v1-3-0-read-side-collection-runtime.md
+++ b/docs/exec-plans/CHORE-0408-v1-3-0-read-side-collection-runtime.md
@@ -1,0 +1,81 @@
+# CHORE-0408 v1.3 read-side collection runtime carrier 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0408-v1-3-0-read-side-collection-runtime`
+- Issue：`#408`
+- item_type：`CHORE`
+- release：`v1.3.0`
+- sprint：`2026-S25`
+- Parent Phase：`#381`
+- Parent FR：`#403`
+- 关联 spec：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/spec.md`
+- 关联 decision：
+- 关联 PR：`#412`
+- 状态：`active`
+- active 收口事项：`CHORE-0408-v1-3-0-read-side-collection-runtime`
+
+## 目标
+
+- 实现 #408 指定的 read-side collection runtime carrier，共享 result/continuation/item envelope。
+- 将 `content_search_by_keyword` 与 `content_list_by_creator` 作为 runtime stable operation 纳入 taxonomy。
+- 将新 carrier 纳入 platform leakage 扫描和 version_gate 证据基线。
+- 覆盖对应 runtime fake/adaptor 回归测试。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/read_side_collection.py`
+  - `syvert/operation_taxonomy.py`
+  - `syvert/platform_leakage.py`
+  - `syvert/version_gate.py`
+  - `tests/runtime/test_read_side_collection.py`
+  - 相关 runtime/platform/leakage/version-gate 测试修正。
+- 本次不纳入：
+  - TaskRecord/result query/compatibility consumers 迁移（#409）
+  - fixture/evidence closeout（#410）
+  - release/sprint/FR closeout（#411）
+
+## 当前停点
+
+- Issue `#408` 仍处于 runtime carrier 实施收口。
+- Worktree key：`issue-408-403-v1-3-0-read-side-collection-runtime`
+- Branch：`issue-408-403-v1-3-0-read-side-collection-runtime`
+- 最新基线提交：`87b783de578d7646d1ab69f27f898f5379579ae0`
+
+## 下一步动作
+
+- 等待 PR #412 完成治理门禁并进入 merge-ready。
+- 按链路继续推进 #409/#410/#411。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v1.3.0` 首批 read-side collection runtime contract 提供 carrier 契约与扫描基线对齐。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`#403` run-time carrier 执行子切片。
+- 阻塞：在 #409/#410/#411 审批前，不得将此 PR 合并进主线。
+
+## 已验证项
+
+- `python3 -m unittest tests.runtime.test_read_side_collection tests.runtime.test_operation_taxonomy tests.runtime.test_platform_leakage tests.runtime.test_real_adapter_regression tests.runtime.test_cli_http_same_path`
+- `python3 -m unittest tests.runtime.test_version_gate`
+- `python3 scripts/spec_guard.py --mode ci --all`
+- `python3 scripts/docs_guard.py --mode ci`
+- `python3 scripts/workflow_guard.py --mode ci`
+- `python3 scripts/version_guard.py --mode ci`
+- `git diff --check`
+
+## 未决风险
+
+- 缺少 #409/#410/#411 的执行快照会导致 `#408` 不能直接声明全量完成。
+- #412 若受限于外部 GitHub issue 上下文（如 exec-plan 授权）可导致受控合并被阻断。
+
+## 回滚方式
+
+- 使用 revert PR 回退本 PR 所有 runtime 实现与扫描/测试变更。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `87b783de578d7646d1ab69f27f898f5379579ae0`

--- a/syvert/operation_taxonomy.py
+++ b/syvert/operation_taxonomy.py
@@ -113,6 +113,38 @@ STABLE_CONTENT_DETAIL_ENTRY = OperationTaxonomyEntry(
     notes=("v1.0.0 stable baseline; must not be rewritten by proposed candidates.",),
 )
 
+STABLE_CONTENT_SEARCH_BY_KEYWORD_ENTRY = OperationTaxonomyEntry(
+    capability_family="content_search",
+    operation="content_search_by_keyword",
+    target_type="keyword",
+    execution_mode="single",
+    collection_mode="paginated",
+    lifecycle=CAPABILITY_LIFECYCLE_STABLE,
+    runtime_delivery=True,
+    contract_refs=("FR-0403",),
+    admission_evidence_refs=(
+        "tests.runtime.test_read_side_collection",
+        "tests.runtime.test_operation_taxonomy_admission_evidence",
+    ),
+    notes=("v1.3.0 runtime contract frozen; collection continuation + envelope shared shape.",),
+)
+
+STABLE_CONTENT_LIST_BY_CREATOR_ENTRY = OperationTaxonomyEntry(
+    capability_family="content_list",
+    operation="content_list_by_creator",
+    target_type="creator",
+    execution_mode="single",
+    collection_mode="paginated",
+    lifecycle=CAPABILITY_LIFECYCLE_STABLE,
+    runtime_delivery=True,
+    contract_refs=("FR-0403",),
+    admission_evidence_refs=(
+        "tests.runtime.test_read_side_collection",
+        "tests.runtime.test_operation_taxonomy_admission_evidence",
+    ),
+    notes=("v1.3.0 runtime contract frozen; collection continuation + envelope shared shape.",),
+)
+
 PROPOSED_OPERATION_TAXONOMY_ENTRIES = (
     OperationTaxonomyEntry(
         capability_family="content_search",
@@ -238,6 +270,8 @@ PROPOSED_OPERATION_TAXONOMY_ENTRIES = (
 
 DEFAULT_OPERATION_TAXONOMY = (
     STABLE_CONTENT_DETAIL_ENTRY,
+    STABLE_CONTENT_SEARCH_BY_KEYWORD_ENTRY,
+    STABLE_CONTENT_LIST_BY_CREATOR_ENTRY,
     *PROPOSED_OPERATION_TAXONOMY_ENTRIES,
 )
 

--- a/syvert/platform_leakage.py
+++ b/syvert/platform_leakage.py
@@ -35,6 +35,10 @@ _SCAN_TARGETS = (
         "relative_path": Path("syvert/operation_taxonomy.py"),
         "default_boundary": "shared_input_model",
     },
+    {
+        "relative_path": Path("syvert/read_side_collection.py"),
+        "default_boundary": "shared_result_contract",
+    },
 )
 
 _RUNTIME_SYMBOL_BOUNDARIES = {

--- a/syvert/read_side_collection.py
+++ b/syvert/read_side_collection.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from typing import Any
+
+READ_SIDE_COLLECTION_RESULT_STATUSES = frozenset(
+    {
+        "complete",
+        "empty",
+        "partial_result",
+    }
+)
+
+COLLECTION_ERROR_CLASSIFICATIONS = frozenset(
+    {
+        "empty_result",
+        "target_not_found",
+        "rate_limited",
+        "permission_denied",
+        "platform_failed",
+        "provider_or_network_blocked",
+        "cursor_invalid_or_expired",
+        "parse_failed",
+        "partial_result",
+        "credential_invalid",
+        "verification_required",
+        "signature_or_request_invalid",
+    }
+)
+
+READ_SIDE_COLLECTION_OPERATIONS = frozenset(
+    {
+        "content_search_by_keyword",
+        "content_list_by_creator",
+    }
+)
+
+RFC3339_TIMESTAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+class CollectionContractError(ValueError):
+    def __init__(self, code: str, message: str, *, details: Mapping[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = dict(details or {})
+
+
+@dataclass(frozen=True)
+class SourceTrace:
+    adapter_key: str
+    provider_path: str
+    fetched_at: str
+    evidence_alias: str
+    resource_profile_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class CollectionTarget:
+    operation: str
+    target_type: str
+    target_ref: str
+    target_display_hint: str | None = None
+    policy_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class CollectionContinuation:
+    continuation_token: str
+    continuation_family: str
+    resume_target_ref: str
+    issued_at: str | None = None
+
+
+@dataclass(frozen=True)
+class NormalizedCollectionItem:
+    source_platform: str
+    source_type: str
+    source_id: str
+    canonical_ref: str
+    title_or_text_hint: str
+    creator_ref: str | None = None
+    published_at: str | None = None
+    media_refs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CollectionItemEnvelope:
+    item_type: str
+    dedup_key: str
+    source_id: str
+    source_ref: str
+    normalized: NormalizedCollectionItem
+    raw_payload_ref: str
+    source_trace: SourceTrace
+
+
+@dataclass(frozen=True)
+class CollectionResultEnvelope:
+    operation: str
+    target: CollectionTarget
+    items: tuple[CollectionItemEnvelope, ...]
+    has_more: bool
+    next_continuation: CollectionContinuation | None
+    result_status: str
+    error_classification: str
+    raw_payload_ref: str
+    source_trace: SourceTrace
+    audit: Mapping[str, Any]
+
+
+def _contract_error(code: str, message: str, *, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return {"code": code, "message": message, "details": dict(details or {})}
+
+
+def _ensure_mapping(payload: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 必须是对象",
+            details={"field": field_name, "type": type(payload).__name__},
+        )
+    return payload
+
+
+def _ensure_non_empty_string(payload: Any, field_name: str) -> str:
+    if not isinstance(payload, str) or not payload.strip():
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 必须为非空字符串",
+            details={"field": field_name},
+        )
+    return payload
+
+
+def _ensure_optional_non_empty_string(payload: Any, field_name: str) -> str | None:
+    if payload is None:
+        return None
+    return _ensure_non_empty_string(payload, field_name)
+
+
+def _ensure_bool(payload: Any, field_name: str) -> bool:
+    if not isinstance(payload, bool):
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 必须为布尔值",
+            details={"field": field_name},
+        )
+    return payload
+
+
+def _ensure_tuple_of_non_empty_strings(payload: Any, field_name: str) -> tuple[str, ...]:
+    if payload is None:
+        return ()
+    if not isinstance(payload, (tuple, list)):
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 必须为字符串数组",
+            details={"field": field_name},
+        )
+    values = tuple(payload)
+    for index, value in enumerate(values):
+        if not isinstance(value, str) or not value.strip():
+            raise CollectionContractError(
+                "parse_failed",
+                f"{field_name}[{index}] 必须为非空字符串",
+                details={"field": f"{field_name}[{index}]"},
+            )
+    return values
+
+
+def _ensure_rfc3339_timestamp(payload: Any, field_name: str) -> str:
+    value = _ensure_non_empty_string(payload, field_name)
+    if not RFC3339_TIMESTAMP_RE.fullmatch(value):
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 必须为 RFC3339 时间戳",
+            details={"field": field_name},
+        )
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 无法按 RFC3339 解析",
+            details={"field": field_name, "python_error": error.__class__.__name__},
+        )
+    return value
+
+
+def _ensure_strict_fields(
+    payload: Mapping[str, Any],
+    *,
+    field_name: str,
+    required: tuple[str, ...],
+    allowed: tuple[str, ...] | frozenset[str],
+) -> None:
+    missing = [name for name in required if name not in payload]
+    if missing:
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 缺少字段: {', '.join(missing)}",
+            details={"field": field_name, "missing_fields": tuple(missing)},
+        )
+    unknown = tuple(sorted(set(payload) - set(allowed)))
+    if unknown:
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 包含未知字段",
+            details={"field": field_name, "unknown_fields": unknown},
+        )
+
+
+def _read_source_trace(payload: Any, *, field_name: str) -> SourceTrace:
+    raw_trace = _ensure_mapping(payload, field_name=field_name)
+    _ensure_strict_fields(
+        raw_trace,
+        field_name=field_name,
+        required=("adapter_key", "provider_path", "fetched_at", "evidence_alias"),
+        allowed=(
+            "adapter_key",
+            "provider_path",
+            "resource_profile_ref",
+            "fetched_at",
+            "evidence_alias",
+        ),
+    )
+    return SourceTrace(
+        adapter_key=_ensure_non_empty_string(raw_trace["adapter_key"], f"{field_name}.adapter_key"),
+        provider_path=_ensure_non_empty_string(raw_trace["provider_path"], f"{field_name}.provider_path"),
+        resource_profile_ref=_ensure_optional_non_empty_string(
+            raw_trace.get("resource_profile_ref"),
+            f"{field_name}.resource_profile_ref",
+        ),
+        fetched_at=_ensure_rfc3339_timestamp(raw_trace["fetched_at"], f"{field_name}.fetched_at"),
+        evidence_alias=_ensure_non_empty_string(raw_trace["evidence_alias"], f"{field_name}.evidence_alias"),
+    )
+
+
+def _read_target(payload: Any, *, field_name: str) -> CollectionTarget:
+    raw_target = _ensure_mapping(payload, field_name=field_name)
+    _ensure_strict_fields(
+        raw_target,
+        field_name=field_name,
+        required=("operation", "target_type", "target_ref"),
+        allowed=(
+            "operation",
+            "target_type",
+            "target_ref",
+            "target_display_hint",
+            "policy_ref",
+        ),
+    )
+    target = CollectionTarget(
+        operation=_ensure_non_empty_string(raw_target["operation"], f"{field_name}.operation"),
+        target_type=_ensure_non_empty_string(raw_target["target_type"], f"{field_name}.target_type"),
+        target_ref=_ensure_non_empty_string(raw_target["target_ref"], f"{field_name}.target_ref"),
+        target_display_hint=_ensure_optional_non_empty_string(
+            raw_target.get("target_display_hint"),
+            f"{field_name}.target_display_hint",
+        ),
+        policy_ref=_ensure_optional_non_empty_string(raw_target.get("policy_ref"), f"{field_name}.policy_ref"),
+    )
+    if target.operation == "content_search_by_keyword" and target.target_type != "keyword":
+        raise CollectionContractError(
+            "parse_failed",
+            "content_search_by_keyword 的 target_type 必须为 keyword",
+            details={"field": f"{field_name}.target_type", "value": target.target_type},
+        )
+    if target.operation == "content_list_by_creator" and target.target_type != "creator":
+        raise CollectionContractError(
+            "parse_failed",
+            "content_list_by_creator 的 target_type 必须为 creator",
+            details={"field": f"{field_name}.target_type", "value": target.target_type},
+        )
+    return target
+
+
+def _read_continuation(payload: Any, *, field_name: str) -> CollectionContinuation | None:
+    if payload is None:
+        return None
+    raw_continuation = _ensure_mapping(payload, field_name=field_name)
+    _ensure_strict_fields(
+        raw_continuation,
+        field_name=field_name,
+        required=("continuation_token", "continuation_family", "resume_target_ref"),
+        allowed=(
+            "continuation_token",
+            "continuation_family",
+            "resume_target_ref",
+            "issued_at",
+        ),
+    )
+    return CollectionContinuation(
+        continuation_token=_ensure_non_empty_string(
+            raw_continuation["continuation_token"], f"{field_name}.continuation_token"
+        ),
+        continuation_family=_ensure_non_empty_string(
+            raw_continuation["continuation_family"], f"{field_name}.continuation_family"
+        ),
+        resume_target_ref=_ensure_non_empty_string(
+            raw_continuation["resume_target_ref"], f"{field_name}.resume_target_ref"
+        ),
+        issued_at=_ensure_optional_non_empty_string(raw_continuation.get("issued_at"), f"{field_name}.issued_at"),
+    )
+
+
+def _read_normalized_item(payload: Any, *, field_name: str) -> NormalizedCollectionItem:
+    raw_item = _ensure_mapping(payload, field_name=field_name)
+    _ensure_strict_fields(
+        raw_item,
+        field_name=field_name,
+        required=(
+            "source_platform",
+            "source_type",
+            "source_id",
+            "canonical_ref",
+            "title_or_text_hint",
+        ),
+        allowed=(
+            "source_platform",
+            "source_type",
+            "source_id",
+            "canonical_ref",
+            "title_or_text_hint",
+            "creator_ref",
+            "published_at",
+            "media_refs",
+        ),
+    )
+    published_at = _ensure_optional_non_empty_string(raw_item.get("published_at"), f"{field_name}.published_at")
+    if published_at is not None:
+        _ensure_rfc3339_timestamp(published_at, f"{field_name}.published_at")
+    return NormalizedCollectionItem(
+        source_platform=_ensure_non_empty_string(raw_item["source_platform"], f"{field_name}.source_platform"),
+        source_type=_ensure_non_empty_string(raw_item["source_type"], f"{field_name}.source_type"),
+        source_id=_ensure_non_empty_string(raw_item["source_id"], f"{field_name}.source_id"),
+        canonical_ref=_ensure_non_empty_string(raw_item["canonical_ref"], f"{field_name}.canonical_ref"),
+        title_or_text_hint=_ensure_non_empty_string(raw_item["title_or_text_hint"], f"{field_name}.title_or_text_hint"),
+        creator_ref=_ensure_optional_non_empty_string(raw_item.get("creator_ref"), f"{field_name}.creator_ref"),
+        published_at=published_at,
+        media_refs=_ensure_tuple_of_non_empty_strings(raw_item.get("media_refs"), f"{field_name}.media_refs"),
+    )
+
+
+def _read_item(payload: Any, *, field_name: str) -> CollectionItemEnvelope:
+    raw_item = _ensure_mapping(payload, field_name=field_name)
+    _ensure_strict_fields(
+        raw_item,
+        field_name=field_name,
+        required=(
+            "item_type",
+            "dedup_key",
+            "source_id",
+            "source_ref",
+            "normalized",
+            "raw_payload_ref",
+            "source_trace",
+        ),
+        allowed=(
+            "item_type",
+            "dedup_key",
+            "source_id",
+            "source_ref",
+            "normalized",
+            "raw_payload_ref",
+            "source_trace",
+        ),
+    )
+    return CollectionItemEnvelope(
+        item_type=_ensure_non_empty_string(raw_item["item_type"], f"{field_name}.item_type"),
+        dedup_key=_ensure_non_empty_string(raw_item["dedup_key"], f"{field_name}.dedup_key"),
+        source_id=_ensure_non_empty_string(raw_item["source_id"], f"{field_name}.source_id"),
+        source_ref=_ensure_non_empty_string(raw_item["source_ref"], f"{field_name}.source_ref"),
+        normalized=_read_normalized_item(raw_item["normalized"], field_name=f"{field_name}.normalized"),
+        raw_payload_ref=_ensure_non_empty_string(raw_item["raw_payload_ref"], f"{field_name}.raw_payload_ref"),
+        source_trace=_read_source_trace(raw_item["source_trace"], field_name=f"{field_name}.source_trace"),
+    )
+
+
+def _read_items(payload: Any, *, field_name: str) -> tuple[CollectionItemEnvelope, ...]:
+    if not isinstance(payload, (list, tuple)):
+        raise CollectionContractError(
+            "parse_failed",
+            f"{field_name} 必须为数组",
+            details={"field": field_name},
+        )
+    return tuple(
+        _read_item(item, field_name=f"{field_name}[{index}]")
+        for index, item in enumerate(payload)
+    )
+
+
+def _read_audit(payload: Any, *, field_name: str) -> Mapping[str, Any]:
+    return _ensure_mapping(payload, field_name=field_name)
+
+
+def _validate_contract(
+    envelope: CollectionResultEnvelope,
+) -> dict[str, Any] | None:
+    if envelope.operation not in READ_SIDE_COLLECTION_OPERATIONS:
+        return _contract_error(
+            "invalid_collection_contract",
+            "operation 不是已冻结的 read-side collection operation",
+            details={"field": "operation", "value": envelope.operation},
+        )
+    if envelope.operation != envelope.target.operation:
+        return _contract_error(
+            "invalid_collection_contract",
+            "operation 与 target.operation 不一致",
+            details={
+                "operation": envelope.operation,
+                "target_operation": envelope.target.operation,
+            },
+        )
+    if envelope.result_status not in READ_SIDE_COLLECTION_RESULT_STATUSES:
+        return _contract_error(
+            "invalid_collection_contract",
+            "result_status 不在允许范围",
+            details={"field": "result_status", "value": envelope.result_status},
+        )
+    if envelope.error_classification not in COLLECTION_ERROR_CLASSIFICATIONS:
+        return _contract_error(
+            "invalid_collection_contract",
+            "error_classification 不在允许范围",
+            details={"field": "error_classification", "value": envelope.error_classification},
+        )
+
+    if envelope.result_status == "empty":
+        if envelope.error_classification != "empty_result":
+            return _contract_error(
+                "invalid_collection_contract",
+                "empty 结果必须归类为 empty_result",
+                details={"field": "error_classification", "value": envelope.error_classification},
+            )
+        if envelope.items:
+            return _contract_error(
+                "invalid_collection_contract",
+                "empty 结果必须不携带 items",
+                details={"field": "items", "count": len(envelope.items)},
+            )
+        if envelope.has_more:
+            return _contract_error(
+                "invalid_collection_contract",
+                "empty 结果不得设置 has_more=true",
+                details={"field": "has_more", "value": envelope.has_more},
+            )
+        if envelope.next_continuation is not None:
+            return _contract_error(
+                "invalid_collection_contract",
+                "empty 结果不得携带 next_continuation",
+                details={"field": "next_continuation"},
+            )
+    else:
+        if envelope.error_classification == "empty_result":
+            return _contract_error(
+                "invalid_collection_contract",
+                "empty_result 仅用于 result_status=empty",
+                details={"field": "error_classification"},
+            )
+
+    if envelope.result_status == "partial_result" and envelope.error_classification != "parse_failed":
+        return _contract_error(
+            "invalid_collection_contract",
+            "partial_result 必须与 parse_failed 配对",
+            details={"field": "result_status", "value": envelope.result_status},
+        )
+    if envelope.result_status != "partial_result" and envelope.error_classification == "parse_failed":
+        return _contract_error(
+            "invalid_collection_contract",
+            "parse_failed 仅可用于 partial_result",
+            details={"field": "error_classification", "value": envelope.error_classification},
+        )
+
+    if envelope.has_more and envelope.next_continuation is None:
+        return _contract_error(
+            "invalid_collection_contract",
+            "has_more=true 时必须返回 next_continuation",
+            details={"field": "next_continuation"},
+        )
+    if not envelope.has_more and envelope.next_continuation is not None:
+        return _contract_error(
+            "invalid_collection_contract",
+            "has_more=false 时不允许返回 next_continuation",
+            details={"field": "next_continuation"},
+        )
+    if envelope.next_continuation is not None and envelope.target.target_ref != envelope.next_continuation.resume_target_ref:
+        return _contract_error(
+            "invalid_collection_contract",
+            "next_continuation.resume_target_ref 必须与 target_ref 一致",
+            details={
+                "field": "next_continuation.resume_target_ref",
+                "target_ref": envelope.target.target_ref,
+                "resume_target_ref": envelope.next_continuation.resume_target_ref,
+            },
+        )
+
+    dedup_keys = tuple(item.dedup_key for item in envelope.items)
+    if len(dedup_keys) != len(set(dedup_keys)):
+        return _contract_error(
+            "invalid_collection_contract",
+            "CollectionItemEnvelope.dedup_key 不能重复",
+            details={"field": "items"},
+        )
+
+    return None
+
+
+def _parse_collection_result_envelope(payload: Mapping[str, Any]) -> CollectionResultEnvelope:
+    _ensure_strict_fields(
+        payload,
+        field_name="collection_result_envelope",
+        required=(
+            "operation",
+            "target",
+            "items",
+            "has_more",
+            "next_continuation",
+            "result_status",
+            "error_classification",
+            "raw_payload_ref",
+            "source_trace",
+            "audit",
+        ),
+        allowed=(
+            "operation",
+            "target",
+            "items",
+            "has_more",
+            "next_continuation",
+            "result_status",
+            "error_classification",
+            "raw_payload_ref",
+            "source_trace",
+            "audit",
+        ),
+    )
+    target = _read_target(payload["target"], field_name="target")
+    raw_payload_ref = _ensure_non_empty_string(payload["raw_payload_ref"], "raw_payload_ref")
+    operation = _ensure_non_empty_string(payload["operation"], "operation")
+    if operation != target.operation:
+        raise CollectionContractError(
+            "parse_failed",
+            "operation 与 target.operation 不一致",
+            details={"field": "operation", "operation": operation, "target_operation": target.operation},
+        )
+
+    envelope = CollectionResultEnvelope(
+        operation=operation,
+        target=target,
+        items=_read_items(payload["items"], field_name="items"),
+        has_more=_ensure_bool(payload["has_more"], "has_more"),
+        next_continuation=_read_continuation(payload["next_continuation"], field_name="next_continuation"),
+        result_status=_ensure_non_empty_string(payload["result_status"], "result_status"),
+        error_classification=_ensure_non_empty_string(payload["error_classification"], "error_classification"),
+        raw_payload_ref=raw_payload_ref,
+        source_trace=_read_source_trace(payload["source_trace"], field_name="source_trace"),
+        audit=_read_audit(payload["audit"], field_name="audit"),
+    )
+
+    validation_error = _validate_contract(envelope)
+    if validation_error is not None:
+        raise CollectionContractError(
+            validation_error["code"],
+            validation_error["message"],
+            details=validation_error["details"],
+        )
+    return envelope
+
+
+def collection_result_envelope_from_dict(payload: Mapping[str, Any] | Any) -> CollectionResultEnvelope:
+    if not isinstance(payload, Mapping):
+        raise CollectionContractError(
+            "parse_failed",
+            "collection_result_envelope 输入必须是对象",
+            details={"field": "collection_result_envelope", "type": type(payload).__name__},
+        )
+    return _parse_collection_result_envelope(payload)
+
+
+def collection_result_envelope_to_dict(envelope: CollectionResultEnvelope) -> dict[str, Any]:
+    if not isinstance(envelope, CollectionResultEnvelope):
+        raise ValueError("collection_result_envelope_to_dict 只接受 CollectionResultEnvelope")
+    validation = validate_collection_result_envelope(envelope)
+    if validation is not None:
+        raise ValueError(f"invalid collection result envelope: {validation['message']}")
+
+    return {
+        "operation": envelope.operation,
+        "target": {
+            "operation": envelope.target.operation,
+            "target_type": envelope.target.target_type,
+            "target_ref": envelope.target.target_ref,
+            **(
+                {"target_display_hint": envelope.target.target_display_hint}
+                if envelope.target.target_display_hint is not None
+                else {}
+            ),
+            **(
+                {"policy_ref": envelope.target.policy_ref}
+                if envelope.target.policy_ref is not None
+                else {}
+            ),
+        },
+        "items": [
+            {
+                "item_type": item.item_type,
+                "dedup_key": item.dedup_key,
+                "source_id": item.source_id,
+                "source_ref": item.source_ref,
+                "normalized": {
+                    "source_platform": item.normalized.source_platform,
+                    "source_type": item.normalized.source_type,
+                    "source_id": item.normalized.source_id,
+                    "canonical_ref": item.normalized.canonical_ref,
+                    "title_or_text_hint": item.normalized.title_or_text_hint,
+                    **(
+                        {"creator_ref": item.normalized.creator_ref}
+                        if item.normalized.creator_ref is not None
+                        else {}
+                    ),
+                    **(
+                        {"published_at": item.normalized.published_at}
+                        if item.normalized.published_at is not None
+                        else {}
+                    ),
+                    **(
+                        {"media_refs": list(item.normalized.media_refs)}
+                        if item.normalized.media_refs
+                        else {}
+                    ),
+                },
+                "raw_payload_ref": item.raw_payload_ref,
+                "source_trace": {
+                    "adapter_key": item.source_trace.adapter_key,
+                    "provider_path": item.source_trace.provider_path,
+                    **(
+                        {"resource_profile_ref": item.source_trace.resource_profile_ref}
+                        if item.source_trace.resource_profile_ref is not None
+                        else {}
+                    ),
+                    "fetched_at": item.source_trace.fetched_at,
+                    "evidence_alias": item.source_trace.evidence_alias,
+                },
+            }
+            for item in envelope.items
+        ],
+        "has_more": envelope.has_more,
+        "next_continuation": (
+            None
+            if envelope.next_continuation is None
+            else {
+                "continuation_token": envelope.next_continuation.continuation_token,
+                "continuation_family": envelope.next_continuation.continuation_family,
+                "resume_target_ref": envelope.next_continuation.resume_target_ref,
+                **(
+                    {"issued_at": envelope.next_continuation.issued_at}
+                    if envelope.next_continuation.issued_at is not None
+                    else {}
+                ),
+            }
+        ),
+        "result_status": envelope.result_status,
+        "error_classification": envelope.error_classification,
+        "raw_payload_ref": envelope.raw_payload_ref,
+        "source_trace": {
+            "adapter_key": envelope.source_trace.adapter_key,
+            "provider_path": envelope.source_trace.provider_path,
+            **(
+                {"resource_profile_ref": envelope.source_trace.resource_profile_ref}
+                if envelope.source_trace.resource_profile_ref is not None
+                else {}
+            ),
+            "fetched_at": envelope.source_trace.fetched_at,
+            "evidence_alias": envelope.source_trace.evidence_alias,
+        },
+        "audit": dict(envelope.audit),
+    }
+
+
+def validate_collection_result_envelope(payload: Any) -> dict[str, Any] | None:
+    try:
+        if isinstance(payload, Mapping):
+            _parse_collection_result_envelope(payload)
+            return None
+        if isinstance(payload, CollectionResultEnvelope):
+            return _validate_contract(payload)
+        raise TypeError(f"invalid payload type: {type(payload).__name__}")
+    except CollectionContractError as error:
+        return {
+            "code": error.code,
+            "message": error.message,
+            "details": dict(error.details),
+        }
+    except TypeError as error:
+        return _contract_error("parse_failed", str(error), details={"type": type(payload).__name__})
+    except ValueError as error:
+        return _contract_error("parse_failed", str(error), details={"type": type(payload).__name__})

--- a/syvert/version_gate.py
+++ b/syvert/version_gate.py
@@ -75,6 +75,7 @@ _REQUIRED_LEAKAGE_SCAN_REFS = tuple(
         "syvert/registry.py",
         "syvert/version_gate.py",
         "syvert/operation_taxonomy.py",
+        "syvert/read_side_collection.py",
     )
 )
 

--- a/tests/runtime/platform_leakage_fixtures.py
+++ b/tests/runtime/platform_leakage_fixtures.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 def canonical_platform_leakage_evidence_refs() -> list[str]:
     return [
-        "platform_leakage:scan:syvert/registry.py",
         "platform_leakage:scan:syvert/operation_taxonomy.py",
+        "platform_leakage:scan:syvert/read_side_collection.py",
+        "platform_leakage:scan:syvert/registry.py",
         "platform_leakage:scan:syvert/runtime.py",
         "platform_leakage:scan:syvert/version_gate.py",
     ]

--- a/tests/runtime/test_operation_taxonomy.py
+++ b/tests/runtime/test_operation_taxonomy.py
@@ -42,6 +42,39 @@ class OperationTaxonomyTests(unittest.TestCase):
             )
         )
 
+    def test_stable_search_and_list_by_creator_lookup_return_runtime_entry(self) -> None:
+        search = stable_operation_entry(
+            operation="content_search_by_keyword",
+            target_type="keyword",
+            collection_mode="paginated",
+        )
+        listing = stable_operation_entry(
+            operation="content_list_by_creator",
+            target_type="creator",
+            collection_mode="paginated",
+        )
+
+        self.assertEqual(search.capability_family, "content_search")
+        self.assertTrue(search.runtime_delivery)
+        self.assertEqual(search.lifecycle, CAPABILITY_LIFECYCLE_STABLE)
+        self.assertEqual(listing.capability_family, "content_list")
+        self.assertTrue(listing.runtime_delivery)
+        self.assertEqual(listing.lifecycle, CAPABILITY_LIFECYCLE_STABLE)
+        self.assertTrue(
+            is_stable_operation(
+                operation="content_search_by_keyword",
+                target_type="keyword",
+                collection_mode="paginated",
+            )
+        )
+        self.assertTrue(
+            is_stable_operation(
+                operation="content_list_by_creator",
+                target_type="creator",
+                collection_mode="paginated",
+            )
+        )
+
     def test_proposed_candidates_are_registered_but_not_stable_runtime_operations(self) -> None:
         proposed_operations = {entry.operation for entry in proposed_operation_taxonomy_entries()}
 

--- a/tests/runtime/test_platform_leakage.py
+++ b/tests/runtime/test_platform_leakage.py
@@ -18,6 +18,7 @@ SCAN_TARGETS = (
     "syvert/registry.py",
     "syvert/version_gate.py",
     "syvert/operation_taxonomy.py",
+    "syvert/read_side_collection.py",
 )
 EXPECTED_SCAN_REFS = {f"platform_leakage:scan:{target}" for target in SCAN_TARGETS}
 

--- a/tests/runtime/test_read_side_collection.py
+++ b/tests/runtime/test_read_side_collection.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from typing import Any
+import unittest
+
+from syvert.read_side_collection import (
+    CollectionContractError,
+    collection_result_envelope_from_dict,
+    collection_result_envelope_to_dict,
+    validate_collection_result_envelope,
+)
+
+
+def make_source_trace() -> dict[str, Any]:
+    return {
+        "adapter_key": "fake-adapter",
+        "provider_path": "tests.fake_provider",
+        "fetched_at": "2026-05-09T00:00:00Z",
+        "evidence_alias": "evidence-read-side-collection-001",
+    }
+
+
+def make_target(
+    *,
+    operation: str = "content_search_by_keyword",
+    target_type: str = "keyword",
+    target_ref: str = "keyword-search",
+) -> dict[str, Any]:
+    return {
+        "operation": operation,
+        "target_type": target_type,
+        "target_ref": target_ref,
+    }
+
+
+def make_continuation(*, target_ref: str = "keyword-search") -> dict[str, Any]:
+    return {
+        "continuation_token": "cursor-1",
+        "continuation_family": "opaque",
+        "resume_target_ref": target_ref,
+        "issued_at": "2026-05-09T00:00:00Z",
+    }
+
+
+def make_normalized_item(*, index: int, source_platform: str = "xhs") -> dict[str, Any]:
+    return {
+        "source_platform": source_platform,
+        "source_type": "post",
+        "source_id": f"sid-{index}",
+        "canonical_ref": f"https://example.com/posts/{index}",
+        "title_or_text_hint": f"item title {index}",
+        "creator_ref": f"creator-{index}",
+        "published_at": "2026-05-09T00:00:00Z",
+        "media_refs": [f"media-{index}-1", f"media-{index}-2"],
+    }
+
+
+def make_item(*, index: int = 1, dedup_key: str = "dedup-1") -> dict[str, Any]:
+    return {
+        "item_type": "content",
+        "dedup_key": dedup_key,
+        "source_id": f"source-{index}",
+        "source_ref": f"https://example.com/posts/{index}",
+        "normalized": make_normalized_item(index=index),
+        "raw_payload_ref": f"raw-payload-{index}",
+        "source_trace": make_source_trace(),
+    }
+
+
+def make_payload(
+    *,
+    operation: str = "content_search_by_keyword",
+    target_type: str = "keyword",
+    result_status: str = "complete",
+    error_classification: str = "platform_failed",
+    items: tuple[dict[str, Any], ...] | list[dict[str, Any]] = (make_item(index=1),),
+    has_more: bool = False,
+    include_continuation: bool = False,
+) -> dict[str, Any]:
+    target = make_target(operation=operation, target_type=target_type)
+    return {
+        "operation": operation,
+        "target": target,
+        "items": list(items),
+        "has_more": has_more,
+        "next_continuation": make_continuation(target_ref=target["target_ref"]) if include_continuation else None,
+        "result_status": result_status,
+        "error_classification": error_classification,
+        "raw_payload_ref": f"raw-result-{result_status}-{operation}",
+        "source_trace": make_source_trace(),
+        "audit": {
+            "carrier": "fake-read-side-collection",
+            "test_mode": True,
+        },
+    }
+
+
+class FakeReadSideCarrier:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def execute(self, _request: dict[str, Any]) -> dict[str, Any]:
+        return self.payload
+
+
+class ReadSideCollectionCarrierTests(unittest.TestCase):
+    def test_fake_carrier_happy_path(self) -> None:
+        payload = make_payload(
+            has_more=True,
+            include_continuation=True,
+        )
+        adapter = FakeReadSideCarrier(payload)
+        envelope = collection_result_envelope_from_dict(adapter.execute({}))
+
+        self.assertIsNone(validate_collection_result_envelope(envelope))
+        self.assertEqual(collection_result_envelope_to_dict(envelope), payload)
+
+    def test_fake_carrier_empty_result(self) -> None:
+        payload = make_payload(
+            result_status="empty",
+            error_classification="empty_result",
+            items=(),
+            has_more=False,
+            include_continuation=False,
+        )
+
+        envelope = collection_result_envelope_from_dict(payload)
+
+        self.assertIsNone(validate_collection_result_envelope(envelope))
+        self.assertEqual(collection_result_envelope_to_dict(envelope), payload)
+
+    def test_fake_carrier_partial_result(self) -> None:
+        payload = make_payload(
+            result_status="partial_result",
+            error_classification="parse_failed",
+            items=(
+                make_item(index=1, dedup_key="dedup-1"),
+                make_item(index=2, dedup_key="dedup-2"),
+            ),
+            has_more=False,
+            include_continuation=False,
+        )
+
+        envelope = collection_result_envelope_from_dict(payload)
+
+        self.assertIsNone(validate_collection_result_envelope(envelope))
+        self.assertEqual(collection_result_envelope_to_dict(envelope)["result_status"], "partial_result")
+
+    def test_fake_carrier_duplicate_dedup_keys_are_rejected(self) -> None:
+        payload = make_payload(
+            items=[
+                make_item(index=1, dedup_key="dup-key"),
+                make_item(index=2, dedup_key="dup-key"),
+            ]
+        )
+        payload["has_more"] = False
+
+        self.assertEqual(
+            validate_collection_result_envelope(payload),
+            {
+                "code": "invalid_collection_contract",
+                "message": "CollectionItemEnvelope.dedup_key 不能重复",
+                "details": {"field": "items"},
+            },
+        )
+
+    def test_fake_carrier_cursor_invalid_or_expired(self) -> None:
+        payload = make_payload(
+            operation="content_list_by_creator",
+            target_type="creator",
+            result_status="complete",
+            error_classification="cursor_invalid_or_expired",
+            items=(make_item(index=1),),
+            has_more=False,
+        )
+        payload["target"]["target_ref"] = "creator-search"
+        payload["has_more"] = True
+        payload["next_continuation"] = make_continuation(target_ref="creator-different")
+
+        result = validate_collection_result_envelope(payload)
+
+        self.assertEqual(result["code"], "invalid_collection_contract")
+        self.assertIn("resume_target_ref", str(result))
+
+    def test_fake_carrier_error_classification_variants(self) -> None:
+        for error_classification in (
+            "permission_denied",
+            "rate_limited",
+            "provider_or_network_blocked",
+            "credential_invalid",
+            "verification_required",
+            "signature_or_request_invalid",
+            "platform_failed",
+            "target_not_found",
+            "empty_result",
+        ):
+            with self.subTest(error_classification=error_classification):
+                payload = make_payload(
+                    result_status="complete",
+                    error_classification=error_classification,
+                    has_more=False,
+                    items=(make_item(index=1),),
+                )
+                if error_classification == "empty_result":
+                    payload["result_status"] = "empty"
+                    payload["items"] = []
+
+                self.assertIsNone(
+                    validate_collection_result_envelope(payload),
+                    msg=f"{error_classification} should be valid",
+                )
+
+    def test_fake_carrier_parse_failed_malformed(self) -> None:
+        payload = make_payload(
+            result_status="partial_result",
+            error_classification="parse_failed",
+            items=(make_item(index=1),),
+        )
+        payload["items"][0]["normalized"]["source_id"] = ""
+
+        result = validate_collection_result_envelope(payload)
+
+        self.assertEqual(result["code"], "parse_failed")
+        self.assertIn("source_id", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/runtime/test_version_gate.py
+++ b/tests/runtime/test_version_gate.py
@@ -651,12 +651,7 @@ class VersionGateTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertIn("platform_leakage_evidence_refs_mismatch", {item["code"] for item in report["details"]["failures"]})
         self.assertEqual(
             report["evidence_refs"],
-            [
-                "platform_leakage:scan:syvert/operation_taxonomy.py",
-                "platform_leakage:scan:syvert/registry.py",
-                "platform_leakage:scan:syvert/runtime.py",
-                "platform_leakage:scan:syvert/version_gate.py",
-            ],
+            canonical_platform_leakage_payload()["evidence_refs"],
         )
 
     def test_platform_leakage_rejects_finding_evidence_ref_missing_from_evidence_refs(self) -> None:
@@ -1774,14 +1769,13 @@ class VersionGateTests(ResourceStoreEnvMixin, unittest.TestCase):
         )
 
         self.assertEqual(
-            report["source_reports"]["platform_leakage"]["evidence_refs"],
-            [
-                "leakage:core-runtime:1",
-                "platform_leakage:scan:syvert/operation_taxonomy.py",
-                "platform_leakage:scan:syvert/registry.py",
-                "platform_leakage:scan:syvert/runtime.py",
-                "platform_leakage:scan:syvert/version_gate.py",
-            ],
+            sorted(report["source_reports"]["platform_leakage"]["evidence_refs"]),
+            sorted(
+                {
+                    "leakage:core-runtime:1",
+                    *canonical_platform_leakage_payload()["evidence_refs"],
+                }
+            ),
         )
 
     def test_orchestrator_rejects_forged_real_regression_operation(self) -> None:


### PR DESCRIPTION
## Scope
- 实现 #408 runtime carrier 核心公共契约（`syvert/read_side_collection.py`，包含 `CollectionResultEnvelope` 全量 shape、校验与错误分类）。
- 仅在 `operation_taxonomy` 中晋升 `content_search_by_keyword` 与 `content_list_by_creator` 为 stable + runtime_delivery。
- 覆盖平台泄露扫描与 `version_gate` 证据基线，新增扫描 target `syvert/read_side_collection.py`。
- 新增 runtime fake/adaptor carrier 回归测试（happy/empty/partial/duplicate/dedup/cursor/error 等）与 taxonomy/platform leakage/version_gate 测试修正。

## 不包含内容
- 不包含 #409/TaskRecord/result query/compatibility consumers 迁移。
- 不包含 #410/#411 的 evidence 与 closeout 文档闭环。

## 验证
- `python3 -m unittest tests.runtime.test_read_side_collection tests.runtime.test_operation_taxonomy tests.runtime.test_platform_leakage tests.runtime.test_real_adapter_regression tests.runtime.test_cli_http_same_path`
- `python3 -m unittest tests.runtime.test_version_gate`
- `python3 scripts/spec_guard.py --mode ci --all`
- `python3 scripts/docs_guard.py --mode ci`
- `python3 scripts/workflow_guard.py --mode ci`
- `python3 scripts/version_guard.py --mode ci`

Closes #408
