### PR TITLE
feat: implement creator profile runtime carrier

### DIFF
--- a/docs/exec-plans/CHORE-0422-v1-5-creator-profile-runtime.md
+++ b/docs/exec-plans/CHORE-0422-v1-5-creator-profile-runtime.md
@@ -1,0 +1,93 @@
+# CHORE-0422 v1.5 creator profile runtime carrier 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0422-v1-5-creator-profile-runtime`
+- Issue：`#422`
+- item_type：`CHORE`
+- release：`v1.5.0`
+- sprint：`2026-S25`
+- Parent Phase：`#381`
+- Parent FR：`#405`
+- 关联 spec：`docs/specs/FR-0405-creator-profile-media-asset-read-contract/spec.md`
+- 关联 PR：待创建
+- 状态：`active`
+- active 收口事项：`CHORE-0422-v1-5-creator-profile-runtime`
+
+## 目标
+
+- 实现 `creator_profile_by_id` runtime carrier。
+- 将 `creator_profile + creator + single + direct` 升级为 stable runtime delivery。
+- 覆盖 creator ref、normalized public profile、public count 白名单、raw payload ref、source trace、unavailable/failed 分类与 fail-closed 脱敏边界。
+- 保持 `content_detail_by_url`、`content_search_by_keyword`、`content_list_by_creator`、`comment_collection` 与 `media_asset_fetch_by_ref` 已冻结行为不回退。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/operation_taxonomy.py`
+  - `syvert/runtime.py`
+  - `syvert/task_record.py`
+  - `syvert/registry.py`
+  - `tests/runtime/test_operation_taxonomy.py`
+  - `tests/runtime/test_runtime.py`
+  - `tests/runtime/test_task_record.py`
+  - 本 exec-plan
+- 本次不纳入：
+  - `media_asset_fetch_by_ref` runtime carrier追加修改，除非为 creator/media 共享合同冲突修复所必需。
+  - TaskRecord/result query/runtime admission 与 compatibility consumer migration（#424）。
+  - sanitized evidence matrix（#425）。
+  - `#405` closeout、release tag、GitHub Release 或 Phase `#381` closeout（#426）。
+  - raw payload files、source names、local paths、private creator fields。
+
+## 当前停点
+
+- `#421 / PR #428 / f66136f9772bea348b7ad48ccc766467bc1569ba` 已冻结 `#405` formal spec。
+- `#423 / PR #439 / e2e62f8667784d0b746a6c086f259c5268d8430c` 已合入，作为 creator/media shared runtime base。
+- `#404` conflict-risk clearance locator：PR `#438`。
+- Worktree key：`issue-422-405-v1-5-0-creator-profile-runtime`
+- Branch：`issue-422-405-v1-5-0-creator-profile-runtime`
+
+## FR-0405 creator carrier 不变量核对
+
+- public carrier 字段必须白名单：`target`、`profile`、`profile.public_counts`、`source_trace`、`audit` 不接受未定义扩展字段。
+- target 使用 formal `CreatorProfileTarget.creator_ref`；`creator_ref`、`target_display_hint`、`policy_ref` 必须是脱敏 opaque ref/hint。
+- `result_status` 与 `error_classification` 使用 creator-only 映射：success 为 `complete/null`，`target_not_found/profile_unavailable/permission_denied` 为 `unavailable`，creator failed 分类不接受 media-only `media_unavailable/unsupported_content_type/fetch_policy_denied`。
+- raw/normalized/audit split 固定：complete 必须有 raw ref；`provider_or_network_blocked` 必须 raw null；`audit` 只能为空对象。
+- privacy boundary 固定：target/profile/source_trace 均拒绝 URL、平台名、账号池、本地路径、credential/session。
+
+## 下一步动作
+
+- 创建 `#422` PR，进入 guardian review。
+
+## 已验证项
+
+- `python3 -m unittest tests.runtime.test_operation_taxonomy tests.runtime.test_runtime tests.runtime.test_task_record`
+  - 结果：通过，200 tests。
+- `python3 -m unittest tests.runtime.test_operation_taxonomy tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_platform_leakage`
+  - 结果：通过，311 tests。
+- `python3 -m unittest discover -s tests -p 'test*.py'`
+  - 结果：通过，527 tests。
+- `python3 -m py_compile syvert/operation_taxonomy.py syvert/registry.py syvert/runtime.py syvert/task_record.py tests/runtime/test_operation_taxonomy.py tests/runtime/test_runtime.py tests/runtime/test_task_record.py`
+  - 结果：通过。
+- `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过。
+- `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/version_guard.py --mode ci`
+  - 结果：通过。
+- `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过。
+- `git diff --check`
+  - 结果：通过。
+
+## 未决风险
+
+- `#424` 尚未迁移 TaskRecord/result query/runtime admission 与 compatibility consumers，当前只交付 creator runtime carrier。
+- `#425` 尚未补 evidence matrix，当前不声明 `#405` release criteria 满足。
+- `#426` 必须单独完成 closeout 与 explicit release decision。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销本 Work Item 对 runtime、TaskRecord、registry、taxonomy、tests 与本 exec-plan 的增量修改。

--- a/docs/exec-plans/CHORE-0422-v1-5-creator-profile-runtime.md
+++ b/docs/exec-plans/CHORE-0422-v1-5-creator-profile-runtime.md
@@ -82,6 +82,10 @@
 - `git diff --check`
   - 结果：通过。
 
+## 最近一次 checkpoint 对应的 head SHA
+
+- `a5a41631851d57f4a3c8692195a19eaf353841c7`
+
 ## 未决风险
 
 - `#424` 尚未迁移 TaskRecord/result query/runtime admission 与 compatibility consumers，当前只交付 creator runtime carrier。

--- a/syvert/operation_taxonomy.py
+++ b/syvert/operation_taxonomy.py
@@ -161,6 +161,19 @@ STABLE_COMMENT_COLLECTION_ENTRY = OperationTaxonomyEntry(
     notes=("v1.4.0 comment collection runtime contract frozen; comment-specific hierarchy and visibility surface.",),
 )
 
