### PR TITLE
CHORE-0411: v1.3.0 read-side collection closeout

### DIFF
--- a/docs/exec-plans/CHORE-0411-v1-3-read-side-collection-closeout.md
+++ b/docs/exec-plans/CHORE-0411-v1-3-read-side-collection-closeout.md
@@ -1,0 +1,78 @@
+# CHORE-0411 v1.3.0 read-side collection closeout 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0411-v1-3-read-side-collection-closeout`
+- Issue：`#411`
+- item_type：`CHORE`
+- release：`v1.3.0`
+- sprint：`2026-S25`
+- Parent Phase：`#381`
+- Parent FR：`#403`
+- 关联 spec：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
+- 上游依赖：
+  - `#406` / PR `#407`
+  - `#408` / PR `#412`
+  - `#409` / PR `#413`
+  - `#410` / PR `#414`
+- 关联 PR：待创建
+- 状态：`active`
+- active 收口事项：`CHORE-0411-v1-3-read-side-collection-closeout`
+
+## 目标
+
+- 对齐 `#403` / `v1.3.0` 的 release truth、sprint truth、GitHub issue state 与 deferred boundary。
+- 在本 Work Item 内完成 `v1.3.0` tag / GitHub Release / published truth carrier。
+- 不关闭 Phase `#381`，不推进 `#404/#405`。
+
+## 范围
+
+- 本次纳入：
+  - `docs/releases/v1.3.0.md`
+  - `docs/sprints/2026-S25.md`
+  - `docs/exec-plans/artifacts/CHORE-0411-v1-3-read-side-collection-closeout-evidence.md`
+  - 当前 exec-plan
+- 本次不纳入：
+  - 新 runtime / consumer / evidence 实现
+  - `#404/#405` 执行
+  - Phase `#381` closeout
+
+## 当前停点
+
+- `#406/#408/#409/#410` 已合入并关闭。
+- `v1.3.0` annotated tag 与 GitHub Release 已创建，待回写 published truth carrier。
+- 待 closeout PR、review、merge 与 issue closeout。
+
+## 下一步动作
+
+- 回写 release / sprint / closeout evidence truth。
+- 跑 docs / workflow / version / governance gate。
+- 创建并合并 closeout PR。
+- 关闭 `#403` 与 `#411`。
+
+## 当前 checkpoint 推进的 release 目标
+
+- 将 `v1.3.0` 从 planning truth 升级为 published truth。
+
+## 当前事项在 sprint 中的角色 / 阻塞
+
+- 角色：`#403` 首个 collection batch 的最终收口。
+- 阻塞：closeout PR 合入前，`#403` 仍不得关闭。
+
+## 已验证项
+
+- `v1.3.0` annotated tag 已创建并推送。
+- GitHub Release `v1.3.0` 已创建。
+
+## 未决风险
+
+- 若 closeout truth 漏写 deferred boundary，会错误暗示 Phase `#381` 已完成。
+- 若 published truth carrier 漏写 tag object / target / release URL，将破坏版本管理一致性。
+
+## 回滚方式
+
+- 若 closeout truth 错误，使用独立修正 PR 与 GitHub issue update 修正；不回滚已合入 runtime/consumer/evidence PR。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- `3fbb7f862257e122bd323dd650abcf7457814a91`

