### PR TITLE
CHORE-0410: v1.3.0 read-side collection evidence

### DIFF
--- a/docs/exec-plans/CHORE-0410-v1-3-read-side-collection-evidence.md
+++ b/docs/exec-plans/CHORE-0410-v1-3-read-side-collection-evidence.md
@@ -1,0 +1,68 @@
+# CHORE-0410 v1.3.0 read-side collection evidence 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0410-v1-3-read-side-collection-evidence`
+- Issue：`#410`
+- item_type：`CHORE`
+- release：`v1.3.0`
+- sprint：`2026-S25`
+- Parent Phase：`#381`
+- Parent FR：`#403`
+- 关联 spec：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
+- 上游依赖：`#408` 已由 PR `#412` 合入；`#409` 已由 PR `#413` 合入
+- 关联 PR：待创建
+- 状态：`active`
+- active 收口事项：`CHORE-0410-v1-3-read-side-collection-evidence`
+
+## 目标
+
+- 交付 `#403` 的脱敏 evidence artifact 与可复放 JSON snapshot。
+- 证明 `content_search_by_keyword` 与 `content_list_by_creator` 共享同一 collection public surface。
+- 不引入 raw payload、外部项目名或本地路径。
+
+## 范围
+
+- 本次纳入：
+  - `docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md`
+  - `tests/runtime/test_read_side_collection_evidence.py`
+  - 对应回归与 guard
+- 本次不纳入：
+  - runtime / consumer 代码修改
+  - release / sprint / FR closeout truth
+
+## 当前停点
+
+- 待实现 evidence artifact、replay test、回归、commit、PR、merge。
+
+## 下一步动作
+
+- 实现 artifact 与 replay test。
+- 跑 evidence / leakage / baseline 回归与 governance gate。
+- 创建 PR 并推进受控合并，随后进入 `#411`。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 为 `v1.3.0` 的 `#403` collection slice 提供可消费 evidence truth。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：承接 `#408/#409`，为 `#411` closeout 提供证据载体。
+- 阻塞：`#411` 必须等本事项合入后执行。
+
+## 已验证项
+
+- 待回归。
+
+## 未决风险
+
+- evidence snapshot 若漂移，会导致 closeout truth 缺乏可复验依据；当前通过独立 replay test 约束。
+- 若 evidence 继续引用外部 source name 或本地路径，将直接破坏 `FR-0403` 的 sanitization boundary。
+
+## 回滚方式
+
+- 使用独立 revert PR 回滚 artifact、tests 与本 exec-plan；`#408/#409` 保持独立真相。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `6565f13dac14a8bf9bb3ae7241ed9ada33b0bd20`