+STABLE_CREATOR_PROFILE_BY_ID_ENTRY = OperationTaxonomyEntry(
+    capability_family="creator_profile",
+    operation="creator_profile_by_id",
+    target_type="creator",
+    execution_mode="single",
+    collection_mode="direct",
+    lifecycle=CAPABILITY_LIFECYCLE_STABLE,
+    runtime_delivery=True,
+    contract_refs=("FR-0405",),
+    admission_evidence_refs=("tests.runtime.test_operation_taxonomy",),
+    notes=("v1.5.0 creator profile runtime carrier; one-shot creator read contract and platform-neutral profile result.",),
+)
+
 STABLE_MEDIA_ASSET_FETCH_BY_REF_ENTRY = OperationTaxonomyEntry(
     capability_family="media_asset_fetch",
     operation="media_asset_fetch_by_ref",
@@ -292,6 +305,7 @@ DEFAULT_OPERATION_TAXONOMY = (
     STABLE_CONTENT_SEARCH_BY_KEYWORD_ENTRY,
     STABLE_CONTENT_LIST_BY_CREATOR_ENTRY,
     STABLE_COMMENT_COLLECTION_ENTRY,
+    STABLE_CREATOR_PROFILE_BY_ID_ENTRY,
     STABLE_MEDIA_ASSET_FETCH_BY_REF_ENTRY,
     *PROPOSED_OPERATION_TAXONOMY_ENTRIES,
 )

--- a/syvert/registry.py
+++ b/syvert/registry.py
@@ -82,10 +82,10 @@ _APPROVED_FROZEN_RESOURCE_CAPABILITY_RECORDS = tuple(
     )
 )
 _ALLOWED_RESOURCE_REQUIREMENT_CAPABILITIES = frozenset(
-    {"content_detail", "content_search", "content_list", "comment_collection", "media_asset_fetch"}
+    {"content_detail", "content_search", "content_list", "comment_collection", "creator_profile", "media_asset_fetch"}
 )
 _CONTENT_DETAIL_RESOURCE_PROFILE_COMPATIBLE_CAPABILITIES = frozenset(
-    {"content_search", "content_list", "comment_collection", "media_asset_fetch"}
+    {"content_search", "content_list", "comment_collection", "creator_profile", "media_asset_fetch"}
 )
 _APPROVED_RESOURCE_REQUIREMENT_EVIDENCE_REFS = frozenset(
     evidence_ref

--- a/syvert/runtime.py
+++ b/syvert/runtime.py
@@ -53,11 +53,13 @@ CONTENT_DETAIL_BY_URL = "content_detail_by_url"
 CONTENT_SEARCH_BY_KEYWORD = "content_search_by_keyword"
 CONTENT_LIST_BY_CREATOR = "content_list_by_creator"
 COMMENT_COLLECTION = COMMENT_COLLECTION_OPERATION
+CREATOR_PROFILE_BY_ID = "creator_profile_by_id"
 MEDIA_ASSET_FETCH_BY_REF = "media_asset_fetch_by_ref"
 CONTENT_DETAIL = "content_detail"
 CONTENT_SEARCH = "content_search"
 CONTENT_LIST = "content_list"
 COMMENT_COLLECTION_FAMILY = "comment_collection"
+CREATOR_PROFILE = "creator_profile"
 MEDIA_ASSET_FETCH = "media_asset_fetch"
 LEGACY_COLLECTION_MODE = "hybrid"
 PAGINATED_COLLECTION_MODE = "paginated"
@@ -70,9 +72,46 @@ CAPABILITY_FAMILY_BY_OPERATION = {
     CONTENT_SEARCH_BY_KEYWORD: CONTENT_SEARCH,
     CONTENT_LIST_BY_CREATOR: CONTENT_LIST,
     COMMENT_COLLECTION: COMMENT_COLLECTION_FAMILY,
+    CREATOR_PROFILE_BY_ID: CREATOR_PROFILE,
     MEDIA_ASSET_FETCH_BY_REF: MEDIA_ASSET_FETCH,
 }
 ALLOWED_CONTENT_TYPES = {"video", "image_post", "mixed_media", "unknown"}
+CREATOR_PROFILE_RESULT_STATUSES = frozenset({"complete", "unavailable", "failed"})
+CREATOR_PROFILE_UNAVAILABLE_CLASSIFICATIONS = frozenset(
+    {
+        "target_not_found",
+        "profile_unavailable",
+        "permission_denied",
+    }
+)
+CREATOR_PROFILE_FAILED_CLASSIFICATIONS = frozenset(
+    {
+        "rate_limited",
+        "platform_failed",
+        "provider_or_network_blocked",
+        "parse_failed",
+        "credential_invalid",
+        "verification_required",
+        "signature_or_request_invalid",
+    }
+)
+CREATOR_PROFILE_ALLOWED_CLASSIFICATIONS = (
+    CREATOR_PROFILE_UNAVAILABLE_CLASSIFICATIONS | CREATOR_PROFILE_FAILED_CLASSIFICATIONS
+)
+CREATOR_PROFILE_FORBIDDEN_REF_VALUE_TOKENS = (
+    "http://",
+    "https://",
+    "file://",
+    "/tmp/",
+    "/var/",
+    "\\",
+    "token=",
+    "session",
+    "credential",
+    "secret",
+    "account-pool",
+    "proxy-pool",
+)
 MEDIA_ASSET_CONTENT_TYPES = frozenset({"image", "video"})
 MEDIA_ASSET_FETCH_MODES = frozenset({"metadata_only", "preserve_source_ref", "download_if_allowed", "download_required"})
 MEDIA_ASSET_FETCH_OUTCOMES = frozenset({"metadata_only", "source_ref_preserved", "downloaded_bytes"})
@@ -117,6 +156,7 @@ RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE = {
     (CONTENT_SEARCH_BY_KEYWORD, PAGINATED_COLLECTION_MODE): ("account", "proxy"),
     (CONTENT_LIST_BY_CREATOR, PAGINATED_COLLECTION_MODE): ("account", "proxy"),
     (COMMENT_COLLECTION, PAGINATED_COLLECTION_MODE): ("account", "proxy"),
+    (CREATOR_PROFILE_BY_ID, DIRECT_COLLECTION_MODE): ("account", "proxy"),
     (MEDIA_ASSET_FETCH_BY_REF, DIRECT_COLLECTION_MODE): ("account", "proxy"),
 }
 DEFAULT_BUNDLE_VALIDATION_RELEASE_REASON = "host_side_bundle_validation_failed"
@@ -135,7 +175,7 @@ EXECUTION_CONTROL_CODE_RETRY_EXHAUSTED = "retry_exhausted"
 EXECUTION_TIMEOUT_CLOSEOUT_GRACE_SECONDS = 0.1
 _ALLOWED_MATCH_STATUSES = frozenset({MATCH_STATUS_MATCHED, MATCH_STATUS_UNMATCHED})
 _ALLOWED_MATCHER_CAPABILITIES = frozenset(
-    {CONTENT_DETAIL, CONTENT_SEARCH, CONTENT_LIST, COMMENT_COLLECTION_FAMILY, MEDIA_ASSET_FETCH}
+    {CONTENT_DETAIL, CONTENT_SEARCH, CONTENT_LIST, COMMENT_COLLECTION_FAMILY, CREATOR_PROFILE, MEDIA_ASSET_FETCH}
 )
 _APPROVED_RESOURCE_CAPABILITY_IDS = approved_resource_capability_ids()
 _EXECUTION_CONCURRENCY_LOCK = threading.Lock()
@@ -1553,6 +1593,19 @@ def run_adapter_attempt_with_timeout(
             success_envelope.update(
                 comment_collection_result_envelope_to_dict(comment_collection_result_envelope_from_dict(payload))
             )
+        elif capability == CREATOR_PROFILE_BY_ID:
+            success_envelope.update(
+                {
+                    "operation": payload["operation"],
+                    "target": payload["target"],
+                    "result_status": payload["result_status"],
+                    "error_classification": payload["error_classification"],
+                    "profile": payload["profile"],
+                    "raw_payload_ref": payload["raw_payload_ref"],
+                    "source_trace": payload["source_trace"],
+                    "audit": payload.get("audit", {}),
+                }
+            )
         elif capability == MEDIA_ASSET_FETCH_BY_REF:
             success_envelope.update(
                 {
@@ -2817,6 +2870,26 @@ def _media_fetch_policies_match(request_policy: Mapping[str, Any], result_policy
     return normalize_media_fetch_policy(request_policy) == normalize_media_fetch_policy(result_policy)
 
 
+def _creator_ref_value_is_sanitized(value: str) -> bool:
+    normalized = value.lower()
+    return not any(token in normalized for token in CREATOR_PROFILE_FORBIDDEN_REF_VALUE_TOKENS)
+
+
+def _validate_creator_ref_value(value: Any, *, field: str) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value:
+        return runtime_contract_error(
+            "invalid_adapter_success_payload",
+            f"creator profile {field} 必须为非空脱敏 opaque ref",
+        )
+    if not _creator_ref_value_is_sanitized(value):
+        return runtime_contract_error(
+            "invalid_adapter_success_payload",
+            f"creator profile {field} 不得包含 URL、路径、平台名、凭证或账号池定位信息",
+            details={"field": field},
+        )
+    return None
+
+
 def _media_ref_value_is_sanitized(value: str) -> bool:
     normalized = value.lower()
     return not any(token in normalized for token in MEDIA_ASSET_FORBIDDEN_REF_VALUE_TOKENS)
@@ -3208,6 +3281,25 @@ def _project_task_input_to_target(
             CollectionPolicy(collection_mode=PAGINATED_COLLECTION_MODE),
             None,
         )
+    if capability == CREATOR_PROFILE_BY_ID:
+        if not isinstance(input_value.creator_id, str) or not input_value.creator_id:
+            return (
+                InputTarget(adapter_key=adapter_key, capability=capability, target_type="creator", target_value=""),
+                CollectionPolicy(collection_mode=DIRECT_COLLECTION_MODE),
+                invalid_input_error("invalid_task_request", "input.creator_id 不能为空"),
+            )
+        creator_ref_error = _validate_creator_ref_value(input_value.creator_id, field="input.creator_id")
+        if creator_ref_error is not None:
+            return (
+                InputTarget(adapter_key=adapter_key, capability=capability, target_type="creator", target_value=input_value.creator_id),
+                CollectionPolicy(collection_mode=DIRECT_COLLECTION_MODE),
+                invalid_input_error("invalid_task_request", "input.creator_id 必须是脱敏 opaque ref"),
+            )
+        return (
+            InputTarget(adapter_key=adapter_key, capability=capability, target_type="creator", target_value=input_value.creator_id),
+            CollectionPolicy(collection_mode=DIRECT_COLLECTION_MODE),
+            None,
+        )
     if capability == MEDIA_ASSET_FETCH_BY_REF:
         if not isinstance(input_value.media_ref, str) or not input_value.media_ref:
             return (
@@ -3476,7 +3568,7 @@ def resolve_runtime_requested_resource_slots(
         adapter_key=requirement_declaration.adapter_key,
         capability=requirement_declaration.capability,
     )
-    if requirement_declaration.capability not in {COMMENT_COLLECTION_FAMILY, MEDIA_ASSET_FETCH}:
+    if requirement_declaration.capability not in {COMMENT_COLLECTION_FAMILY, CREATOR_PROFILE, MEDIA_ASSET_FETCH}:
         return available_capabilities
     if type(requirement_declaration) is not AdapterResourceRequirementDeclarationV2:
         return tuple(requirement_declaration.required_capabilities)
@@ -3877,6 +3969,293 @@ def validate_success_payload(
                         "next_resume_comment_ref": envelope.next_continuation.resume_comment_ref,
                     },
                 )
+        return None
+    if capability == CREATOR_PROFILE_BY_ID:
+        if target_type is None or target_value is None:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile success validation requires target_type and target_value",
+            )
+
+        operation = payload.get("operation")
+        if not isinstance(operation, str) or operation != CREATOR_PROFILE_BY_ID:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile result.operation 必须为 creator_profile_by_id",
+                details={"operation": operation, "expected_operation": CREATOR_PROFILE_BY_ID},
+            )
+
+        target = payload.get("target")
+        if not isinstance(target, Mapping):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile result.target 必须是对象",
+            )
+        allowed_payload_fields = {
+            "operation",
+            "target",
+            "result_status",
+            "error_classification",
+            "profile",
+            "raw_payload_ref",
+            "source_trace",
+            "audit",
+        }
+        for field in payload:
+            if field not in allowed_payload_fields:
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile result 只能包含公共白名单字段",
+                    details={"field": field},
+                )
+        allowed_target_fields = {"operation", "target_type", "creator_ref", "target_display_hint", "policy_ref"}
+        for field in target:
+            if field not in allowed_target_fields:
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile result.target 只能包含公共白名单字段",
+                    details={"field": field},
+                )
+        if target.get("operation") != CREATOR_PROFILE_BY_ID:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile result.target.operation 必须与顶层 operation 一致",
+                details={"operation": target.get("operation"), "expected_operation": CREATOR_PROFILE_BY_ID},
+            )
+
+        result_target_type = target.get("target_type")
+        result_target_ref = target.get("creator_ref")
+        if result_target_type != target_type:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile result.target.target_type 必须与请求一致",
+                details={"target_type": result_target_type, "expected_target_type": target_type},
+            )
+        target_ref_error = _validate_creator_ref_value(result_target_ref, field="target.creator_ref")
+        if target_ref_error is not None:
+            return target_ref_error
+        if result_target_ref != target_value:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile result.target.creator_ref 必须与请求 target_value 一致",
+                details={"target_ref": result_target_ref, "expected_target_ref": target_value},
+            )
+        for optional_ref in ("target_display_hint", "policy_ref"):
+            value = target.get(optional_ref)
+            if value is not None:
+                ref_error = _validate_creator_ref_value(value, field=f"target.{optional_ref}")
+                if ref_error is not None:
+                    return ref_error
+        for required_field in (
+            "result_status",
+            "error_classification",
+            "profile",
+            "raw_payload_ref",
+            "source_trace",
+            "audit",
+        ):
+            if required_field not in payload:
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile result 字段必须显式存在",
+                    details={"field": required_field},
+                )
+
+        result_status = payload.get("result_status")
+        if not isinstance(result_status, str) or result_status not in CREATOR_PROFILE_RESULT_STATUSES:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile result.result_status 不在允许范围",
+                details={"result_status": result_status},
+            )
+
+        error_classification = payload.get("error_classification")
+        if result_status == "complete":
+            if error_classification is not None:
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile result_status=complete 时 error_classification 必须为 null",
+                    details={"error_classification": error_classification},
+                )
+        elif result_status == "unavailable":
+            if not (isinstance(error_classification, str) and error_classification in CREATOR_PROFILE_UNAVAILABLE_CLASSIFICATIONS):
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile result_status=unavailable 时错误分类不允许",
+                    details={"error_classification": error_classification},
+                )
+        else:
+            if not (isinstance(error_classification, str) and error_classification in CREATOR_PROFILE_FAILED_CLASSIFICATIONS):
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile result_status=failed 时错误分类不允许",
+                    details={"error_classification": error_classification},
+                )
+
+        raw_payload_ref = payload.get("raw_payload_ref")
+        if not (isinstance(raw_payload_ref, str) or raw_payload_ref is None):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile raw_payload_ref 必须为字符串或 null",
+            )
+        if result_status == "complete" and not (isinstance(raw_payload_ref, str) and raw_payload_ref):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile complete result 必须包含 raw_payload_ref",
+            )
+        if error_classification == "provider_or_network_blocked" and raw_payload_ref is not None:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile provider_or_network_blocked 必须使用 null raw_payload_ref",
+            )
+
+        source_trace = payload.get("source_trace")
+        if not isinstance(source_trace, Mapping):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile source_trace 必须是对象",
+            )
+        allowed_source_trace_fields = {"adapter_key", "provider_path", "resource_profile_ref", "fetched_at", "evidence_alias"}
+        for field in source_trace:
+            if field not in allowed_source_trace_fields:
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile source_trace 只能包含公共白名单字段",
+                    details={"field": field},
+                )
+        for required_field in ("adapter_key", "provider_path", "fetched_at", "evidence_alias"):
+            value = source_trace.get(required_field)
+            if not isinstance(value, str) or not value:
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile source_trace 字段缺失或无效",
+                    details={"field": required_field},
+                )
+        if not is_valid_rfc3339_utc(source_trace.get("fetched_at")):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile source_trace.fetched_at 必须为 RFC3339 UTC",
+            )
+        provider_path = source_trace.get("provider_path")
+        if not isinstance(provider_path, str) or not _creator_ref_value_is_sanitized(provider_path):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile source_trace.provider_path 不得包含平台、路径、凭证或账号池定位信息",
+                details={"field": "source_trace.provider_path"},
+            )
+        if error_classification == "provider_or_network_blocked" and not provider_path.startswith("provider://blocked-path-alias"):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile provider_or_network_blocked 必须使用脱敏 blocked-path alias",
+                details={"field": "source_trace.provider_path"},
+            )
+        resource_profile_ref = source_trace.get("resource_profile_ref")
+        if resource_profile_ref is not None:
+            resource_profile_error = _validate_creator_ref_value(
+                resource_profile_ref,
+                field="source_trace.resource_profile_ref",
+            )
+            if resource_profile_error is not None:
+                return resource_profile_error
+
+        if "audit" not in payload:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile result 字段必须显式存在",
+                details={"field": "audit"},
+            )
+        audit = payload.get("audit")
+        if audit is None:
+            audit = {}
+        if not isinstance(audit, Mapping):
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile audit 必须是对象或 null",
+            )
+        if audit:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile audit 只能是空对象",
+            )
+
+        profile = payload.get("profile")
+        if result_status == "complete":
+            if not isinstance(profile, Mapping):
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile complete 结果 profile 必须是对象",
+                )
+            allowed_profile_fields = {
+                "creator_ref",
+                "canonical_ref",
+                "display_name",
+                "avatar_ref",
+                "description",
+                "public_counts",
+                "profile_url_hint",
+            }
+            for field in profile:
+                if field not in allowed_profile_fields:
+                    return runtime_contract_error(
+                        "invalid_adapter_success_payload",
+                        "creator profile profile 只能包含公共白名单字段",
+                        details={"field": field},
+                    )
+            creator_ref = profile.get("creator_ref")
+            creator_ref_error = _validate_creator_ref_value(creator_ref, field="profile.creator_ref")
+            if creator_ref_error is not None:
+                return creator_ref_error
+            canonical_ref_error = _validate_creator_ref_value(profile.get("canonical_ref"), field="profile.canonical_ref")
+            if canonical_ref_error is not None:
+                return canonical_ref_error
+            display_name = profile.get("display_name")
+            if not isinstance(display_name, str) or not display_name:
+                return runtime_contract_error(
+                    "invalid_adapter_success_payload",
+                    "creator profile 完整成功时 normalized display_name 必须为非空字符串",
+                )
+            for field in ("avatar_ref", "description", "profile_url_hint"):
+                value = profile.get(field)
+                if field == "description":
+                    if value is not None and not isinstance(value, str):
+                        return runtime_contract_error(
+                            "invalid_adapter_success_payload",
+                            "creator profile 字段 description 必须为字符串或 null",
+                        )
+                    continue
+                if value is not None:
+                    ref_error = _validate_creator_ref_value(value, field=f"profile.{field}")
+                    if ref_error is not None:
+                        return ref_error
+            public_counts = profile.get("public_counts")
+            if public_counts is not None:
+                if not isinstance(public_counts, Mapping):
+                    return runtime_contract_error(
+                        "invalid_adapter_success_payload",
+                        "creator profile public_counts 必须是对象或 null",
+                    )
+                allowed_count_fields = {"follower_count", "following_count", "content_count", "like_count"}
+                for count_name, value in public_counts.items():
+                    if count_name not in allowed_count_fields:
+                        return runtime_contract_error(
+                            "invalid_adapter_success_payload",
+                            "creator profile public_counts 只能包含公共白名单字段",
+                            details={"field": count_name},
+                        )
+                    if value is None:
+                        continue
+                    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                        return runtime_contract_error(
+                            "invalid_adapter_success_payload",
+                            "creator profile public_counts 计数字段必须为非负整数或 null",
+                            details={"field": count_name},
+                        )
+        elif profile is not None:
+            return runtime_contract_error(
+                "invalid_adapter_success_payload",
+                "creator profile unavailable/failed 时 profile 必须为 null",
+            )
+
         return None
 
     if capability == MEDIA_ASSET_FETCH_BY_REF:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -26,11 +26,41 @@ SHARED_CAPABILITIES = frozenset(
         "content_list_by_creator",
         "comment_collection",
         "media_asset_fetch_by_ref",
+        "creator_profile_by_id",
     }
 )
 SHARED_TARGET_TYPES = frozenset({"url", "content", "content_id", "creator", "creator_id", "keyword", "media_ref"})
 SHARED_COLLECTION_MODES = frozenset({"public", "authenticated", "hybrid", "paginated", "direct"})
 ALLOWED_CONTENT_TYPES = frozenset({"video", "image_post", "mixed_media", "unknown"})