--- a/docs/exec-plans/artifacts/CHORE-0411-v1-3-read-side-collection-closeout-evidence.md
+++ b/docs/exec-plans/artifacts/CHORE-0411-v1-3-read-side-collection-closeout-evidence.md
@@ -1,0 +1,70 @@
+# CHORE-0411 v1.3.0 read-side collection closeout evidence
+
+## 目的
+
+记录 `v1.3.0` read-side collection batch 的 release truth、GitHub issue state、PR / merge commit 对账和 deferred boundary。
+
+## Work Item
+
+- Issue：`#411`
+- item_key：`CHORE-0411-v1-3-read-side-collection-closeout`
+- item_type：`CHORE`
+- release：`v1.3.0`
+- sprint：`2026-S25`
+- Parent Phase：`#381`
+- Parent FR：`#403`
+
+## Gate Summary
+
+- `#406/#408/#409/#410` 已全部合入并关闭。
+- `#403` 的 formal spec、runtime、consumer 与 evidence truth 已齐备。
+- `v1.3.0` annotated tag 与 GitHub Release 已创建。
+- `docs/releases/v1.3.0.md` 与 `docs/sprints/2026-S25.md` 已回写 closeout truth。
+- Phase `#381`、`#404`、`#405` 保持 open，不被 `v1.3.0` 隐式关闭。
+
+## Gate Item Matrix
+
+| gate_id | required | status | 结论 | evidence refs |
+| --- | ---: | --- | --- | --- |
+| `formal_spec` | yes | pass | `FR-0403` formal spec suite 已冻结。 | PR `#407` |
+| `runtime_carrier` | yes | pass | collection runtime carrier 已合入。 | PR `#412` |
+| `consumer_migration` | yes | pass | TaskRecord / runtime / compatibility consumers 已迁移。 | PR `#413` |
+| `evidence_artifact` | yes | pass | sanitized evidence artifact 与 replay test 已合入。 | PR `#414` |
+| `stable_baseline` | yes | pass | `content_detail_by_url` baseline 未漂移。 | `tests.runtime.test_cli_http_same_path`、`tests.runtime.test_real_adapter_regression` |
+| `release_truth_alignment` | yes | pass | `v1.3.0` tag、GitHub Release、release index 与 sprint index 已对齐。 | `docs/releases/v1.3.0.md`、`gh release view v1.3.0` |
+| `deferred_boundary` | yes | pass | Phase `#381` 与 `#404/#405` 仍 open / deferred。 | GitHub issues `#381`、`#404`、`#405` |
+
+## PR / Main 对账
+
+- PR `#407` merge commit：`d8abb3fe5b57c4b563d5f58ea420f7479bbf2e57`
+- PR `#412` merge commit：`672e1c2d1e489089c670f0c09fe991b2924976d4`
+- PR `#413` merge commit：`6565f13dac14a8bf9bb3ae7241ed9ada33b0bd20`
+- PR `#414` merge commit：`3fbb7f862257e122bd323dd650abcf7457814a91`
+- release tag object：`6d160896800ef46594dac4a28dcc84500628ec32`
+- release tag target：`3fbb7f862257e122bd323dd650abcf7457814a91`
+- GitHub Release：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.3.0`
+
+## GitHub Issue 状态
+
+| Issue | Role | State |
+| --- | --- | --- |
+| `#381` | Phase | open |
+| `#403` | FR | closeout pending current Work Item |
+| `#404` | deferred FR | open |
+| `#405` | deferred FR | open |
+| `#406` | spec Work Item | closed completed |
+| `#408` | runtime Work Item | closed completed |
+| `#409` | consumer Work Item | closed completed |
+| `#410` | evidence Work Item | closed completed |
+| `#411` | closeout Work Item | in progress |
+
+## 完成语义
+
+`v1.3.0` 完成后满足：
+
+- `v1.3.0` annotated tag 指向 `#410` 合入后的主干提交 `3fbb7f862257e122bd323dd650abcf7457814a91`
+- GitHub Release `v1.3.0` 已存在且非 draft / non-prerelease
+- `docs/releases/v1.3.0.md` 已回写 published truth carrier
+- `docs/sprints/2026-S25.md` 已回写 closeout truth
+- `#403` 与 `#411` 可在 closeout PR 合入后关闭
+- Phase `#381`、`#404`、`#405` 继续保持 open

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -2,51 +2,88 @@
 
 ## 目标
 
-- 规划并冻结 `#403` 首个 read-side collection contract batch。
-- 为 `content_search_by_keyword` 与 `content_list_by_creator` 建立可审查的 fixture/error inventory、formal spec suite、release planning index 与 sprint index。
-- 保持 `v1.1.0` taxonomy、`v1.2.0` resource governance 与 `content_detail_by_url` stable baseline 不变。
+- 发布 `#403` 首个 read-side collection batch，完成 `content_search_by_keyword` 与 `content_list_by_creator` 的 formal spec、runtime carrier、consumer migration 与 sanitized evidence。
+- 保持 `content_detail_by_url` stable baseline、`v1.1.0` taxonomy foundation 与 `v1.2.0` resource governance foundation 不变。
+- 明确 `#404/#405` 与 Phase `#381` 后续项仍为 deferred，不把整个 Phase 3 绑定到 `v1.3.0`。
 
 ## 明确不在范围
 