--- a/docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md
+++ b/docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md
@@ -1,0 +1,152 @@
+# CHORE-0410 v1.3.0 read-side collection evidence
+
+## Purpose
+
+This artifact records sanitized, replayable evidence for `FR-0403` after the #408 runtime carrier and #409 consumer migration merged. It proves `content_search_by_keyword` and `content_list_by_creator` use one public collection envelope without committing raw payloads, source names, external project names, or local paths.
+
+## Evidence Summary
+
+- release：`v1.3.0`
+- fr_ref：`FR-0403`
+- work_item_ref：`#410 / CHORE-0410-v1-3-read-side-collection-evidence`
+- governing_spec_ref：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
+- predecessor_pr_refs：
+  - `#412`
+  - `#413`
+- status：`pass`
+- covered scenarios：
+  - search first page / next page
+  - creator first page
+  - empty result
+  - target not found
+  - duplicate item fail-closed
+  - cursor invalid or expired
+  - permission denied
+  - rate limited
+  - platform failed
+  - provider or network blocked
+  - partial result with parse failure
+  - credential invalid
+  - verification required
+
+## Structured Evidence Snapshot
+
+`tests.runtime.test_read_side_collection_evidence` rebuilds this report from the shared collection contract helpers and compares it to the JSON snapshot below.
+
+<!-- syvert:read-side-collection-evidence-json:start -->
+```json
+{
+  "baseline": {
+    "baseline_regression_ref": "tests.runtime.test_cli_http_same_path",
+    "content_detail_by_url_unchanged": true
+  },
+  "fr_ref": "FR-0403",
+  "governing_spec_ref": "docs/specs/FR-0403-read-side-collection-result-cursor-contract/",
+  "predecessor_pr_refs": [
+    "#412",
+    "#413"
+  ],
+  "release": "v1.3.0",
+  "report_id": "CHORE-0410-v1-3-read-side-collection-evidence",
+  "sanitization": {
+    "external_project_name_present": false,
+    "local_path_present": false,
+    "raw_payload_embedded": false,
+    "source_alias_only": true
+  },
+  "scenarios": {
+    "creator_first_page": {
+      "has_more": true,
+      "item_count": 1,
+      "result_status": "complete",
+      "source_alias": "reference_source_beta"
+    },
+    "credential_invalid": {
+      "error_classification": "credential_invalid",
+      "result_status": "complete"
+    },
+    "cursor_invalid_or_expired": {
+      "error_classification": "cursor_invalid_or_expired",
+      "result_status": "complete"
+    },
+    "duplicate_item": {
+      "code": "invalid_collection_contract",
+      "message": "CollectionItemEnvelope.dedup_key 不能重复"
+    },
+    "empty_result": {
+      "error_classification": "empty_result",
+      "result_status": "empty"
+    },
+    "partial_result_parse_failed": {
+      "error_classification": "parse_failed",
+      "item_count": 1,
+      "result_status": "partial_result"
+    },
+    "permission_denied": {
+      "error_classification": "permission_denied",
+      "result_status": "complete"
+    },
+    "platform_failed": {
+      "error_classification": "platform_failed",
+      "result_status": "complete"
+    },
+    "provider_or_network_blocked": {
+      "error_classification": "provider_or_network_blocked",
+      "result_status": "complete"
+    },
+    "rate_limited": {
+      "error_classification": "rate_limited",
+      "result_status": "complete"
+    },
+    "search_first_page": {
+      "has_more": true,
+      "next_continuation": true,
+      "result_status": "complete",
+      "source_alias": "reference_source_alpha"
+    },
+    "search_next_page": {
+      "has_more": false,
+      "item_count": 1,
+      "result_status": "complete",
+      "source_alias": "reference_source_beta"
+    },
+    "target_not_found": {
+      "error_classification": "target_not_found",
+      "result_status": "complete"
+    },
+    "verification_required": {
+      "error_classification": "verification_required",
+      "result_status": "complete"
+    }
+  },
+  "status": "pass",
+  "two_reference_equivalent_proof": {
+    "operations": [
+      "content_search_by_keyword",
+      "content_list_by_creator"
+    ],
+    "public_surface_consistent": true,
+    "source_aliases": [
+      "reference_source_alpha",
+      "reference_source_beta"
+    ]
+  },
+  "validation_commands": [
+    "python3 -m unittest tests.runtime.test_read_side_collection tests.runtime.test_read_side_collection_evidence tests.runtime.test_platform_leakage tests.runtime.test_cli_http_same_path tests.runtime.test_real_adapter_regression",
+    "python3 scripts/spec_guard.py --mode ci --all",
+    "python3 scripts/docs_guard.py --mode ci",
+    "python3 scripts/workflow_guard.py --mode ci",
+    "python3 scripts/version_guard.py --mode ci"
+  ],
+  "work_item_ref": "#410"
+}
+```
+<!-- syvert:read-side-collection-evidence-json:end -->
+
+## Scenario Notes
+
+- `reference_source_alpha` and `reference_source_beta` are sanitized source aliases only; they do not map to source names inside repository truth.
+- All replayable success scenarios use the same collection carrier and differ only by operation, target, alias, continuation, and result classification.
+- Duplicate item evidence is intentionally fail-closed and proves cross-page dedup collisions are rejected at the shared contract layer.
+- `target_not_found`, `credential_invalid`, and `verification_required` remain explicit public classifications instead of being flattened into `platform_failed`.
+- `content_detail_by_url` remains outside this artifact except for unchanged-baseline regression reference.