+CREATOR_PROFILE_RESULT_STATUSES = frozenset({"complete", "unavailable", "failed"})
+CREATOR_PROFILE_UNAVAILABLE_CLASSIFICATIONS = frozenset(
+    {"target_not_found", "profile_unavailable", "permission_denied"}
+)
+CREATOR_PROFILE_FAILED_CLASSIFICATIONS = frozenset(
+    {
+        "rate_limited",
+        "platform_failed",
+        "provider_or_network_blocked",
+        "parse_failed",
+        "credential_invalid",
+        "verification_required",
+        "signature_or_request_invalid",
+    }
+)
+CREATOR_PROFILE_FORBIDDEN_REF_VALUE_TOKENS = (
+    "http://",
+    "https://",
+    "file://",
+    "/tmp/",
+    "/var/",
+    "\\",
+    "token=",
+    "session",
+    "credential",
+    "secret",
+    "account-pool",
+    "proxy-pool",
+)
 MEDIA_ASSET_CONTENT_TYPES = frozenset({"image", "video"})
 MEDIA_ASSET_FETCH_MODES = frozenset({"metadata_only", "preserve_source_ref", "download_if_allowed", "download_required"})
 MEDIA_ASSET_FETCH_OUTCOMES = frozenset({"metadata_only", "source_ref_preserved", "downloaded_bytes"})