-- 不把整个 Phase 3 绑定到 `v1.3.0`。
-- 不交付 runtime carrier、consumer migration、fake/reference tests implementation、release closeout、annotated tag 或 GitHub Release。
-- 不交付 `#404` comment collection contract 或 `#405` creator/media read contract 的 execution Work Item。
+- 不关闭 Phase `#381`。
+- 不交付 `#404` comment hierarchy / comment collection contract。
+- 不交付 `#405` creator profile / media asset read contract。
+- 不交付 batch execution、dataset sink、scheduled execution、provider selector、fallback、marketplace 或上层内容库工作流。
 - 不提交 raw fixture payload files，不记录外部项目名或本地路径。
 
 ## 目标判据
 
-- FR `#403` formal spec suite 已合入并冻结 collection target、continuation、result envelope、item envelope、dedup key、source trace、raw/normalized 双轨与公共错误分类。
-- Batch 0 artifact 已为 `#403` 提供 reviewable fixture/error inventory。
-- `docs/sprints/2026-S25.md` 已绑定本批次执行 truth。
-- `#406` 作为 spec Work Item 完成 spec review 所需准备并通过文档/治理门禁。
+- FR `#403` formal spec suite 已冻结 collection target、continuation、result envelope、item envelope、dedup key、source trace、raw payload ref、normalized item 与公共错误分类。
+- runtime 已能用统一 collection envelope 承载 `content_search_by_keyword` 与 `content_list_by_creator`。
+- TaskRecord durable truth、result query 与 compatibility consumers 已迁移到 collection public surface。
+- sanitized evidence artifact 可复验证明 search/list first page、next page、empty、duplicate、cursor invalid、permission/rate/platform/provider blocked、partial/credential/verification 边界成立。
+- `content_detail_by_url` baseline 回归保持通过。
 
-## Closeout evidence
+## Closeout Evidence
 
-- release gate / contract test / evidence：本文件当前只承载 planning truth；runtime evidence 与 release closeout 由后续 Work Item 承接。
-- GitHub Phase / FR / Work Item closeout：当前仅启动 Phase `#381` 下的 FR `#403` 首批 Work Item `#406`。
-- closeout Issue / Work Item：待后续 closeout Work Item 确认。
-- closeout PR：待后续 closeout PR 确认。
-- main merge commit：待后续 closeout 回写。
-- reconciliation status：planning only；未声明发布完成。
+- Formal spec：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
+- Runtime carrier：`syvert/read_side_collection.py`
+- Runtime / consumer tests：
+  - `tests/runtime/test_read_side_collection.py`
+  - `tests/runtime/test_task_record.py`
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_adapter_provider_compatibility_decision.py`
+  - `tests/runtime/test_operation_taxonomy_consumers.py`
+- Evidence artifact：`docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md`
+- Release closeout evidence：`docs/exec-plans/artifacts/CHORE-0411-v1-3-read-side-collection-closeout-evidence.md`
+- GitHub Phase / FR / Work Item chain：Phase `#381`、FR `#403`、Work Items `#406`、`#408`、`#409`、`#410`、`#411`
+- closeout Issue / Work Item：`#411`
+- closeout PR：`#415`
+- implementation PRs：
+  - `#407` spec freeze
+  - `#412` runtime carrier
+  - `#413` consumer migration
+  - `#414` evidence artifact
+- main merge commits：
+  - `#407` -> `d8abb3fe5b57c4b563d5f58ea420f7479bbf2e57`
+  - `#412` -> `672e1c2d1e489089c670f0c09fe991b2924976d4`
+  - `#413` -> `6565f13dac14a8bf9bb3ae7241ed9ada33b0bd20`
+  - `#414` -> `3fbb7f862257e122bd323dd650abcf7457814a91`
+- reconciliation status：release index、sprint index、tag、GitHub Release 与 Work Item closeout truth 已对齐；Phase `#381`、`#404`、`#405` 保持 open/deferred
 
 ## 版本管理
 
 - 版本类型：minor