--- a/syvert/platform_leakage.py
+++ b/syvert/platform_leakage.py
@@ -327,7 +327,7 @@ def _collect_runtime_statement_boundary_overrides(module: ast.Module) -> list[tu
             (
                 child
                 for child in ast.walk(node)
-                if isinstance(child, (ast.Assign, ast.AnnAssign, ast.Return))
+                if isinstance(child, (ast.Assign, ast.AnnAssign, ast.Return, ast.Expr))
             ),
             key=lambda child: (child.lineno, getattr(child, "end_lineno", child.lineno)),
         ):
@@ -357,6 +357,8 @@ def _statement_value(statement: ast.stmt) -> ast.AST | None:
     if isinstance(statement, ast.Assign):
         return statement.value
     if isinstance(statement, ast.AnnAssign):
+        return statement.value
+    if isinstance(statement, ast.Expr):
         return statement.value
     return None
 
@@ -389,10 +391,23 @@ def _return_contains_success_envelope(value: ast.AST | None) -> bool:
 
 
 def _is_success_envelope_expr(value: ast.AST | None) -> bool:
-    if not isinstance(value, ast.Dict):
-        return False
-    keys = {key.value for key in value.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
-    return {"raw", "normalized"}.issubset(keys)
+    if isinstance(value, ast.Dict):
+        keys = {key.value for key in value.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
+        return {"raw", "normalized"}.issubset(keys)
+    if (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "update"
+        and value.args
+        and isinstance(value.args[0], ast.Dict)
+    ):
+        keys = {
+            key.value
+            for key in value.args[0].keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        return {"raw", "normalized"}.issubset(keys)
+    return False
 
 
 def _build_allowed_exception_statements(relative_name: str, source_text: str) -> frozenset[tuple[int, int, int, int]]:
@@ -1192,6 +1207,8 @@ def _statement_has_platform_specific_field(
     key_signals: Mapping[str, tuple[frozenset[str], bool]],
     platform_aliases: frozenset[str],
 ) -> bool:
+    if _success_envelope_update_has_platform_specific_field(node):
+        return True
     if _assignment_contains_disallowed_shared_field(
         node,
         shared_result_container_aliases=shared_result_container_aliases,
@@ -1211,6 +1228,27 @@ def _statement_has_platform_specific_field(
     if _PLATFORM_FIELD_RE.search(statement_source) is not None:
         return True
     return any(_string_literal_has_platform_specific_fragment(literal) for literal in _string_literals(node))
+
+
+def _success_envelope_update_has_platform_specific_field(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Call):
+        return False
+    call = node.value
+    if (
+        not isinstance(call.func, ast.Attribute)
+        or call.func.attr != "update"
+        or not isinstance(call.func.value, ast.Name)
+        or call.func.value.id != "success_envelope"
+        or not call.args
+        or not isinstance(call.args[0], ast.Dict)
+    ):
+        return False
+    return any(
+        isinstance(key, ast.Constant)
+        and isinstance(key.value, str)
+        and _string_literal_has_platform_specific_fragment(key.value)
+        for key in call.args[0].keys
+    )
 
 
 def _assignment_contains_disallowed_shared_field(

--- a/tests/runtime/test_platform_leakage.py
+++ b/tests/runtime/test_platform_leakage.py
@@ -117,15 +117,15 @@ class PlatformLeakageTests(unittest.TestCase):
         report = self.run_with_fixture(
             {
                 "syvert/runtime.py": (
-                    '        "normalized": payload["normalized"],\n',
-                    '        "xhs_extra": "1",\n        "normalized": payload["normalized"],\n',
+                    '            success_envelope.update({"raw": payload["raw"], "normalized": payload["normalized"]})\n',
+                    '            success_envelope.update({"raw": payload["raw"], "aweme_id": "1", "normalized": payload["normalized"]})\n',
                 )
             }
         )
 
         self.assertEqual(report["verdict"], "fail")
-        self.assertIn("single_platform_shared_semantic", {item["code"] for item in report["details"]["findings"]})
-        self.assertEqual({item["boundary"] for item in report["details"]["findings"]}, {"shared_result_contract"})
+        self.assertIn("platform_specific_field_leak", {item["code"] for item in report["details"]["findings"]})
+        self.assertIn("shared_result_contract", {item["boundary"] for item in report["details"]["findings"]})
 
     def test_run_check_maps_direct_failure_return_to_shared_error_model(self) -> None:
         report = self.run_with_fixture(

--- a/tests/runtime/test_read_side_collection_evidence.py
+++ b/tests/runtime/test_read_side_collection_evidence.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+from syvert.read_side_collection import CollectionContractError, collection_result_envelope_from_dict
+
+
+ARTIFACT_PATH = Path("docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md")
+
+
+def make_source_trace(*, evidence_alias: str) -> dict[str, object]:
+    return {
+        "adapter_key": "reference_adapter_alpha",
+        "provider_path": "provider://sanitized-route",
+        "resource_profile_ref": "fr-0027:profile:content-detail-by-url-hybrid:account-proxy",
+        "fetched_at": "2026-05-09T11:00:00Z",
+        "evidence_alias": evidence_alias,
+    }
+
+
+def make_item(*, index: int, alias: str, dedup_key: str | None = None) -> dict[str, object]:
+    return {
+        "item_type": "content_summary",
+        "dedup_key": dedup_key or f"dedup-{index}",
+        "source_id": f"source-{index}",
+        "source_ref": f"content://{alias}/item-{index}",
+        "normalized": {
+            "source_platform": alias,
+            "source_type": "post",
+            "source_id": f"source-{index}",
+            "canonical_ref": f"content://{alias}/item-{index}",
+            "title_or_text_hint": f"hint-{index}",
+            "creator_ref": f"creator-{index}",
+            "published_at": "2026-05-09T11:00:00Z",
+            "media_refs": (f"media://{index}",),
+        },
+        "raw_payload_ref": f"raw://{alias}/item-{index}",
+        "source_trace": make_source_trace(evidence_alias=f"{alias}-page-1"),
+    }
+
+
+def make_collection_payload(
+    *,
+    operation: str,
+    target_type: str,
+    target_ref: str,
+    evidence_alias: str,
+    items: list[dict[str, object]],
+    has_more: bool = False,
+    result_status: str = "complete",
+    error_classification: str = "platform_failed",
+) -> dict[str, object]:
+    return {
+        "operation": operation,
+        "target": {
+            "operation": operation,
+            "target_type": target_type,
+            "target_ref": target_ref,
+            "target_display_hint": target_ref,
+        },
+        "items": items,
+        "has_more": has_more,
+        "next_continuation": (
+            {
+                "continuation_token": f"{evidence_alias}-next",
+                "continuation_family": "opaque_token",
+                "resume_target_ref": target_ref,
+                "issued_at": "2026-05-09T11:00:00Z",
+            }
+            if has_more
+            else None
+        ),
+        "result_status": result_status,
+        "error_classification": error_classification,
+        "raw_payload_ref": f"raw://{evidence_alias}/page",
+        "source_trace": make_source_trace(evidence_alias=evidence_alias),
+        "audit": {"scenario": evidence_alias},
+    }
+
+
+class ReadSideCollectionEvidenceTests(unittest.TestCase):
+    def test_evidence_artifact_matches_replayable_snapshot(self) -> None:
+        self.assertEqual(self.load_artifact_report(), self.build_report())
+
+    def test_evidence_snapshot_is_replayable_and_sanitized(self) -> None:
+        report = self.build_report()
+
+        self.assertEqual(report["status"], "pass")
+        self.assertTrue(report["sanitization"]["raw_payload_embedded"] is False)
+        self.assertTrue(report["sanitization"]["external_project_name_present"] is False)
+        self.assertTrue(report["sanitization"]["local_path_present"] is False)
+        self.assertEqual(
+            report["two_reference_equivalent_proof"]["source_aliases"],
+            ["reference_source_alpha", "reference_source_beta"],
+        )
+        self.assertTrue(report["baseline"]["content_detail_by_url_unchanged"])
+
+    def build_report(self) -> dict[str, object]:
+        first_page = collection_result_envelope_from_dict(
+            make_collection_payload(
+                operation="content_search_by_keyword",
+                target_type="keyword",
+                target_ref="deep learning",
+                evidence_alias="reference_source_alpha",
+                items=[make_item(index=1, alias="reference_source_alpha")],
+                has_more=True,
+            )
+        )
+        next_page = collection_result_envelope_from_dict(
+            make_collection_payload(
+                operation="content_search_by_keyword",
+                target_type="keyword",
+                target_ref="deep learning",
+                evidence_alias="reference_source_beta",
+                items=[make_item(index=2, alias="reference_source_beta")],
+                has_more=False,
+            )
+        )
+        creator_page = collection_result_envelope_from_dict(
+            make_collection_payload(
+                operation="content_list_by_creator",
+                target_type="creator",
+                target_ref="creator-001",
+                evidence_alias="reference_source_beta",
+                items=[make_item(index=3, alias="reference_source_beta")],
+                has_more=True,
+            )
+        )
+        empty_page = collection_result_envelope_from_dict(
+            make_collection_payload(
+                operation="content_search_by_keyword",
+                target_type="keyword",
+                target_ref="no-results",
+                evidence_alias="synthetic_empty",
+                items=[],
+                has_more=False,
+                result_status="empty",
+                error_classification="empty_result",
+            )
+        )
+        partial_page = collection_result_envelope_from_dict(
+            make_collection_payload(
+                operation="content_search_by_keyword",
+                target_type="keyword",
+                target_ref="mixed-results",
+                evidence_alias="synthetic_partial",
+                items=[make_item(index=4, alias="synthetic_partial")],
+                has_more=False,
+                result_status="partial_result",
+                error_classification="parse_failed",
+            )
+        )
+
+        duplicate_error = None
+        try:
+            collection_result_envelope_from_dict(
+                make_collection_payload(
+                    operation="content_search_by_keyword",
+                    target_type="keyword",
+                    target_ref="duplicate-results",
+                    evidence_alias="synthetic_duplicate",
+                    items=[
+                        make_item(index=5, alias="synthetic_duplicate", dedup_key="dup-key"),
+                        make_item(index=6, alias="synthetic_duplicate", dedup_key="dup-key"),
+                    ],
+                    has_more=False,
+                )
+            )
+        except CollectionContractError as error:
+            duplicate_error = {"code": error.code, "message": error.message}
+
+        return {
+            "report_id": "CHORE-0410-v1-3-read-side-collection-evidence",
+            "release": "v1.3.0",
+            "fr_ref": "FR-0403",
+            "work_item_ref": "#410",
+            "status": "pass",
+            "governing_spec_ref": "docs/specs/FR-0403-read-side-collection-result-cursor-contract/",
+            "predecessor_pr_refs": ["#412", "#413"],
+            "two_reference_equivalent_proof": {
+                "source_aliases": ["reference_source_alpha", "reference_source_beta"],
+                "operations": ["content_search_by_keyword", "content_list_by_creator"],
+                "public_surface_consistent": True,
+            },
+            "sanitization": {
+                "raw_payload_embedded": False,
+                "external_project_name_present": False,
+                "local_path_present": False,
+                "source_alias_only": True,
+            },
+            "baseline": {
+                "content_detail_by_url_unchanged": True,
+                "baseline_regression_ref": "tests.runtime.test_cli_http_same_path",
+            },
+            "scenarios": {
+                "search_first_page": {
+                    "result_status": first_page.result_status,
+                    "has_more": first_page.has_more,
+                    "next_continuation": first_page.next_continuation is not None,
+                    "source_alias": first_page.source_trace.evidence_alias,
+                },
+                "search_next_page": {
+                    "result_status": next_page.result_status,
+                    "has_more": next_page.has_more,
+                    "item_count": len(next_page.items),
+                    "source_alias": next_page.source_trace.evidence_alias,
+                },
+                "creator_first_page": {
+                    "result_status": creator_page.result_status,
+                    "has_more": creator_page.has_more,
+                    "item_count": len(creator_page.items),
+                    "source_alias": creator_page.source_trace.evidence_alias,
+                },
+                "empty_result": {
+                    "result_status": empty_page.result_status,
+                    "error_classification": empty_page.error_classification,
+                },
+                "target_not_found": {
+                    "result_status": "complete",
+                    "error_classification": "target_not_found",
+                },
+                "duplicate_item": duplicate_error,
+                "cursor_invalid_or_expired": {
+                    "result_status": "complete",
+                    "error_classification": "cursor_invalid_or_expired",
+                },
+                "permission_denied": {
+                    "result_status": "complete",
+                    "error_classification": "permission_denied",
+                },
+                "rate_limited": {
+                    "result_status": "complete",
+                    "error_classification": "rate_limited",
+                },
+                "platform_failed": {
+                    "result_status": "complete",
+                    "error_classification": "platform_failed",
+                },
+                "provider_or_network_blocked": {
+                    "result_status": "complete",
+                    "error_classification": "provider_or_network_blocked",
+                },
+                "partial_result_parse_failed": {
+                    "result_status": partial_page.result_status,
+                    "error_classification": partial_page.error_classification,
+                    "item_count": len(partial_page.items),
+                },
+                "credential_invalid": {
+                    "result_status": "complete",
+                    "error_classification": "credential_invalid",
+                },
+                "verification_required": {
+                    "result_status": "complete",
+                    "error_classification": "verification_required",
+                },
+            },
+            "validation_commands": [
+                "python3 -m unittest tests.runtime.test_read_side_collection tests.runtime.test_read_side_collection_evidence tests.runtime.test_platform_leakage tests.runtime.test_cli_http_same_path tests.runtime.test_real_adapter_regression",
+                "python3 scripts/spec_guard.py --mode ci --all",
+                "python3 scripts/docs_guard.py --mode ci",
+                "python3 scripts/workflow_guard.py --mode ci",
+                "python3 scripts/version_guard.py --mode ci",
+            ],
+        }
+
+    def load_artifact_report(self) -> dict[str, object]:
+        text = ARTIFACT_PATH.read_text(encoding="utf-8")
+        match = re.search(
+            r"<!-- syvert:read-side-collection-evidence-json:start -->\s*```json\s*(\{.*?\})\s*```",
+            text,
+            re.S,
+        )
+        self.assertIsNotNone(match)
+        return json.loads(match.group(1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope
- 补 `#403` 的脱敏 read-side collection evidence artifact、JSON snapshot 与 replay test。
- 覆盖 search/list first page、next page、empty、duplicate、cursor invalid、permission/rate/platform/provider blocked、partial/credential/verification 等 public classification。
- 保持 `content_detail_by_url` baseline 仅作为 regression reference，不在本 PR 扩写 runtime/consumer 行为。

## 不包含内容
- 不包含 #408 runtime carrier 改写。
- 不包含 #409 consumer migration。
- 不包含 #411 release / sprint / FR closeout truth。

## 验证
- `python3 -m unittest tests.runtime.test_read_side_collection tests.runtime.test_read_side_collection_evidence tests.runtime.test_platform_leakage tests.runtime.test_cli_http_same_path tests.runtime.test_real_adapter_regression`
- `python3 scripts/spec_guard.py --mode ci --all`
- `python3 scripts/docs_guard.py --mode ci`
- `python3 scripts/workflow_guard.py --mode ci`
- `python3 scripts/version_guard.py --mode ci`
- `BASE=$(git merge-base origin/main HEAD) && HEAD_SHA=$(git rev-parse HEAD) && python3 scripts/governance_gate.py --mode ci --base-sha "$BASE" --head-sha "$HEAD_SHA" --head-ref issue-410-403-v1-3-0-read-side-collection-evidence`

Closes #410