@@ -757,6 +787,8 @@ def validate_request_snapshot(snapshot: TaskRequestSnapshot) -> None:
         raise TaskRecordContractError("TaskRequestSnapshot.collection_mode 不在共享请求模型允许值范围内")
     if not adapter_key:
         raise TaskRecordContractError("TaskRequestSnapshot.adapter_key 必须为非空字符串")
+    if capability == "creator_profile_by_id" and target_type == "creator":
+        _require_sanitized_creator_ref(target_value, field="TaskRequestSnapshot.target_value")
     if capability == "media_asset_fetch_by_ref" and target_type == "media_ref":
         _require_sanitized_media_ref(target_value, field="TaskRequestSnapshot.target_value")
 
@@ -1041,6 +1073,14 @@ def validate_terminal_envelope_contract(record: TaskRecord, envelope: Mapping[st
                 raise TaskRecordContractError("comment collection target_type 与请求快照不一致")
             if collection.target.target_ref != record.request.target_value:
                 raise TaskRecordContractError("comment collection target_ref 与请求快照不一致")
+        if capability == "creator_profile_by_id":
+            target = envelope.get("target")
+            if not isinstance(target, Mapping):
+                raise TaskRecordContractError("creator profile target 必须是对象")
+            if target.get("target_type") != record.request.target_type:
+                raise TaskRecordContractError("creator profile target_type 与请求快照不一致")
+            if target.get("creator_ref") != record.request.target_value:
+                raise TaskRecordContractError("creator profile creator_ref 与请求快照不一致")
         if capability == "media_asset_fetch_by_ref":
             target = envelope.get("target")
             if not isinstance(target, Mapping):
@@ -1108,6 +1148,9 @@ def validate_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
     if capability == COMMENT_COLLECTION_OPERATION:
         _validate_comment_collection_success_terminal_envelope(envelope)
         return
+    if capability == "creator_profile_by_id":
+        _validate_creator_profile_success_terminal_envelope(envelope)
+        return
     if capability == "media_asset_fetch_by_ref":
         _validate_media_asset_fetch_success_terminal_envelope(envelope)
         return
@@ -1173,6 +1216,145 @@ def validate_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
     image_urls = media.get("image_urls")
     if not isinstance(image_urls, list) or not all(isinstance(item, str) for item in image_urls):
         raise TaskRecordContractError("result.envelope.normalized.media.image_urls 必须是字符串数组")
+
+
+def _validate_creator_profile_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:
+    operation = require_string(envelope.get("operation"), field="result.envelope.operation")
+    if operation != "creator_profile_by_id":
+        raise TaskRecordContractError("creator profile result.operation 必须为 creator_profile_by_id")
+
+    target = envelope.get("target")
+    if not isinstance(target, Mapping):
+        raise TaskRecordContractError("creator profile result.target 必须是对象")
+    allowed_target_fields = {"operation", "target_type", "creator_ref", "target_display_hint", "policy_ref"}
+    if any(field not in allowed_target_fields for field in target):
+        raise TaskRecordContractError("creator profile result.target 只能包含公共白名单字段")
+    if target.get("operation") != operation:
+        raise TaskRecordContractError("creator profile result.target.operation 必须与顶层 operation 一致")
+    if target.get("target_type") != "creator":
+        raise TaskRecordContractError("creator profile result.target.target_type 必须为 creator")
+    _require_sanitized_creator_ref(target.get("creator_ref"), field="creator profile result.target.creator_ref")
+    for optional_ref in ("target_display_hint", "policy_ref"):
+        value = target.get(optional_ref)
+        if value is not None:
+            _require_sanitized_creator_ref(value, field=f"creator profile result.target.{optional_ref}")
+    for required_field in ("result_status", "error_classification", "profile", "raw_payload_ref", "source_trace", "audit"):
+        if required_field not in envelope:
+            raise TaskRecordContractError("creator profile result 字段必须显式存在")
+
+    result_status = envelope.get("result_status")
+    if not isinstance(result_status, str) or result_status not in CREATOR_PROFILE_RESULT_STATUSES:
+        raise TaskRecordContractError("creator profile result_status 不在允许范围")
+
+    error_classification = envelope.get("error_classification")
+    if result_status == "complete":
+        if error_classification is not None:
+            raise TaskRecordContractError("creator profile result_status=complete 时 error_classification 必须为 null")
+    elif result_status == "unavailable":
+        if not (isinstance(error_classification, str) and error_classification in CREATOR_PROFILE_UNAVAILABLE_CLASSIFICATIONS):
+            raise TaskRecordContractError("creator profile result_status=unavailable 时错误分类不允许")
+    else:
+        if not (isinstance(error_classification, str) and error_classification in CREATOR_PROFILE_FAILED_CLASSIFICATIONS):
+            raise TaskRecordContractError("creator profile result_status=failed 时错误分类不允许")
+
+    raw_payload_ref = envelope.get("raw_payload_ref")
+    if not (isinstance(raw_payload_ref, str) or raw_payload_ref is None):
+        raise TaskRecordContractError("creator profile raw_payload_ref 必须为字符串或 null")
+    if result_status == "complete" and not (isinstance(raw_payload_ref, str) and raw_payload_ref):
+        raise TaskRecordContractError("creator profile complete result 必须包含 raw_payload_ref")
+    if error_classification == "provider_or_network_blocked" and raw_payload_ref is not None:
+        raise TaskRecordContractError("creator profile provider_or_network_blocked 必须使用 null raw_payload_ref")
+
+    source_trace = envelope.get("source_trace")
+    if not isinstance(source_trace, Mapping):
+        raise TaskRecordContractError("creator profile source_trace 必须是对象")
+    allowed_source_trace_fields = {"adapter_key", "provider_path", "resource_profile_ref", "fetched_at", "evidence_alias"}
+    if any(field not in allowed_source_trace_fields for field in source_trace):
+        raise TaskRecordContractError("creator profile source_trace 只能包含公共白名单字段")
+    for required_field in ("adapter_key", "provider_path", "fetched_at", "evidence_alias"):
+        value = source_trace.get(required_field)
+        if not isinstance(value, str) or not value:
+            raise TaskRecordContractError(f"creator profile source_trace 字段缺失或无效: {required_field}")
+    fetched_at = source_trace.get("fetched_at")
+    try:
+        validate_timestamp(fetched_at, field="result.envelope.source_trace.fetched_at")
+    except TaskRecordContractError as error:
+        raise TaskRecordContractError("creator profile source_trace.fetched_at 必须为 RFC3339 UTC") from error
+    resource_profile_ref = source_trace.get("resource_profile_ref")
+    if resource_profile_ref is not None:
+        _require_sanitized_creator_ref(resource_profile_ref, field="result.envelope.source_trace.resource_profile_ref")
+    provider_path = source_trace.get("provider_path")
+    if not isinstance(provider_path, str) or not _creator_ref_value_is_sanitized(provider_path):
+        raise TaskRecordContractError("creator profile source_trace.provider_path 不得包含平台、路径、凭证或账号池定位信息")
+    if error_classification == "provider_or_network_blocked" and not (
+        isinstance(provider_path, str) and provider_path.startswith("provider://blocked-path-alias")
+    ):
+        raise TaskRecordContractError("creator profile provider_or_network_blocked 必须使用脱敏 blocked-path alias")
+
+    if "audit" not in envelope:
+        raise TaskRecordContractError("creator profile result 字段必须显式存在")
+    audit = envelope.get("audit", {})
+    if audit is None:
+        audit = {}
+    if not isinstance(audit, Mapping):
+        raise TaskRecordContractError("creator profile audit 必须是对象或 null")
+    if audit:
+        raise TaskRecordContractError("creator profile audit 只能是空对象")
+
+    profile = envelope.get("profile")
+    if result_status == "complete":
+        if not isinstance(profile, Mapping):
+            raise TaskRecordContractError("creator profile complete 结果 profile 必须是对象")
+        allowed_profile_fields = {
+            "creator_ref",
+            "canonical_ref",
+            "display_name",
+            "avatar_ref",
+            "description",
+            "public_counts",
+            "profile_url_hint",
+        }
+        if any(field not in allowed_profile_fields for field in profile):
+            raise TaskRecordContractError("creator profile profile 只能包含公共白名单字段")
+        _require_sanitized_creator_ref(profile.get("creator_ref"), field="result.envelope.profile.creator_ref")
+        _require_sanitized_creator_ref(profile.get("canonical_ref"), field="result.envelope.profile.canonical_ref")
+        display_name = profile.get("display_name")
+        if not isinstance(display_name, str) or not display_name:
+            raise TaskRecordContractError("creator profile 完整成功时 display_name 必须为非空字符串")
+        for field in ("avatar_ref", "profile_url_hint"):
+            value = profile.get(field)
+            if value is not None:
+                _require_sanitized_creator_ref(value, field=f"result.envelope.profile.{field}")
+        description = profile.get("description")
+        if description is not None and not isinstance(description, str):
+            raise TaskRecordContractError("creator profile 字段 description 必须为字符串或 null")
+
+        public_counts = profile.get("public_counts")
+        if public_counts is not None:
+            if not isinstance(public_counts, Mapping):
+                raise TaskRecordContractError("creator profile public_counts 必须是对象或 null")
+            allowed_count_fields = {"follower_count", "following_count", "content_count", "like_count"}
+            for count_name, value in public_counts.items():
+                if count_name not in allowed_count_fields:
+                    raise TaskRecordContractError("creator profile public_counts 只能包含公共白名单字段")
+                if value is None:
+                    continue
+                if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                    raise TaskRecordContractError("creator profile public_counts 计数字段必须为非负整数或 null")
+    elif profile is not None:
+        raise TaskRecordContractError("creator profile unavailable/failed 时 profile 必须为 null")
+
+
+def _creator_ref_value_is_sanitized(value: str) -> bool:
+    normalized = value.lower()
+    return not any(token in normalized for token in CREATOR_PROFILE_FORBIDDEN_REF_VALUE_TOKENS)
+
+
+def _require_sanitized_creator_ref(value: Any, *, field: str) -> str:
+    ref = require_string(value, field=field)
+    if not _creator_ref_value_is_sanitized(ref):
+        raise TaskRecordContractError(f"{field} 不得包含 URL、路径、平台名、凭证或账号池定位信息")
+    return ref
 
 
 def _validate_collection_success_terminal_envelope(envelope: Mapping[str, Any]) -> None:

--- a/tests/runtime/test_operation_taxonomy.py
+++ b/tests/runtime/test_operation_taxonomy.py
@@ -94,6 +94,25 @@ class OperationTaxonomyTests(unittest.TestCase):
             )
         )
 
