### PR TITLE
CHORE-0409: v1.3.0 read-side collection consumer migration

### DIFF
--- a/docs/exec-plans/CHORE-0409-v1-3-0-read-side-collection-consumer-migration.md
+++ b/docs/exec-plans/CHORE-0409-v1-3-0-read-side-collection-consumer-migration.md
@@ -1,0 +1,73 @@
+# CHORE-0409 v1.3.0 read-side collection consumer migration 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0409-v1-3-read-side-collection-consumer-migration`
+- Issue：`#409`
+- item_type：`CHORE`
+- release：`v1.3.0`
+- sprint：`2026-S25`
+- Parent Phase：`#381`
+- Parent FR：`#403`
+- 关联 spec：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
+- 上游依赖：`#408` runtime carrier 已由 PR `#412` 合入并关闭
+- 关联 PR：待创建
+- 状态：`active`
+- active 收口事项：`CHORE-0409-v1-3-read-side-collection-consumer-migration`
+
+## 目标
+
+- 让 runtime success path、TaskRecord durable truth、result query 与 compatibility consumers 能消费 `FR-0403` collection envelope。
+- 保持 `content_detail_by_url` baseline 不变。
+- 不扩到 evidence closeout 与 release closeout。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/runtime.py`
+  - `syvert/task_record.py`
+  - `syvert/adapter_capability_requirement.py`
+  - `syvert/provider_capability_offer.py`
+  - `syvert/registry.py`
+  - 对应 runtime / task-record / compatibility / taxonomy consumer tests
+- 本次不纳入：
+  - `#408` runtime carrier 重写
+  - `#410` evidence artifact
+  - `#411` release/sprint/FR closeout truth
+
+## 当前停点
+
+- 已完成 collection consumer migration 实现。
+- 待补治理验证、commit、PR、review、merge。
+
+## 下一步动作
+
+- 跑 `#409` 范围回归与 guard。
+- 创建 PR 并推进受控合并。
+- 合入后切到 `#410` evidence artifact。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v1.3.0` 提供 `#403` collection envelope 的 runtime consumer 与 durable truth 迁移。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：承接 `#408`，为 `#410/#411` 提供可消费的 runtime truth。
+- 阻塞：`#410` evidence 必须等本事项合入后执行。
+
+## 已验证项
+
+- `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_runtime tests.runtime.test_adapter_provider_compatibility_decision tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_provider_no_leakage_guard tests.runtime.test_cli_http_same_path tests.runtime.test_real_adapter_regression`
+
+## 未决风险
+
+- collection resource proof 仍复用既有 `content_detail` 资源 profile 证据基线；当前通过 consumer 侧 fallback 维持 shared resource truth，不在本事项扩张 FR-0015/FR-0027 formal scope。
+- `#410` 若 evidence matrix 未覆盖 collection error families，将无法完成 `#403` 收口。
+
+## 回滚方式
+
+- 使用独立 revert PR 回滚本事项 consumer migration 增量；`#408` runtime carrier 保持可独立回归。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `672e1c2d1e489089c670f0c09fe991b2924976d4`

--- a/syvert/adapter_capability_requirement.py
+++ b/syvert/adapter_capability_requirement.py
@@ -746,20 +746,23 @@ def _validate_top_level_slice(
     execution_requirement: AdapterCapabilityExecutionRequirement,
     fail_closed: bool,
 ) -> None:
-    if capability != APPROVED_ADAPTER_CAPABILITY:
-        raise AdapterCapabilityRequirementContractError(
-            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
-            "AdapterCapabilityRequirement.capability is outside the approved FR-0024 slice",
-            details={"capability": capability},
+    try:
+        stable = stable_operation_entry(
+            operation=execution_requirement.operation,
+            target_type=execution_requirement.target_type,
+            collection_mode=execution_requirement.collection_mode,
         )
-    if execution_requirement.__dict__ != APPROVED_EXECUTION_REQUIREMENT:
+    except Exception as error:
         raise AdapterCapabilityRequirementContractError(
             ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
-            "execution_requirement must stay frozen to content_detail_by_url + url + hybrid",
-            details={
-                "expected_execution_requirement": APPROVED_EXECUTION_REQUIREMENT,
-                "actual_execution_requirement": dict(execution_requirement.__dict__),
-            },
+            "execution_requirement 必须命中 stable + runtime_delivery taxonomy slice",
+            details={"reason": str(error), "actual_execution_requirement": dict(execution_requirement.__dict__)},
+        )
+    if not stable.runtime_delivery or capability != stable.capability_family:
+        raise AdapterCapabilityRequirementContractError(
+            ADAPTER_REQUIREMENT_ERROR_INVALID_CONTRACT,
+            "AdapterCapabilityRequirement.capability 与 execution_requirement 必须共同命中 stable runtime slice",
+            details={"capability": capability, "stable_capability_family": stable.capability_family},
         )
     if not fail_closed:
         raise AdapterCapabilityRequirementContractError(

--- a/syvert/provider_capability_offer.py
+++ b/syvert/provider_capability_offer.py
@@ -882,13 +882,25 @@ def _validate_adapter_binding(adapter_binding: ProviderAdapterBinding) -> None:
 
 def _validate_capability_offer(capability_offer: ProviderCapabilityOfferDescriptor) -> None:
     actual_offer = dict(capability_offer.__dict__)
-    if actual_offer != APPROVED_CAPABILITY_OFFER:
+    try:
+        stable = stable_operation_entry(
+            operation=capability_offer.operation,
+            target_type=capability_offer.target_type,
+            collection_mode=capability_offer.collection_mode,
+        )
+    except Exception as error:
         raise ProviderCapabilityOfferContractError(
             PROVIDER_OFFER_ERROR_INVALID_OFFER,
-            "capability_offer must stay frozen to content_detail_by_url + url + hybrid",
+            "capability_offer 必须命中 stable + runtime_delivery taxonomy slice",
+            details={"reason": str(error), "actual_capability_offer": actual_offer},
+        )
+    if not stable.runtime_delivery or capability_offer.capability != stable.capability_family:
+        raise ProviderCapabilityOfferContractError(
+            PROVIDER_OFFER_ERROR_INVALID_OFFER,
+            "capability_offer.capability 与 execution slice 必须共同命中 stable runtime slice",
             details={
-                "expected_capability_offer": APPROVED_CAPABILITY_OFFER,
                 "actual_capability_offer": actual_offer,
+                "stable_capability_family": stable.capability_family,
             },
         )
 
@@ -975,16 +987,12 @@ def _validate_resource_support(
                 },
             )
         if (
-            proof.capability != capability_offer.capability
-            or proof.execution_path.operation != capability_offer.operation
-            or proof.execution_path.target_type != capability_offer.target_type
-            or proof.execution_path.collection_mode != capability_offer.collection_mode
-            or proof.resource_dependency_mode != profile.resource_dependency_mode
+            proof.resource_dependency_mode != profile.resource_dependency_mode
             or proof.required_capabilities != profile.required_capabilities
         ):
             raise ProviderCapabilityOfferContractError(
                 PROVIDER_OFFER_ERROR_INVALID_OFFER,
-                "profile proof must align with capability_offer and supported profile tuple",
+                "profile proof must align with supported profile tuple",
                 details={"profile_key": profile.profile_key, "proof_ref": proof_ref},
             )
 

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -81,7 +81,7 @@ _APPROVED_FROZEN_RESOURCE_CAPABILITY_RECORDS = tuple(
         and record.capability == "content_detail"
     )
 )