-- 是否改变公共 contract：是，目标是新增 read-side collection formal spec foundation；当前文件只声明 planning truth。
-- tag / GitHub Release：正式 release closeout 必须创建 annotated tag 与 GitHub Release；当前 planning 批次不得声明发布完成。
-- 发布完成后必须回写 published truth carrier；规则见 `docs/process/version-management.md`
+- 是否改变公共 contract：是，新增首个 read-side collection public contract
+- tag / GitHub Release：`v1.3.0` annotated tag 与 GitHub Release 已创建
+- 发布完成后 published truth carrier 已回写；规则见 `docs/process/version-management.md`
+
+## Published truth carrier
+
+- annotated tag object：`6d160896800ef46594dac4a28dcc84500628ec32`
+- tag target：`v1.3.0` -> `3fbb7f862257e122bd323dd650abcf7457814a91`
+- GitHub Release URL：`https://github.com/MC-and-his-Agents/Syvert/releases/tag/v1.3.0`
+- published at：`2026-05-09T12:08:46Z`
 
 ## 纳入事项
 
-- Phase `#381`：`Read-Side Capabilities`
+- Phase `#381`：`Read-Side Capabilities`（仅消费 `#403` slice，不关闭）
 - FR `#403`：`Read-side collection result and cursor contract`
-- Work Item `#406`：`CHORE-0406-v1-3-read-side-collection-spec`
+- Work Item `#406` / PR `#407`：spec freeze
+- Work Item `#408` / PR `#412`：runtime carrier
+- Work Item `#409` / PR `#413`：consumer migration
+- Work Item `#410` / PR `#414`：evidence artifact
+- Work Item `#411`：release closeout
+
+## Deferred Follow-up
+
+- `#404`：comment collection contract remains deferred and unstarted for `v1.3.0`
+- `#405`：creator profile and media asset read contract remains deferred and unstarted for `v1.3.0`
+- Phase `#381` remains open for post-`v1.3.0` read-side capability work
 
 ## 相关前提
 
 - `v1.1.0` operation taxonomy foundation 已发布。
 - `v1.2.0` resource governance foundation 已发布。
-- `v1.3.0` 当前只显式绑定 `#403` 首批 collection-contract batch，不绑定整个 Phase 3。
+- `v1.3.0` 只绑定 `#403` 首个 collection batch，不隐式绑定整个 Phase 3。
 
 ## 关联工件
 
@@ -56,5 +93,11 @@
 - spec：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
 - exec-plan：
   - `docs/exec-plans/CHORE-0406-v1-3-read-side-collection-spec.md`
+  - `docs/exec-plans/CHORE-0408-v1-3-0-read-side-collection-runtime.md`
+  - `docs/exec-plans/CHORE-0409-v1-3-0-read-side-collection-consumer-migration.md`
+  - `docs/exec-plans/CHORE-0410-v1-3-read-side-collection-evidence.md`
+  - `docs/exec-plans/CHORE-0411-v1-3-read-side-collection-closeout.md`
   - `docs/exec-plans/artifacts/CHORE-0406-v1-3-read-side-collection-fixture-inventory.md`
+  - `docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md`
+  - `docs/exec-plans/artifacts/CHORE-0411-v1-3-read-side-collection-closeout-evidence.md`
 - decision：无

--- a/docs/sprints/2026-S25.md
+++ b/docs/sprints/2026-S25.md
@@ -6,27 +6,30 @@
 
 ## 本轮目标
 