+    def test_stable_creator_profile_lookup_returns_runtime_entry(self) -> None:
+        entry = stable_operation_entry(
+            operation="creator_profile_by_id",
+            target_type="creator",
+            collection_mode="direct",
+        )
+
+        self.assertEqual(entry.capability_family, "creator_profile")
+        self.assertTrue(entry.runtime_delivery)
+        self.assertEqual(entry.lifecycle, CAPABILITY_LIFECYCLE_STABLE)
+        self.assertEqual(entry.contract_refs, ("FR-0405",))
+        self.assertTrue(
+            is_stable_operation(
+                operation="creator_profile_by_id",
+                target_type="creator",
+                collection_mode="direct",
+            )
+        )
+
     def test_stable_media_asset_fetch_lookup_returns_runtime_entry(self) -> None:
         entry = stable_operation_entry(
             operation="media_asset_fetch_by_ref",

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -27,6 +27,8 @@ from syvert.resource_trace_store import LocalResourceTraceStore
 from syvert.runtime import (
     AdapterExecutionContext,
     AdapterTaskRequest,
+    CREATOR_PROFILE,
+    CREATOR_PROFILE_BY_ID,
     CollectionPolicy,
     CoreTaskRequest,
     ExecutionConcurrencyPolicy,
@@ -139,6 +141,56 @@ def make_comment_collection_result(*, target_ref: str = "content-001") -> dict[s
         "audit": {"page_index": 1},
     }
 
+def make_creator_profile_success_payload(*, target_ref: str = "creator-001", creator_id: str = "creator-001") -> dict[str, object]:
+    return {
+        "operation": "creator_profile_by_id",
+        "target": {
+            "operation": "creator_profile_by_id",
+            "target_type": "creator",
+            "creator_ref": target_ref,
+            "target_display_hint": "creator-hint-001",
+            "policy_ref": "policy:creator-profile",
+        },
+        "result_status": "complete",
+        "error_classification": None,
+        "profile": {
+            "creator_ref": creator_id,
+            "canonical_ref": f"creator:canonical:{creator_id}",
+            "display_name": "creator-name",
+            "avatar_ref": "avatar:creator-001",
+            "description": "desc",
+            "public_counts": {
+                "follower_count": 100,
+                "following_count": 5,
+                "content_count": 8,
+                "like_count": 16,
+            },
+            "profile_url_hint": "profile:creator-slug",
+        },
+        "raw_payload_ref": "raw://creator-profile",
+        "source_trace": {
+            "adapter_key": TEST_ADAPTER_KEY,
+            "provider_path": "provider://sanitized",
+            "resource_profile_ref": "fr-0405:profile:creator-profile-by-id:account-proxy",
+            "fetched_at": "2026-05-09T10:00:00Z",
+            "evidence_alias": "alias://creator-profile-success",
+        },
+        "audit": {},
+    }
+
+
+def make_creator_profile_unavailable_payload(*, target_ref: str = "creator-001", classification: str = "target_not_found") -> dict[str, object]:
+    payload = make_creator_profile_success_payload(target_ref=target_ref)
+    payload.update(
+        {
+            "result_status": "unavailable",
+            "error_classification": classification,
+            "profile": None,
+            "raw_payload_ref": None,
+        }
+    )
+    return payload
+
 
 def make_media_asset_fetch_result(
     *,
@@ -210,6 +262,19 @@ def make_media_asset_fetch_result(
             else {}
         ),
     }
+
+
+def make_creator_profile_failed_payload(*, target_ref: str = "creator-001", classification: str = "parse_failed") -> dict[str, object]:
+    payload = make_creator_profile_success_payload(target_ref=target_ref)
+    payload.update(
+        {
+            "result_status": "failed",
+            "error_classification": classification,
+            "profile": None,
+            "raw_payload_ref": "raw://creator-profile-failed",
+        }
+    )
+    return payload
 
 
 def make_comment_collection_reply_result(
@@ -366,6 +431,32 @@ class CommentCollectionAdapter:
     def execute(self, request: TaskRequest) -> dict[str, object]:
         self.last_request = request
         return make_comment_collection_result(target_ref=request.input.content_ref or "")
+
+class CreatorProfileAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({CREATOR_PROFILE})
+    supported_targets = frozenset({"creator"})
+    supported_collection_modes = frozenset({"direct"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(
+        adapter_key=TEST_ADAPTER_KEY,
+        capability=CREATOR_PROFILE,
+    )
+
+    def execute(self, request: TaskRequest) -> dict[str, object]:
+        self.last_request = request
+        return make_creator_profile_success_payload(target_ref=request.input.creator_id or "")
+
+
+class CreatorProfileFailureAdapter(CreatorProfileAdapter):
+    def __init__(self, payload: dict[str, object] | None = None) -> None:
+        self.last_request = None
+        self._payload = payload
+
+    def execute(self, request: TaskRequest) -> dict[str, object]:
+        self.last_request = request
+        if self._payload is not None:
+            return self._payload
+        return make_creator_profile_unavailable_payload(target_ref=request.input.creator_id or "")
 
 
 class MediaAssetFetchAdapter:
@@ -2547,6 +2638,189 @@ class RuntimeExecutionTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(envelope["status"], "failed")
         self.assertEqual(envelope["error"]["code"], "invalid_adapter_success_payload")
         self.assertEqual(result["verdict"], "contract_violation")
+
+    def test_validate_success_payload_accepts_creator_profile_runtime_carrier(self) -> None:
+        payload = make_creator_profile_success_payload(target_ref="creator-001")
+
+        self.assertIsNone(
+            validate_success_payload(
+                payload,
+                capability="creator_profile_by_id",
+                target_type="creator",
+                target_value="creator-001",
+            )
+        )
+
+    def test_validate_success_payload_accepts_creator_profile_blocked_alias(self) -> None:
+        payload = make_creator_profile_failed_payload(target_ref="creator-001", classification="provider_or_network_blocked")
+        payload["raw_payload_ref"] = None
+        payload["source_trace"]["provider_path"] = "provider://blocked-path-alias/creator"
+
+        self.assertIsNone(
+            validate_success_payload(
+                payload,
+                capability="creator_profile_by_id",
+                target_type="creator",
+                target_value="creator-001",
+            )
+        )
+
+    def test_validate_success_payload_rejects_creator_profile_complete_payload_with_forbidden_error_classification(self) -> None:
+        payload = make_creator_profile_success_payload(target_ref="creator-001")
+        payload["error_classification"] = "parse_failed"
+
+        result = validate_success_payload(
+            payload,
+            capability="creator_profile_by_id",
+            target_type="creator",
+            target_value="creator-001",
+        )
+
+        self.assertEqual(result["code"], "invalid_adapter_success_payload")
+        self.assertEqual(result["message"], "creator profile result_status=complete 时 error_classification 必须为 null")
+
+    def test_validate_success_payload_rejects_creator_profile_missing_profile_id(self) -> None:
+        payload = make_creator_profile_success_payload(target_ref="creator-001")
+        del payload["profile"]["creator_ref"]
+
+        result = validate_success_payload(
+            payload,
+            capability="creator_profile_by_id",
+            target_type="creator",
+            target_value="creator-001",
+        )
+
+        self.assertEqual(result["code"], "invalid_adapter_success_payload")
+        self.assertEqual(result["message"], "creator profile profile.creator_ref 必须为非空脱敏 opaque ref")
+
+    def test_validate_success_payload_rejects_creator_profile_private_target_ref(self) -> None:
+        payload = make_creator_profile_success_payload(target_ref="https://douyin.example.invalid/user?id=1")
+
+        result = validate_success_payload(
+            payload,
+            capability="creator_profile_by_id",
+            target_type="creator",
+            target_value="https://douyin.example.invalid/user?id=1",
+        )
+
+        self.assertEqual(result["code"], "invalid_adapter_success_payload")
+
+    def test_validate_success_payload_rejects_creator_profile_invalid_public_counts(self) -> None:
+        payload = make_creator_profile_success_payload(target_ref="creator-001")
+        payload["profile"]["public_counts"]["followers"] = 1
+
+        result = validate_success_payload(
+            payload,
+            capability="creator_profile_by_id",
+            target_type="creator",
+            target_value="creator-001",
+        )
+
+        self.assertEqual(result["code"], "invalid_adapter_success_payload")
+
+    def test_validate_success_payload_rejects_creator_profile_non_empty_audit(self) -> None:
+        payload = make_creator_profile_success_payload(target_ref="creator-001")
+        payload["audit"] = {"transfer_observed": True}
+
+        result = validate_success_payload(
+            payload,
+            capability="creator_profile_by_id",
+            target_type="creator",
+            target_value="creator-001",
+        )
+
+        self.assertEqual(result["code"], "invalid_adapter_success_payload")
+
+    def test_execute_task_builds_creator_profile_success_envelope_from_adapter_payload(self) -> None:
+        adapter = CreatorProfileAdapter()
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="creator_profile_by_id",
+            input=TaskInput(creator_id="creator-001"),
+        )
+
+        with mock.patch("syvert.runtime.validate_resource_capability_matcher_input", side_effect=lambda value: value):
+            envelope = execute_task_with_record(
+                request,
+                adapters={TEST_ADAPTER_KEY: adapter},
+                task_id_factory=lambda: "task-runtime-creator-profile-1",
+            )
+
+        self.assertEqual(envelope.envelope["status"], "success")
+        self.assertEqual(envelope.envelope["operation"], "creator_profile_by_id")
+        self.assertEqual(envelope.envelope["target"]["creator_ref"], "creator-001")
+        self.assertEqual(envelope.envelope["target"]["target_type"], "creator")
+        self.assertEqual(envelope.envelope["result_status"], "complete")
+        self.assertIsNone(envelope.envelope["error_classification"])
+        self.assertEqual(envelope.envelope["profile"]["creator_ref"], "creator-001")
+        self.assertEqual(envelope.envelope["audit"], {})
+        self.assertIsInstance(adapter.last_request, AdapterExecutionContext)
+        self.assertEqual(adapter.last_request.request.capability, "creator_profile")
+        self.assertEqual(adapter.last_request.request.target_type, "creator")
+        self.assertEqual(adapter.last_request.request.target_value, "creator-001")
+        self.assertEqual(adapter.last_request.request.collection_mode, "direct")
+
+    def test_execute_task_builds_creator_profile_success_envelope_from_core_request(self) -> None:
+        adapter = CreatorProfileAdapter()
+        request = CoreTaskRequest(
+            target=InputTarget(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="creator_profile_by_id",
+                target_type="creator",
+                target_value="creator-001",
+            ),
+            policy=CollectionPolicy(collection_mode="direct"),
+        )
+
+        with mock.patch("syvert.runtime.validate_resource_capability_matcher_input", side_effect=lambda value: value):
+            envelope = execute_task(
+                request,
+                adapters={TEST_ADAPTER_KEY: adapter},
+                task_id_factory=lambda: "task-runtime-creator-profile-2",
+            )
+
+        self.assertEqual(envelope["status"], "success")
+        self.assertEqual(envelope["operation"], "creator_profile_by_id")
+        self.assertEqual(envelope["result_status"], "complete")
+        self.assertEqual(adapter.last_request.request.collection_mode, "direct")
+
+    def test_execute_task_builds_creator_profile_unavailable_from_adapter_payload(self) -> None:
+        adapter = CreatorProfileFailureAdapter(payload=make_creator_profile_unavailable_payload(classification="target_not_found"))
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="creator_profile_by_id",
+            input=TaskInput(creator_id="creator-001"),
+        )
+
+        with mock.patch("syvert.runtime.validate_resource_capability_matcher_input", side_effect=lambda value: value):
+            envelope = execute_task_with_record(
+                request,
+                adapters={TEST_ADAPTER_KEY: adapter},
+                task_id_factory=lambda: "task-runtime-creator-profile-3",
+            )
+
+        self.assertEqual(envelope.envelope["status"], "success")
+        self.assertEqual(envelope.envelope["result_status"], "unavailable")
+        self.assertEqual(envelope.envelope["error_classification"], "target_not_found")
+        self.assertIsNone(envelope.envelope["profile"])
+        self.assertIsNone(envelope.envelope["raw_payload_ref"])
+
+    def test_execute_task_rejects_private_creator_id(self) -> None:
+        adapter = CreatorProfileAdapter()
+        request = TaskRequest(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="creator_profile_by_id",
+            input=TaskInput(creator_id="https://xhs.example.invalid/user/1"),
+        )
+
+        envelope = execute_task_with_record(
+            request,
+            adapters={TEST_ADAPTER_KEY: adapter},
+            task_id_factory=lambda: "task-runtime-creator-profile-4",
+        )
+
+        self.assertEqual(envelope.envelope["status"], "failed")
+        self.assertEqual(envelope.envelope["error"]["code"], "invalid_task_request")
 
     def test_execute_task_builds_success_envelope_from_adapter_payload(self) -> None:
         adapter = SuccessfulAdapter()

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -133,6 +133,44 @@ def make_comment_collection_result(*, target_ref: str = "content-001") -> dict[s
     }
 
 
+def make_creator_profile_result(*, target_ref: str = "creator-001", creator_id: str = "creator-001") -> dict[str, object]:
+    return {
+        "operation": "creator_profile_by_id",
+        "target": {
+            "operation": "creator_profile_by_id",
+            "target_type": "creator",
+            "creator_ref": target_ref,
+            "target_display_hint": "creator-hint-001",
+            "policy_ref": "policy:creator-profile",
+        },
+        "result_status": "complete",
+        "error_classification": None,
+        "profile": {
+            "creator_ref": creator_id,
+            "canonical_ref": f"creator:canonical:{creator_id}",
+            "display_name": "creator-name",
+            "avatar_ref": "avatar:creator-001",
+            "description": "desc",
+            "public_counts": {
+                "follower_count": 100,
+                "following_count": 5,
+                "content_count": 8,
+                "like_count": 16,
+            },
+            "profile_url_hint": "profile:creator-slug",
+        },
+        "raw_payload_ref": "raw://creator-profile",
+        "source_trace": {
+            "adapter_key": TEST_ADAPTER_KEY,
+            "provider_path": "provider://sanitized",
+            "resource_profile_ref": "fr-0405:profile:creator-profile-by-id:account-proxy",
+            "fetched_at": "2026-05-09T10:00:00Z",
+            "evidence_alias": "alias://creator-profile-success",
+        },
+        "audit": {},
+    }
+
+
 def make_media_asset_fetch_result(*, target_ref: str = "media:asset-001") -> dict[str, object]:
     return {
         "operation": "media_asset_fetch_by_ref",
@@ -362,6 +400,20 @@ class CommentCollectionAdapter:
         return make_comment_collection_result(target_ref=request.input.content_ref or "")
 
 
+class CreatorProfileAdapter:
+    adapter_key = TEST_ADAPTER_KEY
+    supported_capabilities = frozenset({"creator_profile"})
+    supported_targets = frozenset({"creator"})
+    supported_collection_modes = frozenset({"direct"})
+    resource_requirement_declarations = baseline_resource_requirement_declarations(
+        adapter_key=TEST_ADAPTER_KEY,
+        capability="creator_profile",
+    )
+
+    def execute(self, request):
+        return make_creator_profile_result(target_ref=request.input.creator_id or "")
+
+
 class MediaAssetFetchAdapter:
     adapter_key = TEST_ADAPTER_KEY
     supported_capabilities = frozenset({"media_asset_fetch"})
@@ -442,6 +494,102 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(restored.request.capability, "media_asset_fetch_by_ref")
         self.assertEqual(restored.request.target_type, "media_ref")
         self.assertEqual(restored.request.target_value, "media:asset-001")
+
+    def test_round_trips_creator_profile_record(self) -> None:
+        outcome = execute_task_with_record(
+            TaskRequest(
+                adapter_key=TEST_ADAPTER_KEY,
+                capability="creator_profile_by_id",
+                input=TaskInput(creator_id="creator-001"),
+            ),
+            adapters={TEST_ADAPTER_KEY: CreatorProfileAdapter()},
+            task_id_factory=lambda: "task-record-creator-profile-1",
+        )
+
+        self.assertEqual(outcome.envelope["status"], "success")
+        self.assertEqual(outcome.envelope["operation"], "creator_profile_by_id")
+        self.assertIsNotNone(outcome.task_record)
+
+        payload = task_record_to_dict(outcome.task_record)
+        restored = task_record_from_dict(payload)
+
+        self.assertEqual(restored, outcome.task_record)
+        self.assertEqual(restored.request.capability, "creator_profile_by_id")
+        self.assertEqual(restored.request.target_type, "creator")
+        self.assertEqual(restored.request.target_value, "creator-001")
+
+    def test_round_trips_creator_profile_optional_target_refs(self) -> None:
+        request = TaskRequestSnapshot(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="creator_profile_by_id",
+            target_type="creator",
+            target_value="creator-001",
+            collection_mode="direct",
+        )
+        record = start_task_record(
+            create_task_record(
+                "task-record-creator-profile-origin",
+                request=request,
+                occurred_at="2026-05-09T10:00:00Z",
+            ),
+            occurred_at="2026-05-09T10:00:00Z",
+        )
+        envelope = make_creator_profile_result(target_ref="creator-001")
+        envelope["task_id"] = "task-record-creator-profile-origin"
+        envelope["adapter_key"] = TEST_ADAPTER_KEY
+        envelope["capability"] = "creator_profile_by_id"
+        envelope["status"] = "success"
+        record = finish_task_record(
+            record,
+            envelope,
+            occurred_at="2026-05-09T10:00:01Z",
+        )
+
+        restored = task_record_from_dict(task_record_to_dict(record))
+
+        self.assertEqual(restored, record)
+        self.assertEqual(restored.result.envelope["target"]["target_display_hint"], "creator-hint-001")
+        self.assertEqual(restored.result.envelope["target"]["policy_ref"], "policy:creator-profile")
+
+    def test_rejects_private_creator_profile_request_snapshot(self) -> None:
+        with self.assertRaises(TaskRecordContractError):
+            create_task_record(
+                "task-record-creator-private-ref",
+                TaskRequestSnapshot(
+                    adapter_key=TEST_ADAPTER_KEY,
+                    capability="creator_profile_by_id",
+                    target_type="creator",
+                    target_value="https://xhs.example.invalid/user/1",
+                    collection_mode="direct",
+                ),
+                occurred_at="2026-05-09T10:00:00Z",
+            )
+
+    def test_rejects_creator_profile_non_empty_audit(self) -> None:
+        request = TaskRequestSnapshot(
+            adapter_key=TEST_ADAPTER_KEY,
+            capability="creator_profile_by_id",
+            target_type="creator",
+            target_value="creator-001",
+            collection_mode="direct",
+        )
+        record = start_task_record(
+            create_task_record(
+                "task-record-creator-profile-audit",
+                request=request,
+                occurred_at="2026-05-09T10:00:00Z",
+            ),
+            occurred_at="2026-05-09T10:00:00Z",
+        )
+        envelope = make_creator_profile_result(target_ref="creator-001")
+        envelope["audit"] = {"transfer_observed": True}
+        envelope["task_id"] = "task-record-creator-profile-audit"
+        envelope["adapter_key"] = TEST_ADAPTER_KEY
+        envelope["capability"] = "creator_profile_by_id"
+        envelope["status"] = "success"
+
+        with self.assertRaises(TaskRecordContractError):
+            finish_task_record(record, envelope, occurred_at="2026-05-09T10:00:01Z")
 
     def test_round_trips_media_asset_fetch_parse_failed_record(self) -> None:
         request = TaskRequestSnapshot(


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：实现 `#422` 的 `creator_profile_by_id` runtime carrier。
- 主要改动：稳定 taxonomy、runtime admission/projection、TaskRecord carrier 校验、resource requirement compatibility 与回归测试。

## Issue 摘要

- Work Item `#422` 是 FR `#405` 的 creator profile runtime carrier 子事项。
- 本 PR 只覆盖 `creator_profile_by_id`，不包含 media fetch consumer migration、evidence 或 closeout。

## 关联事项

- Issue: #422
- item_key: `CHORE-0422-v1-5-creator-profile-runtime`
- item_type: `CHORE`
- release: `v1.5.0`
- sprint: `2026-S25`
- Closing: Closes #422

## Review Artifacts

- Active exec-plan: `docs/exec-plans/CHORE-0422-v1-5-creator-profile-runtime.md`
- Governing spec / bootstrap contract: `docs/specs/FR-0405-creator-profile-media-asset-read-contract/spec.md`
- Review artifact: `code_review.md`
- Validation evidence: `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`

## 风险

- 风险级别：`medium`
- 审查关注：creator carrier 是否 fail-closed、是否保持 public-only profile boundary、是否未扩到 #424/#425/#426 consumer/evidence/closeout 范围。

## 验证

- `python3 -m unittest tests.runtime.test_operation_taxonomy tests.runtime.test_runtime tests.runtime.test_task_record` (200 tests)
- `python3 -m unittest tests.runtime.test_operation_taxonomy tests.runtime.test_runtime tests.runtime.test_task_record tests.runtime.test_platform_leakage` (311 tests)
- `python3 -m unittest discover -s tests -p 'test*.py'` (527 tests)
- `python3 -m py_compile syvert/operation_taxonomy.py syvert/registry.py syvert/runtime.py syvert/task_record.py tests/runtime/test_operation_taxonomy.py tests/runtime/test_runtime.py tests/runtime/test_task_record.py`
- `python3 scripts/spec_guard.py --mode ci --all`
- `python3 scripts/docs_guard.py --mode ci`
- `python3 scripts/workflow_guard.py --mode ci`
- `python3 scripts/version_guard.py --mode ci`
- `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
- `git diff --check`

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint（`none` / `check_required` / `active` / `blocked` / `resolved`）: none
- shared_contract_changed（`no` / `yes`）: no
- integration_ref: none
- external_dependency（`none` / `syvert` / `webenvoy` / `both`）: none
- merge_gate（`local_only` / `integration_check_required`）: local_only
- contract_surface（`none` / `execution_provider` / `ids_trace` / `errors` / `raw_normalized` / `diagnostics_observability` / `runtime_modes`）: none
- joint_acceptance_needed（`no` / `yes`）: no
- integration_status_checked_before_pr（`no` / `yes`）: no
- integration_status_checked_before_merge（`no` / `yes`）: no

补充说明：本 PR 只更新 Syvert 内部 creator profile runtime carrier；后续 consumer migration/evidence/closeout 由 #424/#425/#426 承接。

## 回滚

- 回滚方式：使用独立 revert PR 撤销本 Work Item 对 runtime、TaskRecord、registry、taxonomy、tests 与 exec-plan 的增量修改。

## Notes

`python3 -m unittest` alone currently reports `NO TESTS RAN` in this repository; full discovery was run with `python3 -m unittest discover -s tests -p 'test*.py'`.