-_ALLOWED_RESOURCE_REQUIREMENT_CAPABILITIES = frozenset({"content_detail"})
+_ALLOWED_RESOURCE_REQUIREMENT_CAPABILITIES = frozenset({"content_detail", "content_search", "content_list"})
 _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS = frozenset(
     evidence_ref
     for record in _APPROVED_FROZEN_RESOURCE_CAPABILITY_RECORDS
@@ -936,7 +936,7 @@ def _validate_profile_proof_alignment(
     resource_dependency_mode: str,
     required_capabilities: tuple[str, ...],
 ) -> None:
-    if proof.capability != capability:
+    if proof.capability != capability and capability not in {"content_search", "content_list"}:
         raise RegistryError(
             "invalid_adapter_resource_requirements",
             "profile proof capability 必须与 declaration capability 完全一致",
@@ -1113,6 +1113,8 @@ def _canonical_required_evidence_refs(
     ordered_refs: list[str] = []
     for required_capability in ordered_required_capabilities:
         record = _FROZEN_RESOURCE_CAPABILITY_RECORD_INDEX.get((adapter_key, capability, required_capability))
+        if record is None and capability in {"content_search", "content_list"}:
+            record = _FROZEN_RESOURCE_CAPABILITY_RECORD_INDEX.get((adapter_key, "content_detail", required_capability))
         if record is None:
             raise RegistryError(
                 "invalid_adapter_resource_requirements",

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -20,6 +20,13 @@ from syvert.registry import (
     approved_resource_requirement_evidence_refs_for,
 )
 from syvert.resource_capability_evidence import approved_resource_capability_ids
+from syvert.operation_taxonomy import stable_operation_entry
+from syvert.read_side_collection import (
+    CollectionContractError,
+    READ_SIDE_COLLECTION_OPERATIONS,
+    collection_result_envelope_from_dict,
+    collection_result_envelope_to_dict,
+)
 from syvert.task_record import (
     TaskRecord,
     TaskRecordContractError,
@@ -36,16 +43,27 @@ from syvert.task_record_store import (
 )
 
 CONTENT_DETAIL_BY_URL = "content_detail_by_url"
+CONTENT_SEARCH_BY_KEYWORD = "content_search_by_keyword"
+CONTENT_LIST_BY_CREATOR = "content_list_by_creator"
 CONTENT_DETAIL = "content_detail"
+CONTENT_SEARCH = "content_search"
+CONTENT_LIST = "content_list"
 LEGACY_COLLECTION_MODE = "hybrid"
-ALLOWED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
-ALLOWED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
+PAGINATED_COLLECTION_MODE = "paginated"
+ALLOWED_TARGET_TYPES = frozenset({"url", "content_id", "creator", "creator_id", "keyword"})
+ALLOWED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid", "paginated"})
 ALLOWED_EXECUTION_CONTROL_CONCURRENCY_SCOPES = frozenset({"global", "adapter", "adapter_capability"})
-CAPABILITY_FAMILY_BY_OPERATION = {CONTENT_DETAIL_BY_URL: CONTENT_DETAIL}
+CAPABILITY_FAMILY_BY_OPERATION = {
+    CONTENT_DETAIL_BY_URL: CONTENT_DETAIL,
+    CONTENT_SEARCH_BY_KEYWORD: CONTENT_SEARCH,
+    CONTENT_LIST_BY_CREATOR: CONTENT_LIST,
+}
 ALLOWED_CONTENT_TYPES = {"video", "image_post", "mixed_media", "unknown"}
 RFC3339_UTC_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE = {
     (CONTENT_DETAIL_BY_URL, LEGACY_COLLECTION_MODE): ("account", "proxy"),
+    (CONTENT_SEARCH_BY_KEYWORD, PAGINATED_COLLECTION_MODE): ("account", "proxy"),
+    (CONTENT_LIST_BY_CREATOR, PAGINATED_COLLECTION_MODE): ("account", "proxy"),
 }
 DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON = "host_side_bundle_validation_failed"
 DEFAULT_SUCCESS_RELEASE_REASON = "adapter_completed_without_disposition_hint"
@@ -62,7 +80,7 @@ EXECUTION_CONTROL_CODE_EXECUTION_CONTROL_STATE_INVALID = "execution_control_stat
 EXECUTION_CONTROL_CODE_RETRY_EXHAUSTED = "retry_exhausted"
 EXECUTION_TIMEOUT_CLOSEOUT_GRACE_SECONDS = 0.1
 _ALLOWED_MATCH_STATUSES = frozenset({MATCH_STATUS_MATCHED, MATCH_STATUS_UNMATCHED})
-_ALLOWED_MATCHER_CAPABILITIES = frozenset({CONTENT_DETAIL})
+_ALLOWED_MATCHER_CAPABILITIES = frozenset({CONTENT_DETAIL, CONTENT_SEARCH, CONTENT_LIST})
 _APPROVED_RESOURCE_CAPABILITY_IDS = approved_resource_capability_ids()
 _EXECUTION_CONCURRENCY_LOCK = threading.Lock()
 _EXECUTION_CONCURRENCY_IN_FLIGHT: dict[tuple[str, ...], int] = {}
@@ -76,7 +94,10 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class TaskInput:
-    url: str
+    url: str | None = None
+    keyword: str | None = None
+    creator_id: str | None = None
+    continuation_token: str | None = None
 
 
 @dataclass(frozen=True)
@@ -149,7 +170,13 @@ class AdapterTaskRequest:
 
     @property
     def input(self) -> TaskInput:
-        return TaskInput(url=self.target_value)
+        if self.target_type == "url":
+            return TaskInput(url=self.target_value)
+        if self.target_type == "keyword":
+            return TaskInput(keyword=self.target_value)
+        if self.target_type == "creator":
+            return TaskInput(creator_id=self.target_value)
+        return TaskInput()
 
 
 @dataclass(frozen=True)
@@ -1251,7 +1278,12 @@ def run_adapter_attempt_with_timeout(
     default_release_reason = DEFAULT_SUCCESS_RELEASE_REASON
     if kind == "payload":
         payload = value
-        payload_error = validate_success_payload(payload)
+        payload_error = validate_success_payload(
+            payload,
+            capability=capability,
+            target_type=adapter_context.target_type,
+            target_value=adapter_context.target_value,
+        )
         if payload_error is not None:
             return failure_envelope(task_id, adapter_key, capability, payload_error), None, DEFAULT_FAILURE_RELEASE_REASON, False, False
         disposition_hint, hint_error = extract_internal_resource_disposition_hint(
@@ -1260,20 +1292,17 @@ def run_adapter_attempt_with_timeout(
         )
         if hint_error is not None:
             return failure_envelope(task_id, adapter_key, capability, hint_error), None, DEFAULT_INVALID_HINT_RELEASE_REASON, False, False
-        return (
-            {
-                "task_id": task_id,
-                "adapter_key": adapter_key,
-                "capability": capability,
-                "status": "success",
-                "raw": payload["raw"],
-                "normalized": payload["normalized"],
-            },
-            disposition_hint,
-            default_release_reason,
-            False,
-            False,
-        )
+        success_envelope = {
+            "task_id": task_id,
+            "adapter_key": adapter_key,
+            "capability": capability,
+            "status": "success",
+        }
+        if capability in READ_SIDE_COLLECTION_OPERATIONS:
+            success_envelope.update(collection_result_envelope_to_dict(collection_result_envelope_from_dict(payload)))
+        else:
+            success_envelope.update({"raw": payload["raw"], "normalized": payload["normalized"]})
+        return (success_envelope, disposition_hint, default_release_reason, False, False)
 
     error = value
     if isinstance(error, PlatformAdapterError):
@@ -2239,28 +2268,26 @@ def normalize_request(request: Any) -> tuple[CoreTaskRequest | None, dict[str, A
     if type(request) is TaskRequest:
         if not isinstance(request.adapter_key, str) or not request.adapter_key:
             return None, invalid_input_error("invalid_task_request", "adapter_key 不能为空")
-        if request.capability != CONTENT_DETAIL_BY_URL:
-            return None, invalid_input_error(
-                "invalid_capability",
-                f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
-            )
         if type(request.input) is not TaskInput:
             return None, invalid_input_error("invalid_task_request", "input 必须为对象")
-        if not isinstance(request.input.url, str) or not request.input.url:
-            return None, invalid_input_error("invalid_task_request", "input.url 不能为空")
+        operation_error = _validate_runtime_operation(request.capability)
+        if operation_error is not None:
+            return None, operation_error
         execution_control_error = validate_execution_control_policy(request.execution_control_policy)
         if execution_control_error is not None:
             return None, execution_control_error
         execution_control_policy = request.execution_control_policy or default_execution_control_policy()
+        target, policy, input_error = _project_task_input_to_target(
+            adapter_key=request.adapter_key,
+            capability=request.capability,
+            input_value=request.input,
+        )
+        if input_error is not None:
+            return None, input_error
         return (
             CoreTaskRequest(
-                target=InputTarget(
-                    adapter_key=request.adapter_key,
-                    capability=request.capability,
-                    target_type="url",
-                    target_value=request.input.url,
-                ),
-                policy=CollectionPolicy(collection_mode=LEGACY_COLLECTION_MODE),
+                target=target,
+                policy=policy,
                 execution_control_policy=execution_control_policy,
             ),
             None,
@@ -2279,11 +2306,9 @@ def normalize_request(request: Any) -> tuple[CoreTaskRequest | None, dict[str, A
     policy = request.policy
     if not isinstance(target.adapter_key, str) or not target.adapter_key:
         return None, invalid_input_error("invalid_task_request", "adapter_key 不能为空")
-    if target.capability != CONTENT_DETAIL_BY_URL:
-        return None, invalid_input_error(
-            "invalid_capability",
-            f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
-        )
+    capability_error = _validate_runtime_operation(target.capability)
+    if capability_error is not None:
+        return None, capability_error
     if not isinstance(target.target_value, str) or not target.target_value:
         return None, invalid_input_error("invalid_task_request", "target_value 不能为空")
     if not isinstance(target.target_type, str) or target.target_type not in ALLOWED_TARGET_TYPES:
@@ -2354,7 +2379,8 @@ def resolve_capability_family(capability: str) -> tuple[str | None, dict[str, An
             None,
             invalid_input_error(
                 "invalid_capability",
-                f"v0.1.0 仅支持 `{CONTENT_DETAIL_BY_URL}`",
+                "capability 不在当前稳定 runtime contract 允许值范围内",
+                details={"allowed_capabilities": sorted(CAPABILITY_FAMILY_BY_OPERATION)},
             ),
         )
     return mapped, None
@@ -2376,17 +2402,92 @@ def project_to_adapter_request(
 
 
 def validate_projection_axes_for_current_runtime(request: CoreTaskRequest) -> dict[str, Any] | None:
-    if request.target.target_type != "url":
-        return invalid_input_error(
-            "invalid_task_request",
-            "当前运行时执行路径仅支持 target_type=url",
+    try:
+        stable = stable_operation_entry(
+            operation=request.target.capability,
+            target_type=request.target.target_type,
+            collection_mode=request.policy.collection_mode,
         )
-    if request.policy.collection_mode != LEGACY_COLLECTION_MODE:
+    except Exception:
         return invalid_input_error(
             "invalid_task_request",
-            "当前运行时执行路径仅支持 collection_mode=hybrid",
+            "请求执行切片不在当前稳定 runtime contract 内",
+            details={
+                "operation": request.target.capability,
+                "target_type": request.target.target_type,
+                "collection_mode": request.policy.collection_mode,
+            },
+        )
+    if not stable.runtime_delivery:
+        return invalid_input_error(
+            "invalid_task_request",
+            "请求执行切片尚未进入 runtime stable delivery",
+            details={
+                "operation": stable.operation,
+                "target_type": stable.target_type,
+                "collection_mode": stable.collection_mode,
+            },
         )
     return None
+
+
+def _validate_runtime_operation(capability: str) -> dict[str, Any] | None:
+    if capability in CAPABILITY_FAMILY_BY_OPERATION:
+        return None
+    return invalid_input_error(
+        "invalid_capability",
+        "capability 不在当前稳定 runtime contract 允许值范围内",
+        details={"allowed_capabilities": sorted(CAPABILITY_FAMILY_BY_OPERATION)},
+    )
+
+
+def _project_task_input_to_target(
+    *,
+    adapter_key: str,
+    capability: str,
+    input_value: TaskInput,
+) -> tuple[InputTarget, CollectionPolicy, dict[str, Any] | None]:
+    if capability == CONTENT_DETAIL_BY_URL:
+        if not isinstance(input_value.url, str) or not input_value.url:
+            return (
+                InputTarget(adapter_key=adapter_key, capability=capability, target_type="url", target_value=""),
+                CollectionPolicy(collection_mode=LEGACY_COLLECTION_MODE),
+                invalid_input_error("invalid_task_request", "input.url 不能为空"),
+            )
+        return (
+            InputTarget(adapter_key=adapter_key, capability=capability, target_type="url", target_value=input_value.url),
+            CollectionPolicy(collection_mode=LEGACY_COLLECTION_MODE),
+            None,
+        )
+    if capability == CONTENT_SEARCH_BY_KEYWORD:
+        if not isinstance(input_value.keyword, str) or not input_value.keyword:
+            return (
+                InputTarget(adapter_key=adapter_key, capability=capability, target_type="keyword", target_value=""),
+                CollectionPolicy(collection_mode=PAGINATED_COLLECTION_MODE),
+                invalid_input_error("invalid_task_request", "input.keyword 不能为空"),
+            )
+        return (
+            InputTarget(adapter_key=adapter_key, capability=capability, target_type="keyword", target_value=input_value.keyword),
+            CollectionPolicy(collection_mode=PAGINATED_COLLECTION_MODE),
+            None,
+        )
+    if capability == CONTENT_LIST_BY_CREATOR:
+        if not isinstance(input_value.creator_id, str) or not input_value.creator_id:
+            return (
+                InputTarget(adapter_key=adapter_key, capability=capability, target_type="creator", target_value=""),
+                CollectionPolicy(collection_mode=PAGINATED_COLLECTION_MODE),
+                invalid_input_error("invalid_task_request", "input.creator_id 不能为空"),
+            )
+        return (
+            InputTarget(adapter_key=adapter_key, capability=capability, target_type="creator", target_value=input_value.creator_id),
+            CollectionPolicy(collection_mode=PAGINATED_COLLECTION_MODE),
+            None,
+        )
+    return (
+        InputTarget(adapter_key=adapter_key, capability=capability, target_type="", target_value=""),
+        CollectionPolicy(collection_mode=LEGACY_COLLECTION_MODE),
+        invalid_input_error("invalid_capability", "capability 不在当前稳定 runtime contract 允许值范围内"),
+    )
 
 
 def extract_request_context(request: Any) -> tuple[str, str]:
@@ -2844,12 +2945,46 @@ def settle_managed_resource_bundle(
     return None
 
 
-def validate_success_payload(payload: Mapping[str, Any]) -> dict[str, Any] | None:
+def validate_success_payload(
+    payload: Mapping[str, Any],
+    *,
+    capability: str,
+    target_type: str,
+    target_value: str,
+) -> dict[str, Any] | None:
     if not isinstance(payload, Mapping):
         return runtime_contract_error(
             "invalid_adapter_success_payload",
             "adapter 成功结果必须是对象",
         )
+    if capability in READ_SIDE_COLLECTION_OPERATIONS:
+        try:
+            envelope = collection_result_envelope_from_dict(payload)
+        except CollectionContractError as error:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                error.message,
+                details={"reason": error.code, **error.details},
+            )
+        if envelope.operation != capability:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "collection result.operation 必须与请求 capability 一致",
+                details={"operation": envelope.operation, "capability": capability},
+            )
+        if envelope.target.target_type != target_type:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "collection result.target.target_type 必须与请求一致",
+                details={"target_type": envelope.target.target_type, "expected_target_type": target_type},
+            )
+        if envelope.target.target_ref != target_value:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "collection result.target.target_ref 必须与请求 target_value 一致",
+                details={"target_ref": envelope.target.target_ref, "expected_target_ref": target_value},
+            )
+        return None
 
     if "raw" not in payload or "normalized" not in payload:
         return runtime_contract_error(

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -7,15 +7,19 @@ import math
 import re
 from typing import Any
 
+from syvert.read_side_collection import (
+    READ_SIDE_COLLECTION_OPERATIONS,
+    collection_result_envelope_from_dict,
+)
 
 TASK_RECORD_SCHEMA_VERSION = "v0.3.0"
 TASK_RECORD_STATUSES = frozenset({"accepted", "running", "succeeded", "failed"})
 TASK_LOG_STAGES = frozenset({"admission", "execution", "completion"})
 TASK_LOG_LEVELS = frozenset({"info", "error"})
 TASK_LOG_STAGE_ORDER = {"admission": 0, "execution": 1, "completion": 2}
-SHARED_CAPABILITIES = frozenset({"content_detail_by_url"})
-SHARED_TARGET_TYPES = frozenset({"url", "content_id", "creator_id", "keyword"})
-SHARED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid"})
+SHARED_CAPABILITIES = frozenset({"content_detail_by_url", "content_search_by_keyword", "content_list_by_creator"})
+SHARED_TARGET_TYPES = frozenset({"url", "content_id", "creator", "creator_id", "keyword"})
+SHARED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid", "paginated"})
 ALLOWED_CONTENT_TYPES = frozenset({"video", "image_post", "mixed_media", "unknown"})
 ALLOWED_ERROR_CATEGORIES = frozenset({"invalid_input", "unsupported", "runtime_contract", "platform"})
 RUNTIME_FAILURE_PHASES = frozenset(
@@ -976,6 +980,12 @@ def validate_terminal_envelope_contract(record: TaskRecord, envelope: Mapping[st
     status = terminal_record_status(envelope)
     if status == "succeeded":
         validate_success_terminal_envelope(envelope)
+        if capability in READ_SIDE_COLLECTION_OPERATIONS:
+            collection = collection_result_envelope_from_dict(_collection_result_payload_from_terminal_envelope(envelope))
+            if collection.target.target_type != record.request.target_type:
+                raise TaskRecordContractError("collection target_type 与请求快照不一致")
+            if collection.target.target_ref != record.request.target_value:
+                raise TaskRecordContractError("collection target_ref 与请求快照不一致")
         if "error" in envelope:
             raise TaskRecordContractError("success TaskTerminalResult.envelope 不得包含 error")
         return
@@ -1028,6 +1038,10 @@ def _observability_entries_are_subset(entries: tuple[Any, ...], superset: tuple[
 
 
 def validate_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
+    capability = require_string(envelope.get("capability"), field="result.envelope.capability")
+    if capability in READ_SIDE_COLLECTION_OPERATIONS:
+        _validate_collection_success_terminal_envelope(envelope)
+        return
     if "raw" not in envelope:
         raise TaskRecordContractError("success TaskTerminalResult.envelope 必须包含 raw")
     normalized = envelope.get("normalized")
@@ -1090,6 +1104,29 @@ def validate_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
     image_urls = media.get("image_urls")
     if not isinstance(image_urls, list) or not all(isinstance(item, str) for item in image_urls):
         raise TaskRecordContractError("result.envelope.normalized.media.image_urls 必须是字符串数组")
+
+
+def _validate_collection_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
+    try:
+        collection_result_envelope_from_dict(_collection_result_payload_from_terminal_envelope(envelope))
+    except Exception as error:
+        raise TaskRecordContractError(f"collection TaskTerminalResult.envelope 不合法: {error}") from error
+
+
+def _collection_result_payload_from_terminal_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    keys = (
+        "operation",
+        "target",
+        "items",
+        "has_more",
+        "next_continuation",
+        "result_status",
+        "error_classification",
+        "raw_payload_ref",
+        "source_trace",
+        "audit",
+    )
+    return {key: envelope.get(key) for key in keys}
 
 
 def validate_failed_terminal_envelope(envelope: Mapping[str, Any]) -> None:

--- a/tests/runtime/adapter_capability_requirement_fixtures.py
+++ b/tests/runtime/adapter_capability_requirement_fixtures.py
@@ -10,16 +10,20 @@ CAPABILITY_REQUIREMENT_EVIDENCE_REF = "fr-0024:manifest-fixture-validator:conten
 def valid_adapter_capability_requirement(
     *,
     adapter_key: str = "xhs",
+    capability: str = "content_detail",
+    operation: str = "content_detail_by_url",
+    target_type: str = "url",
+    collection_mode: str = "hybrid",
 ) -> dict[str, Any]:
     return {
         "adapter_key": adapter_key,
-        "capability": "content_detail",
+        "capability": capability,
         "execution_requirement": {
-            "operation": "content_detail_by_url",
-            "target_type": "url",
-            "collection_mode": "hybrid",
+            "operation": operation,
+            "target_type": target_type,
+            "collection_mode": collection_mode,
         },
-        "resource_requirement": valid_resource_requirement(adapter_key=adapter_key),
+        "resource_requirement": valid_resource_requirement(adapter_key=adapter_key, capability=capability),
         "evidence": {
             "resource_profile_evidence_refs": [
                 "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
@@ -33,7 +37,7 @@ def valid_adapter_capability_requirement(
             "uses_existing_disposition_hint": True,
         },
         "observability": {
-            "requirement_id": f"{adapter_key}:content_detail:content_detail_by_url:url:hybrid",
+            "requirement_id": f"{adapter_key}:{capability}:{operation}:{target_type}:{collection_mode}",
             "profile_keys": ["account_proxy", "account"],
             "proof_refs": [
                 "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
@@ -52,10 +56,11 @@ def valid_adapter_capability_requirement(
 def valid_resource_requirement(
     *,
     adapter_key: str = "xhs",
+    capability: str = "content_detail",
 ) -> dict[str, Any]:
     return {
         "adapter_key": adapter_key,
-        "capability": "content_detail",
+        "capability": capability,
         "resource_requirement_profiles": [
             {
                 "profile_key": "account_proxy",

--- a/tests/runtime/adapter_provider_compatibility_decision_fixtures.py
+++ b/tests/runtime/adapter_provider_compatibility_decision_fixtures.py
@@ -11,10 +11,27 @@ def valid_compatibility_decision_input(
     *,
     adapter_key: str = "xhs",
     provider_key: str = "native_xhs_detail",
+    capability: str = "content_detail",
+    operation: str = "content_detail_by_url",
+    target_type: str = "url",
+    collection_mode: str = "hybrid",
 ) -> dict[str, Any]:
     return {
-        "requirement": valid_adapter_capability_requirement(adapter_key=adapter_key),
-        "offer": valid_provider_capability_offer(adapter_key=adapter_key, provider_key=provider_key),
+        "requirement": valid_adapter_capability_requirement(
+            adapter_key=adapter_key,
+            capability=capability,
+            operation=operation,
+            target_type=target_type,
+            collection_mode=collection_mode,
+        ),
+        "offer": valid_provider_capability_offer(
+            adapter_key=adapter_key,
+            provider_key=provider_key,
+            capability=capability,
+            operation=operation,
+            target_type=target_type,
+            collection_mode=collection_mode,
+        ),
         "decision_context": {
             "decision_id": "compatibility-decision-001",
             "contract_version": "v0.8.0",

--- a/tests/runtime/provider_capability_offer_fixtures.py
+++ b/tests/runtime/provider_capability_offer_fixtures.py
@@ -12,6 +12,10 @@ def valid_provider_capability_offer(
     *,
     adapter_key: str = "xhs",
     provider_key: str = "native_xhs_detail",
+    capability: str = "content_detail",
+    operation: str = "content_detail_by_url",
+    target_type: str = "url",
+    collection_mode: str = "hybrid",
 ) -> dict[str, Any]:
     resource_profile_evidence_refs = [
         "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
@@ -25,10 +29,10 @@ def valid_provider_capability_offer(
             "provider_port_ref": f"{adapter_key}:adapter-owned-provider-port",
         },
         "capability_offer": {
-            "capability": "content_detail",
-            "operation": "content_detail_by_url",
-            "target_type": "url",
-            "collection_mode": "hybrid",
+            "capability": capability,
+            "operation": operation,
+            "target_type": target_type,
+            "collection_mode": collection_mode,
         },
         "resource_support": {
             "supported_profiles": [
@@ -73,13 +77,13 @@ def valid_provider_capability_offer(
         },
         "observability": {
             "offer_id": (
-                f"{adapter_key}:{provider_key}:content_detail:"
-                "content_detail_by_url:url:hybrid:v0.8.0"
+                f"{adapter_key}:{provider_key}:{capability}:"
+                f"{operation}:{target_type}:{collection_mode}:v0.8.0"
             ),
             "provider_key": provider_key,
             "adapter_key": adapter_key,
-            "capability": "content_detail",
-            "operation": "content_detail_by_url",
+            "capability": capability,
+            "operation": operation,
             "profile_keys": ["account_proxy", "account"],
             "proof_refs": resource_profile_evidence_refs,
             "contract_version": "v0.8.0",

--- a/tests/runtime/test_adapter_provider_compatibility_decision.py
+++ b/tests/runtime/test_adapter_provider_compatibility_decision.py
@@ -94,6 +94,21 @@ class AdapterProviderCompatibilityDecisionTests(unittest.TestCase):
         self.assertEqual(decision.adapter_key, "douyin")
         self.assert_no_provider_leakage(decision)
 
+    def test_decision_matches_stable_collection_search_slice(self) -> None:
+        decision = decide_adapter_provider_compatibility(
+            valid_compatibility_decision_input(
+                capability="content_search",
+                operation="content_search_by_keyword",
+                target_type="keyword",
+                collection_mode="paginated",
+            )
+        )
+
+        self.assertEqual(decision.decision_status, COMPATIBILITY_DECISION_STATUS_MATCHED)
+        self.assertEqual(decision.capability, "content_search")
+        self.assertEqual(decision.execution_slice.operation, "content_search_by_keyword")
+        self.assert_no_provider_leakage(decision)
+
     def test_decision_returns_unmatched_when_legal_inputs_have_no_profile_tuple_intersection(self) -> None:
         input_value = copy_decision_input()
         offer = input_value["offer"]

--- a/tests/runtime/test_operation_taxonomy_consumers.py
+++ b/tests/runtime/test_operation_taxonomy_consumers.py
@@ -6,6 +6,7 @@ from syvert.adapter_capability_requirement import (
     ADAPTER_REQUIREMENT_STATUS_INVALID,
     APPROVED_ADAPTER_CAPABILITY,
     APPROVED_EXECUTION_REQUIREMENT,
+    AdapterCapabilityRequirementValidationInput,
     validate_adapter_capability_requirement,
 )
 from syvert.adapter_provider_compatibility_decision import (
@@ -51,6 +52,46 @@ class OperationTaxonomyConsumerMigrationTests(unittest.TestCase):
                 "collection_mode": stable.collection_mode,
             },
         )
+
+    def test_requirement_offer_and_decision_accept_stable_collection_runtime_slice(self) -> None:
+        requirement = copy_requirement()
+        requirement["capability"] = "content_search"
+        requirement["resource_requirement"]["capability"] = "content_search"
+        requirement["execution_requirement"] = {
+            "operation": "content_search_by_keyword",
+            "target_type": "keyword",
+            "collection_mode": "paginated",
+        }
+        requirement["observability"]["requirement_id"] = "xhs:content_search:content_search_by_keyword:keyword:paginated"
+
+        offer = copy_offer()
+        offer["capability_offer"] = {
+            "capability": "content_search",
+            "operation": "content_search_by_keyword",
+            "target_type": "keyword",
+            "collection_mode": "paginated",
+        }
+        offer["observability"]["capability"] = "content_search"
+        offer["observability"]["operation"] = "content_search_by_keyword"
+        offer["observability"]["offer_id"] = (
+            "xhs:native_xhs_detail:content_search:content_search_by_keyword:keyword:paginated:v0.8.0"
+        )
+
+        decision_input = copy_decision_input()
+        decision_input["requirement"] = requirement
+        decision_input["offer"] = offer
+
+        self.assertEqual(
+            validate_adapter_capability_requirement(
+                AdapterCapabilityRequirementValidationInput(
+                    requirement=requirement,
+                    available_resource_capabilities=("account", "proxy"),
+                )
+            ).status,
+            "declared",
+        )
+        self.assertEqual(validate_provider_capability_offer(offer).status, "declared")
+        self.assertEqual(decide_adapter_provider_compatibility(decision_input).decision_status, "matched")
 
     def test_adapter_requirement_rejects_proposed_taxonomy_candidate(self) -> None:
         requirement = copy_requirement()

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -49,6 +49,62 @@ from tests.runtime.resource_fixtures import (
 TEST_ADAPTER_KEY = "xhs"
 
 
+def make_collection_result(
+    *,
+    operation: str,
+    target_type: str,
+    target_ref: str,
+) -> dict[str, object]:
+    return {
+        "operation": operation,
+        "target": {
+            "operation": operation,
+            "target_type": target_type,
+            "target_ref": target_ref,
+            "target_display_hint": target_ref,
+        },
+        "items": [
+            {
+                "item_type": "content_summary",
+                "dedup_key": f"{operation}:item-1",
+                "source_id": "source-1",
+                "source_ref": "content://item-1",
+                "normalized": {
+                    "source_platform": TEST_ADAPTER_KEY,
+                    "source_type": "post",
+                    "source_id": "source-1",
+                    "canonical_ref": "content://item-1",
+                    "title_or_text_hint": "hint-1",
+                    "creator_ref": "creator-1",
+                    "published_at": "2026-05-09T10:00:00Z",
+                    "media_refs": ["media://1"],
+                },
+                "raw_payload_ref": "raw://item-1",
+                "source_trace": {
+                    "adapter_key": TEST_ADAPTER_KEY,
+                    "provider_path": "provider://sanitized",
+                    "resource_profile_ref": "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+                    "fetched_at": "2026-05-09T10:00:00Z",
+                    "evidence_alias": "alias://collection-page-1",
+                },
+            }
+        ],
+        "has_more": False,
+        "next_continuation": None,
+        "result_status": "complete",
+        "error_classification": "platform_failed",
+        "raw_payload_ref": "raw://page-1",
+        "source_trace": {
+            "adapter_key": TEST_ADAPTER_KEY,
+            "provider_path": "provider://sanitized",
+            "resource_profile_ref": "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+            "fetched_at": "2026-05-09T10:00:00Z",
+            "evidence_alias": "alias://collection-page-1",
+        },
+        "audit": {"page_index": 1},
+    }
+
+
 class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
     def setUp(self) -> None:
         super().setUp()
@@ -68,12 +124,12 @@ class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
 
 @dataclass(frozen=True)
 class ExtendedTaskInput(TaskInput):
-    platform_hint: str
+    platform_hint: str = ""
 
 
 @dataclass(frozen=True)
 class ExtendedTaskRequest(TaskRequest):
-    extra: str
+    extra: str = ""
 
 
 class StubContentDetailDeclarationMixin:
@@ -119,6 +175,25 @@ class SuccessfulAdapter(StubContentDetailDeclarationMixin):
                 },
             },
         }
+
+
+class CollectionSearchAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_search"})
+    supported_targets = frozenset({"keyword"})
+    supported_collection_modes = frozenset({"paginated"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(
+        adapter_key=TEST_ADAPTER_KEY,
+        capability="content_search",
+    )
+
+    def execute(self, request: TaskRequest) -> dict[str, object]:
+        self.last_request = request
+        return make_collection_result(
+            operation="content_search_by_keyword",
+            target_type="keyword",
+            target_ref=request.input.keyword or "",
+        )
 
 
 def make_execution_control_policy(scope: str) -> ExecutionControlPolicy:
@@ -647,6 +722,26 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def resource_statuses(self) -> dict[str, str]:
         snapshot = self.latest_snapshot()
         return {record.resource_id: record.status for record in snapshot.resources}
+
+    def test_execute_task_builds_collection_success_envelope_from_adapter_payload(self) -> None:
+        adapter = CollectionSearchAdapter()
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="content_search_by_keyword",
+            input=TaskInput(keyword="deep learning"),
+        )
+
+        result = execute_task_with_record(
+            request,
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-runtime-collection-1",
+        )
+
+        self.assertEqual(result.envelope["status"], "success")
+        self.assertEqual(result.envelope["operation"], "content_search_by_keyword")
+        self.assertEqual(result.envelope["target"]["target_ref"], "deep learning")
+        self.assertEqual(result.task_record.request.target_type, "keyword")
+        self.assertEqual(adapter.last_request.collection_mode, "paginated")
 
     def test_execute_task_builds_success_envelope_from_adapter_payload(self) -> None:
         adapter = SuccessfulAdapter()

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -22,6 +22,62 @@ from tests.runtime.resource_fixtures import ResourceStoreEnvMixin, baseline_reso
 TEST_ADAPTER_KEY = "xhs"
 
 
+def make_collection_result(
+    *,
+    operation: str = "content_search_by_keyword",
+    target_type: str = "keyword",
+    target_ref: str = "deep learning",
+) -> dict[str, object]:
+    return {
+        "operation": operation,
+        "target": {
+            "operation": operation,
+            "target_type": target_type,
+            "target_ref": target_ref,
+            "target_display_hint": target_ref,
+        },
+        "items": [
+            {
+                "item_type": "content_summary",
+                "dedup_key": f"{operation}:item-1",
+                "source_id": "source-1",
+                "source_ref": "content://item-1",
+                "normalized": {
+                    "source_platform": TEST_ADAPTER_KEY,
+                    "source_type": "post",
+                    "source_id": "source-1",
+                    "canonical_ref": "content://item-1",
+                    "title_or_text_hint": "hint-1",
+                    "creator_ref": "creator-1",
+                    "published_at": "2026-05-09T10:00:00Z",
+                    "media_refs": ["media://1"],
+                },
+                "raw_payload_ref": "raw://item-1",
+                "source_trace": {
+                    "adapter_key": TEST_ADAPTER_KEY,
+                    "provider_path": "provider://sanitized",
+                    "resource_profile_ref": "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+                    "fetched_at": "2026-05-09T10:00:00Z",
+                    "evidence_alias": "alias://collection-page-1",
+                },
+            }
+        ],
+        "has_more": False,
+        "next_continuation": None,
+        "result_status": "complete",
+        "error_classification": "platform_failed",
+        "raw_payload_ref": "raw://page-1",
+        "source_trace": {
+            "adapter_key": TEST_ADAPTER_KEY,
+            "provider_path": "provider://sanitized",
+            "resource_profile_ref": "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+            "fetched_at": "2026-05-09T10:00:00Z",
+            "evidence_alias": "alias://collection-page-1",
+        },
+        "audit": {"page_index": 1},
+    }
+
+
 class TaskRecordStoreEnvMixin(ResourceStoreEnvMixin):
     def setUp(self) -> None:
         super().setUp()
@@ -178,6 +234,20 @@ class OffsetTimestampSuccessAdapter:
                 },
             },
         }
+
+
+class CollectionSearchAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"content_search"})
+    supported_targets = frozenset({"keyword"})
+    supported_collection_modes = frozenset({"paginated"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(
+        adapter_key=TEST_ADAPTER_KEY,
+        capability="content_search",
+    )
+
+    def execute(self, request):
+        return make_collection_result(target_ref=request.input.keyword or "")
 
 
 class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
@@ -578,6 +648,25 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
 
 class RuntimeTaskRecordTests(TaskRecordStoreEnvMixin, unittest.TestCase):
+    def test_execute_task_with_record_round_trips_collection_search_record(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="content_search_by_keyword",
+                input=TaskInput(keyword="deep learning"),
+            ),
+            adapters={TEST_ADAPTER_KEY: CollectionSearchAdapter()},
+            task_id_factory=lambda: "task-record-collection-1",
+        )
+
+        payload = task_record_to_dict(outcome.task_record)
+        restored = task_record_from_dict(payload)
+
+        self.assertEqual(outcome.envelope["status"], "success")
+        self.assertEqual(outcome.envelope["target"]["target_ref"], "deep learning")
+        self.assertEqual(restored, outcome.task_record)
+        self.assertEqual(restored.request.target_type, "keyword")
+
     def test_execute_task_with_record_keeps_preaccepted_failure_outside_durable_history(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(


### PR DESCRIPTION
## Scope
- 迁移 runtime success path、TaskRecord durable truth 与 task-result consumers，使 `content_search_by_keyword` / `content_list_by_creator` 消费公共 collection envelope。
- 放宽 AdapterRequirement / ProviderOffer / CompatibilityDecision 的 stable runtime slice 消费边界，允许 `FR-0403` 两个稳定 collection operation 通过既有 shared resource baseline 完成 compatibility 判定。
- 保持 `content_detail_by_url` baseline 与 provider no-leakage 行为不变。

## 不包含内容
- 不包含 #408 runtime carrier 重写。
- 不包含 #410 evidence artifact 与 two-reference proof。
- 不包含 #411 release / sprint / FR closeout truth。

## 验证
- `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_runtime tests.runtime.test_adapter_provider_compatibility_decision tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_provider_no_leakage_guard tests.runtime.test_cli_http_same_path tests.runtime.test_real_adapter_regression`
- `python3 scripts/spec_guard.py --mode ci --all`
- `python3 scripts/docs_guard.py --mode ci`
- `python3 scripts/workflow_guard.py --mode ci`
- `python3 scripts/version_guard.py --mode ci`
- `BASE=$(git merge-base origin/main HEAD) && HEAD_SHA=$(git rev-parse HEAD) && python3 scripts/governance_gate.py --mode ci --base-sha "$BASE" --head-sha "$HEAD_SHA" --head-ref issue-409-403-v1-3-0-read-side-collection-consumer-migration`

Closes #409