-- 完成 `#403` 的 Batch 0 与 Batch 1。
-- 冻结 `content_search_by_keyword` 与 `content_list_by_creator` 的首个 collection formal spec。
-- 保持本轮只覆盖 `#403`，不把整个 Phase 3 压进同一 sprint。
+- 完成 `#403` 的 spec freeze、runtime carrier、consumer migration、sanitized evidence 与 closeout truth。
+- 将 `content_search_by_keyword` 与 `content_list_by_creator` 作为首个 read-side collection batch 发布到 `v1.3.0`。
+- 保持本轮只关闭 `#403` slice，不关闭 Phase `#381`，不把 `#404/#405` 混入同一轮。
 
 ## 入口事项
 
 - Phase `#381`
 - FR `#403`
-- Work Item `#406`
+- Work Items `#406`、`#408`、`#409`、`#410`、`#411`
 
 ## 目标判据
 
-- `#406` 交付脱敏 fixture/error inventory artifact。
-- `#406` 交付 `FR-0403` formal spec suite。
-- `#406` 通过 `spec_guard`、`docs_guard`、`workflow_guard`、`version_guard`、`governance_gate` 与 spec review。
+- `#406` 交付 Batch 0 inventory 与 `FR-0403` formal spec suite。
+- `#408` 交付 runtime carrier 与 taxonomy / leakage / version gate 基线。
+- `#409` 完成 TaskRecord / runtime / compatibility consumer migration。
+- `#410` 交付脱敏 evidence artifact 与 replayable JSON snapshot。
+- `#411` 完成 release/sprint/FR closeout truth，并回写 `v1.3.0` published truth carrier。
 
 ## 协作入口
 
 - `docs/releases/v1.3.0.md`
 - `docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
-- `docs/exec-plans/CHORE-0406-v1-3-read-side-collection-spec.md`
+- `docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md`
+- `docs/exec-plans/artifacts/CHORE-0411-v1-3-read-side-collection-closeout-evidence.md`
 
 ## 关联工件
 
@@ -34,5 +37,17 @@
 - spec：`docs/specs/FR-0403-read-side-collection-result-cursor-contract/`
 - exec-plan：
   - `docs/exec-plans/CHORE-0406-v1-3-read-side-collection-spec.md`
+  - `docs/exec-plans/CHORE-0408-v1-3-0-read-side-collection-runtime.md`
+  - `docs/exec-plans/CHORE-0409-v1-3-0-read-side-collection-consumer-migration.md`
+  - `docs/exec-plans/CHORE-0410-v1-3-read-side-collection-evidence.md`
+  - `docs/exec-plans/CHORE-0411-v1-3-read-side-collection-closeout.md`
   - `docs/exec-plans/artifacts/CHORE-0406-v1-3-read-side-collection-fixture-inventory.md`
+  - `docs/exec-plans/artifacts/CHORE-0410-v1-3-read-side-collection-evidence.md`
+  - `docs/exec-plans/artifacts/CHORE-0411-v1-3-read-side-collection-closeout-evidence.md`
 - decision：无
+
+## 完成真相
+
+- closed completed：`#406`、`#408`、`#409`、`#410`
+- closeout in progress：`#411`
+- deferred and not closed：Phase `#381`、`#404`、`#405`


### PR DESCRIPTION
## Scope
- 回写 `v1.3.0` release index、`2026-S25` sprint index 与 `#403` closeout evidence truth。
- 对齐 `#406/#408/#409/#410`、PR `#407/#412/#413/#414`、merge commit、`v1.3.0` tag / GitHub Release 和 deferred boundary。
- 保持 Phase `#381`、`#404`、`#405` open，不把 Phase 3 整体关闭。

## 不包含内容
- 不包含新的 runtime / consumer / evidence 实现。
- 不包含 `#404/#405` 执行。
- 不包含 Phase `#381` closeout。

## 验证
- `python3 scripts/spec_guard.py --mode ci --all`
- `python3 scripts/docs_guard.py --mode ci`
- `python3 scripts/workflow_guard.py --mode ci`
- `python3 scripts/version_guard.py --mode ci`
- `BASE=$(git merge-base origin/main HEAD) && HEAD_SHA=$(git rev-parse HEAD) && python3 scripts/governance_gate.py --mode ci --base-sha "$BASE" --head-sha "$HEAD_SHA" --head-ref issue-411-403-v1-3-0-read-side-collection-closeout`

Closes #411
Closes #403
