### PR TITLE
feat(runtime): 迁移批处理消费者兼容读取

### DIFF
--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -126,3 +126,6 @@
 ## 最近一次 checkpoint 对应的 head SHA
 
 - Consumer migration checkpoint：`2df4d3cca1dd8b4e64d01c931750af7342da56e8`
+- Strict batch public carrier validation checkpoint：`15140180888cf2820dcb4e5ff8fd6fe5428ec897`
+- Cursor-sensitive public carrier compatibility checkpoint：`1e632913489b2aa1eaf00f7bb3f39417341bf24f`
+- Live PR head 以 GitHub `headRefOid` 为准；metadata-only checkpoint 只更新本执行计划记录。

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -56,6 +56,7 @@
   - sinkless item 不得伪造 `dataset_record_ref`；
   - `resume_token.next_item_index` 只指向已处理 item 前缀；
   - batch terminal 顶层不得携带 `raw` / `normalized` payload。
+- Guardian follow-up：TaskRecord batch projection 重建 canonical `BatchResultEnvelope` 并调用 #447 public carrier validator，避免 failed item 伪造 `dataset_record_ref`、nested `result_envelope` target drift、source/audit/private carrier 泄漏等宽松读取。
 - CLI query、HTTP status 与 HTTP result 可读取同一 batch TaskRecord public carrier，且不会暴露 `request_cursor_context`。
 - Batch target item consumer 只消费稳定 read-side runtime slices；compatibility consumers 遇到 dataset normalized payload 形状时 fail-closed。
 
@@ -71,6 +72,13 @@
 - Consumer/runtime compatibility suite：
   - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
   - 结果：通过，379 tests。
+- Guardian follow-up validation：
+  - `python3 -m unittest tests.runtime.test_task_record.TaskRecordCodecTests.test_round_trips_batch_execution_record tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_failed_batch_item_with_dataset_record_ref tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_item_result_envelope_target_drift tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_item_result_envelope_private_source_trace tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_execution_top_level_raw_payload`
+  - 结果：通过，5 tests。
+  - `python3 -m unittest tests.runtime.test_cli_http_same_path.CliHttpSamePathTests.test_batch_task_record_query_and_http_result_share_public_carrier`
+  - 结果：通过，1 test。
+  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
+  - 结果：通过，382 tests。
 - Full unittest discovery：
   - `python3 -m unittest discover`
   - 结果：通过，527 tests。
@@ -91,8 +99,9 @@
 ## 未决风险
 
 - 当前实现只迁移消费者读取 public batch carrier，不提供新的 batch/dataset CLI/HTTP submit endpoint。
-- TaskRecord consumer 对 nested read-side result envelope 做 wrapper 一致性检查，不重新验证实体字段；read-side carrier 缺陷仍须单独开修复项。
+- TaskRecord consumer 复用 canonical batch/dataset carrier validation；若发现 read-side carrier 缺陷，仍须单独开修复项。
 - #449 仍需补 sanitized evidence 与 replayable proof。
+- `python3 .loom/bin/loom_check.py .` 已运行但失败，失败项为 Loom full-runtime/adoption scaffold 缺失（如 `tools/loom_init.py`、`skills/*`、`packages/loom-installer`、adoption docs），不属于 #448 consumer migration 范围；Syvert repo-native guards 与 GitHub checks 已通过。
 
 ## 回滚方式
 

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -100,4 +100,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- Consumer migration checkpoint：`0e602a161b7d05c172e8aaf7aa03cd145ca6a285`
+- Consumer migration checkpoint：`2df4d3cca1dd8b4e64d01c931750af7342da56e8`

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -59,6 +59,7 @@
 - Guardian follow-up：TaskRecord batch projection 重建 canonical `BatchResultEnvelope` 并调用 #447 public carrier validator，避免 failed item 伪造 `dataset_record_ref`、nested `result_envelope` target drift、source/audit/private carrier 泄漏等宽松读取；同时对原始 batch envelope 顶层、`resume_token` 与 `item_outcomes` 执行严格字段集校验，避免 canonical projection 忽略的额外私有字段被原样回读。
 - Merge-gate follow-up：TaskRecord 接受 `batch_result_envelope_to_dict` 序列化后的 cursor-sensitive comment batch public carrier；该 public carrier 按 #447 约定不暴露 `request_cursor_context`，consumer 只从公开 comment result 中校验 schema/target/source/continuation 并派生本地验证用 thread ref，再交回 canonical batch validator 校验 aggregation、dataset boundary 与 audit。
 - Guardian follow-up 2：补齐 sinkless、`partial_success`、`all_failed`、`resumable` batch TaskRecord readback 覆盖；补 cursor-sensitive comment public carrier target drift 与多线程歧义拒绝；补真实 cursor-bearing `comment_collection` batch runtime admission/readback 证据。
+- Merge-gate follow-up 2：补 direct spy test，证明 cursor-sensitive public carrier 第一次 canonical validation 因缺少私有 request cursor 进入 fallback，fallback 从公开 comment thread 派生本地验证 context 后，downstream `validate_batch_result_envelope` 接受该 carrier。
 - CLI query、HTTP status 与 HTTP result 可读取同一 batch TaskRecord public carrier，且不会暴露 `request_cursor_context`。
 - Batch target item consumer 只消费稳定 read-side runtime slices；compatibility consumers 遇到 dataset normalized payload 形状时 fail-closed。
 
@@ -100,6 +101,11 @@
   - 结果：通过，72 tests。
   - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
   - 结果：通过，391 tests。
+- Merge-gate follow-up 2 validation：
+  - `python3 -m unittest tests.runtime.test_task_record.TaskRecordCodecTests.test_cursor_sensitive_batch_result_restores_cursor_for_downstream_validation tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers`
+  - 结果：通过，74 tests。
+  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
+  - 结果：通过，392 tests。
 - Full unittest discovery：
   - `python3 -m unittest discover`
   - 结果：通过，527 tests。

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -58,6 +58,7 @@
   - batch terminal 顶层不得携带 `raw` / `normalized` payload。
 - Guardian follow-up：TaskRecord batch projection 重建 canonical `BatchResultEnvelope` 并调用 #447 public carrier validator，避免 failed item 伪造 `dataset_record_ref`、nested `result_envelope` target drift、source/audit/private carrier 泄漏等宽松读取；同时对原始 batch envelope 顶层、`resume_token` 与 `item_outcomes` 执行严格字段集校验，避免 canonical projection 忽略的额外私有字段被原样回读。
 - Merge-gate follow-up：TaskRecord 接受 `batch_result_envelope_to_dict` 序列化后的 cursor-sensitive comment batch public carrier；该 public carrier 按 #447 约定不暴露 `request_cursor_context`，consumer 只从公开 comment result 中校验 schema/target/source/continuation 并派生本地验证用 thread ref，再交回 canonical batch validator 校验 aggregation、dataset boundary 与 audit。
+- Guardian follow-up 2：补齐 sinkless、`partial_success`、`all_failed`、`resumable` batch TaskRecord readback 覆盖；补 cursor-sensitive comment public carrier target drift 与多线程歧义拒绝；补真实 cursor-bearing `comment_collection` batch runtime admission/readback 证据。
 - CLI query、HTTP status 与 HTTP result 可读取同一 batch TaskRecord public carrier，且不会暴露 `request_cursor_context`。
 - Batch target item consumer 只消费稳定 read-side runtime slices；compatibility consumers 遇到 dataset normalized payload 形状时 fail-closed。
 
@@ -94,6 +95,11 @@
   - 结果：通过，45 tests。
   - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
   - 结果：通过，386 tests。
+- Guardian follow-up 2 validation：
+  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers`
+  - 结果：通过，72 tests。
+  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
+  - 结果：通过，391 tests。
 - Full unittest discovery：
   - `python3 -m unittest discover`
   - 结果：通过，527 tests。

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -57,6 +57,7 @@
   - `resume_token.next_item_index` 只指向已处理 item 前缀；
   - batch terminal 顶层不得携带 `raw` / `normalized` payload。
 - Guardian follow-up：TaskRecord batch projection 重建 canonical `BatchResultEnvelope` 并调用 #447 public carrier validator，避免 failed item 伪造 `dataset_record_ref`、nested `result_envelope` target drift、source/audit/private carrier 泄漏等宽松读取；同时对原始 batch envelope 顶层、`resume_token` 与 `item_outcomes` 执行严格字段集校验，避免 canonical projection 忽略的额外私有字段被原样回读。
+- Merge-gate follow-up：TaskRecord 接受 `batch_result_envelope_to_dict` 序列化后的 cursor-sensitive comment batch public carrier；该 public carrier 按 #447 约定不暴露 `request_cursor_context`，consumer 只从公开 comment result 中校验 schema/target/source/continuation 并派生本地验证用 thread ref，再交回 canonical batch validator 校验 aggregation、dataset boundary 与 audit。
 - CLI query、HTTP status 与 HTTP result 可读取同一 batch TaskRecord public carrier，且不会暴露 `request_cursor_context`。
 - Batch target item consumer 只消费稳定 read-side runtime slices；compatibility consumers 遇到 dataset normalized payload 形状时 fail-closed。
 
@@ -86,19 +87,26 @@
   - 结果：通过，1 test。
   - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
   - 结果：通过，385 tests。
+- Merge-gate follow-up validation：
+  - `python3 -m unittest tests.runtime.test_task_record.TaskRecordCodecTests.test_round_trips_serialized_cursor_sensitive_batch_result`
+  - 结果：通过，1 test。
+  - `python3 -m unittest tests.runtime.test_task_record`
+  - 结果：通过，45 tests。
+  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
+  - 结果：通过，386 tests。
 - Full unittest discovery：
   - `python3 -m unittest discover`
   - 结果：通过，527 tests。
 - Guards：
   - `python3 scripts/spec_guard.py --mode ci --all`
   - 结果：通过。
-  - `python3 scripts/docs_guard.py --mode ci`
+  - `python3 scripts/docs_guard.py`
   - 结果：通过。
-  - `python3 scripts/workflow_guard.py --mode ci`
+  - `python3 scripts/workflow_guard.py`
   - 结果：通过。
-  - `python3 scripts/version_guard.py --mode ci`
+  - `python3 scripts/version_guard.py`
   - 结果：通过。
-  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - `python3 scripts/governance_gate.py --base-ref origin/main --head-ref HEAD`
   - 结果：通过。
   - `git diff --check`
   - 结果：通过。
@@ -106,7 +114,7 @@
 ## 未决风险
 
 - 当前实现只迁移消费者读取 public batch carrier，不提供新的 batch/dataset CLI/HTTP submit endpoint。
-- TaskRecord consumer 复用 canonical batch/dataset carrier validation；若发现 read-side carrier 缺陷，仍须单独开修复项。
+- TaskRecord consumer 复用 canonical batch/dataset carrier validation；cursor-sensitive comment public carrier 的私有 request cursor omission 仅在 consumer 读回中按公开字段受控恢复验证上下文。若发现 read-side carrier 缺陷，仍须单独开修复项。
 - #449 仍需补 sanitized evidence 与 replayable proof。
 - `python3 .loom/bin/loom_check.py .` 已运行但失败，失败项为 Loom full-runtime/adoption scaffold 缺失（如 `tools/loom_init.py`、`skills/*`、`packages/loom-installer`、adoption docs），不属于 #448 consumer migration 范围；Syvert repo-native guards 与 GitHub checks 已通过。
 

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -10,7 +10,7 @@
 - Parent Phase：`#444`
 - Parent FR：`#445`
 - 关联 spec：`docs/specs/FR-0445-batch-dataset-core-contract/spec.md`
-- 关联 PR：
+- 关联 PR：`#453`
 - 状态：`active`
 
 ## 目标
@@ -43,7 +43,8 @@
 - Branch：`issue-448-445-v1-6-0-batch-dataset-consumers`
 - Worktree：`/Users/mc/code/worktrees/syvert/issue-448-445-v1-6-0-batch-dataset-consumers`
 - Baseline：`926a378dbec0c93fe2766eff8f4e3277083797c5`
-- PR：待创建。
+- PR：`#453` / `https://github.com/MC-and-his-Agents/Syvert/pull/453`
+- PR metadata follow-up 不刷新 checkpoint head；live review head 以 PR `headRefOid`、GitHub checks、guardian state 与 merge gate 为准。
 
 ## 已实现合同
 

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -1,0 +1,103 @@
+# CHORE-0448 v1.6 batch / dataset consumers 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0448-v1-6-batch-dataset-consumers`
+- Issue：`#448`
+- item_type：`CHORE`
+- release：`v1.6.0`
+- sprint：`2026-S25`
+- Parent Phase：`#444`
+- Parent FR：`#445`
+- 关联 spec：`docs/specs/FR-0445-batch-dataset-core-contract/spec.md`
+- 关联 PR：
+- 状态：`active`
+
+## 目标
+
+- 迁移 TaskRecord、result query、runtime admission 与 compatibility consumers，使 #447 交付的 batch/dataset public carrier 可被公共消费者读取。
+- 保持 direct `execute_task(batch_execution)` fail-closed，不重新打开 #447 runtime carrier 或 shared runtime admission 语义。
+- 保持 read-side result envelope 不被 batch consumer 重写。
+
+## 范围
+
+- 本次纳入：
+  - `syvert/task_record.py` 的 batch TaskRecord request/result projection 校验。
+  - `tests/runtime/test_task_record.py` 的 batch TaskRecord 编解码兼容回归。
+  - `tests/runtime/test_cli_http_same_path.py` 的 CLI query / HTTP status / HTTP result 读取同一 batch public carrier 回归。
+  - `tests/runtime/test_operation_taxonomy_consumers.py` 的 batch target item admission consumer 与 compatibility fail-closed 回归。
+  - 本执行计划。
+- 本次不纳入：
+  - `syvert/batch_dataset.py` runtime carrier 语义改写。
+  - `syvert/runtime.py` shared `TaskRequest` / `CoreTaskRequest` admission 扩容。
+  - scheduler、write-side admission、provider selector/fallback/marketplace、content library、BI、UI。
+  - #449 evidence artifact 与 #450 release closeout。
+
+## 当前停点
+
+- Phase `#444`：open。
+- FR `#445`：open，显式绑定 `v1.6.0 / 2026-S25`。
+- Work Item `#447`：runtime carrier PR `#452` 已合入 main，merge commit `926a378dbec0c93fe2766eff8f4e3277083797c5`。
+- Work Item `#448`：active consumers migration。
+- Workspace key：`issue-448-445-v1-6-0-batch-dataset-consumers`
+- Branch：`issue-448-445-v1-6-0-batch-dataset-consumers`
+- Worktree：`/Users/mc/code/worktrees/syvert/issue-448-445-v1-6-0-batch-dataset-consumers`
+- Baseline：`926a378dbec0c93fe2766eff8f4e3277083797c5`
+- PR：待创建。
+
+## 已实现合同
+
+- TaskRecord request snapshot 允许 `batch_execution / operation_batch / batch` 作为 consumer-side record projection，但不加入 runtime `execute_task` admission mapping。
+- TaskRecord terminal envelope 支持读取 batch public result carrier，并校验：
+  - `batch_id` 与 request snapshot 绑定；
+  - `result_status` 与 item outcome aggregation 一致；
+  - sink-bound success 必须携带 `dataset_record_ref`；
+  - sinkless item 不得伪造 `dataset_record_ref`；
+  - `resume_token.next_item_index` 只指向已处理 item 前缀；
+  - batch terminal 顶层不得携带 `raw` / `normalized` payload。
+- CLI query、HTTP status 与 HTTP result 可读取同一 batch TaskRecord public carrier，且不会暴露 `request_cursor_context`。
+- Batch target item consumer 只消费稳定 read-side runtime slices；compatibility consumers 遇到 dataset normalized payload 形状时 fail-closed。
+
+## 已验证项
+
+- Focused TaskRecord/result-query/compat tests：
+  - `python3 -m unittest tests.runtime.test_task_record.TaskRecordCodecTests.test_round_trips_batch_execution_record tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_execution_result_status_drift`
+  - 结果：通过，2 tests。
+  - `python3 -m unittest tests.runtime.test_cli_http_same_path.CliHttpSamePathTests.test_batch_task_record_query_and_http_result_share_public_carrier`
+  - 结果：通过，1 test。
+  - `python3 -m unittest tests.runtime.test_operation_taxonomy_consumers.OperationTaxonomyConsumerMigrationTests.test_batch_target_items_consume_stable_read_side_runtime_slices tests.runtime.test_operation_taxonomy_consumers.OperationTaxonomyConsumerMigrationTests.test_batch_target_item_rejects_provider_compatibility_as_operation tests.runtime.test_operation_taxonomy_consumers.OperationTaxonomyConsumerMigrationTests.test_compatibility_consumers_do_not_accept_dataset_normalized_payload`
+  - 结果：通过，3 tests。
+- Consumer/runtime compatibility suite：
+  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
+  - 结果：通过，379 tests。
+- Full unittest discovery：
+  - `python3 -m unittest discover`
+  - 结果：通过，527 tests。
+- Guards：
+  - `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过。
+  - `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+  - `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+  - `python3 scripts/version_guard.py --mode ci`
+  - 结果：通过。
+  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过。
+  - `git diff --check`
+  - 结果：通过。
+
+## 未决风险
+
+- 当前实现只迁移消费者读取 public batch carrier，不提供新的 batch/dataset CLI/HTTP submit endpoint。
+- TaskRecord consumer 对 nested read-side result envelope 做 wrapper 一致性检查，不重新验证实体字段；read-side carrier 缺陷仍须单独开修复项。
+- #449 仍需补 sanitized evidence 与 replayable proof。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销本 Work Item 的 TaskRecord consumer 与测试增量。
+- 保留 #445 / #448 truth，由后续 Work Item 重新迁移 consumer。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- Consumer migration checkpoint：`0e602a161b7d05c172e8aaf7aa03cd145ca6a285`

--- a/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
+++ b/docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md
@@ -56,7 +56,7 @@
   - sinkless item 不得伪造 `dataset_record_ref`；
   - `resume_token.next_item_index` 只指向已处理 item 前缀；
   - batch terminal 顶层不得携带 `raw` / `normalized` payload。
-- Guardian follow-up：TaskRecord batch projection 重建 canonical `BatchResultEnvelope` 并调用 #447 public carrier validator，避免 failed item 伪造 `dataset_record_ref`、nested `result_envelope` target drift、source/audit/private carrier 泄漏等宽松读取。
+- Guardian follow-up：TaskRecord batch projection 重建 canonical `BatchResultEnvelope` 并调用 #447 public carrier validator，避免 failed item 伪造 `dataset_record_ref`、nested `result_envelope` target drift、source/audit/private carrier 泄漏等宽松读取；同时对原始 batch envelope 顶层、`resume_token` 与 `item_outcomes` 执行严格字段集校验，避免 canonical projection 忽略的额外私有字段被原样回读。
 - CLI query、HTTP status 与 HTTP result 可读取同一 batch TaskRecord public carrier，且不会暴露 `request_cursor_context`。
 - Batch target item consumer 只消费稳定 read-side runtime slices；compatibility consumers 遇到 dataset normalized payload 形状时 fail-closed。
 
@@ -79,6 +79,13 @@
   - 结果：通过，1 test。
   - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
   - 结果：通过，382 tests。
+- Guardian rerun follow-up validation：
+  - `python3 -m unittest tests.runtime.test_task_record.TaskRecordCodecTests.test_round_trips_batch_execution_record tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_execution_top_level_extra_private_field tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_execution_request_snapshot_unsafe_batch_id tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_item_extra_private_field tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_failed_batch_item_with_dataset_record_ref tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_item_result_envelope_target_drift tests.runtime.test_task_record.TaskRecordCodecTests.test_rejects_batch_item_result_envelope_private_source_trace`
+  - 结果：通过，7 tests。
+  - `python3 -m unittest tests.runtime.test_cli_http_same_path.CliHttpSamePathTests.test_batch_task_record_query_and_http_result_share_public_carrier`
+  - 结果：通过，1 test。
+  - `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
+  - 结果：通过，385 tests。
 - Full unittest discovery：
   - `python3 -m unittest discover`
   - 结果：通过，527 tests。

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -22,17 +22,6 @@ TASK_LOG_STAGE_ORDER = {"admission": 0, "execution": 1, "completion": 2}
 BATCH_EXECUTION_OPERATION = "batch_execution"
 BATCH_TARGET_TYPE = "operation_batch"
 BATCH_COLLECTION_MODE = "batch"
-BATCH_RESULT_STATUSES = frozenset({"complete", "partial_success", "all_failed", "resumable"})
-BATCH_ITEM_STATUSES = frozenset({"succeeded", "failed", "duplicate_skipped"})
-BATCH_ITEM_OPERATIONS = frozenset(
-    {
-        "content_search_by_keyword",
-        "content_list_by_creator",
-        "comment_collection",
-        "creator_profile_by_id",
-        "media_asset_fetch_by_ref",
-    }
-)
 SHARED_CAPABILITIES = frozenset(
     {
         "content_detail_by_url",
@@ -1131,132 +1120,102 @@ def validate_batch_success_terminal_envelope(record: TaskRecord, envelope: Mappi
     batch_id = require_string(envelope.get("batch_id"), field="result.envelope.batch_id")
     if batch_id != record.request.target_value:
         raise TaskRecordContractError("batch TaskTerminalResult.envelope.batch_id 与请求快照不一致")
-    result_status = require_string(envelope.get("result_status"), field="result.envelope.result_status")
-    if result_status not in BATCH_RESULT_STATUSES:
-        raise TaskRecordContractError("batch TaskTerminalResult.envelope.result_status 不在允许值范围内")
+    try:
+        _validate_canonical_batch_result_projection(envelope)
+    except TaskRecordContractError:
+        raise
+    except Exception as error:
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope 不满足 public carrier contract") from error
+
+
+def _validate_canonical_batch_result_projection(envelope: Mapping[str, Any]) -> None:
+    from syvert.batch_dataset import (
+        BatchItemOutcome,
+        BatchResultEnvelope,
+        BatchResumeToken,
+        validate_batch_result_envelope,
+    )
+
     item_outcomes = envelope.get("item_outcomes")
     if not isinstance(item_outcomes, list):
         raise TaskRecordContractError("batch TaskTerminalResult.envelope.item_outcomes 必须是数组")
-    if result_status != "resumable" and not item_outcomes:
-        raise TaskRecordContractError("terminal batch TaskTerminalResult.envelope 必须包含 item_outcomes")
-    for index, outcome in enumerate(item_outcomes):
-        if not isinstance(outcome, Mapping):
-            raise TaskRecordContractError("batch item_outcomes 项必须是对象")
-        validate_batch_item_outcome_projection(outcome, index=index)
-    if result_status != "resumable" and result_status != _batch_result_status_from_items(item_outcomes):
-        raise TaskRecordContractError("batch TaskTerminalResult.envelope.result_status 与 item_outcomes 不一致")
-    resume_token = envelope.get("resume_token")
-    if result_status == "resumable":
-        if not isinstance(resume_token, Mapping):
-            raise TaskRecordContractError("resumable batch TaskTerminalResult.envelope 必须包含 resume_token")
-        if require_string(resume_token.get("batch_id"), field="result.envelope.resume_token.batch_id") != batch_id:
-            raise TaskRecordContractError("batch resume_token.batch_id 与 batch_id 不一致")
-        next_item_index = coerce_int(
-            resume_token.get("next_item_index"),
-            field="result.envelope.resume_token.next_item_index",
+    resume_token_payload = envelope.get("resume_token")
+    resume_token = None
+    if resume_token_payload is not None:
+        if not isinstance(resume_token_payload, Mapping):
+            raise TaskRecordContractError("batch TaskTerminalResult.envelope.resume_token 必须是对象")
+        resume_token = BatchResumeToken(
+            resume_token=require_string(
+                resume_token_payload.get("resume_token"),
+                field="result.envelope.resume_token.resume_token",
+            ),
+            batch_id=require_string(resume_token_payload.get("batch_id"), field="result.envelope.resume_token.batch_id"),
+            target_set_hash=require_string(
+                resume_token_payload.get("target_set_hash"),
+                field="result.envelope.resume_token.target_set_hash",
+            ),
+            next_item_index=coerce_int(
+                resume_token_payload.get("next_item_index"),
+                field="result.envelope.resume_token.next_item_index",
+            ),
+            issued_at=require_string(resume_token_payload.get("issued_at"), field="result.envelope.resume_token.issued_at"),
+            dataset_sink_ref=require_optional_string(
+                resume_token_payload.get("dataset_sink_ref"),
+                field="result.envelope.resume_token.dataset_sink_ref",
+            ),
+            dataset_id=require_optional_string(
+                resume_token_payload.get("dataset_id"),
+                field="result.envelope.resume_token.dataset_id",
+            ),
         )
-        if next_item_index != len(item_outcomes):
-            raise TaskRecordContractError("batch resume_token.next_item_index 必须指向已处理 item 前缀")
-    elif resume_token is not None:
-        raise TaskRecordContractError("terminal batch TaskTerminalResult.envelope 不得包含 resume_token")
-    dataset_sink_ref = require_optional_string(
-        envelope.get("dataset_sink_ref"),
-        field="result.envelope.dataset_sink_ref",
-    )
-    dataset_id = require_optional_string(envelope.get("dataset_id"), field="result.envelope.dataset_id")
-    if dataset_sink_ref is not None and dataset_id is None:
-        raise TaskRecordContractError("batch TaskTerminalResult.envelope.dataset_sink_ref 必须绑定 dataset_id")
-    for outcome in item_outcomes:
-        dataset_record_ref = require_optional_string(
-            outcome.get("dataset_record_ref"),
-            field="result.envelope.item_outcomes.dataset_record_ref",
-        )
-        if dataset_sink_ref is not None and outcome.get("outcome_status") == "succeeded" and dataset_record_ref is None:
-            raise TaskRecordContractError("sink-bound batch succeeded item 必须包含 dataset_record_ref")
-        if dataset_sink_ref is None and dataset_record_ref is not None:
-            raise TaskRecordContractError("sinkless batch item 不得包含 dataset_record_ref")
     audit_trace = envelope.get("audit_trace")
     if not isinstance(audit_trace, Mapping):
         raise TaskRecordContractError("batch TaskTerminalResult.envelope.audit_trace 必须是对象")
-    if audit_trace.get("batch_id") != batch_id:
-        raise TaskRecordContractError("batch audit_trace.batch_id 与 batch_id 不一致")
-    if "item_count" in audit_trace and coerce_int(
-        audit_trace.get("item_count"),
-        field="result.envelope.audit_trace.item_count",
-    ) != len(item_outcomes):
-        raise TaskRecordContractError("batch audit_trace.item_count 与 item_outcomes 不一致")
+    canonical = BatchResultEnvelope(
+        batch_id=require_string(envelope.get("batch_id"), field="result.envelope.batch_id"),
+        operation=require_string(envelope.get("operation"), field="result.envelope.operation"),
+        result_status=require_string(envelope.get("result_status"), field="result.envelope.result_status"),
+        item_outcomes=tuple(_batch_item_outcome_from_projection(item, index=index) for index, item in enumerate(item_outcomes)),
+        resume_token=resume_token,
+        dataset_sink_ref=require_optional_string(envelope.get("dataset_sink_ref"), field="result.envelope.dataset_sink_ref"),
+        dataset_id=require_optional_string(envelope.get("dataset_id"), field="result.envelope.dataset_id"),
+        audit_trace=dict(audit_trace),
+    )
+    validate_batch_result_envelope(canonical)
 
 
-def validate_batch_item_outcome_projection(outcome: Mapping[str, Any], *, index: int) -> None:
-    item_prefix = f"result.envelope.item_outcomes[{index}]"
-    require_string(outcome.get("item_id"), field=f"{item_prefix}.item_id")
-    operation = require_string(outcome.get("operation"), field=f"{item_prefix}.operation")
-    if operation not in BATCH_ITEM_OPERATIONS:
-        raise TaskRecordContractError("batch item_outcome.operation 不在允许值范围内")
-    require_string(outcome.get("adapter_key"), field=f"{item_prefix}.adapter_key")
-    require_string(outcome.get("target_ref"), field=f"{item_prefix}.target_ref")
-    outcome_status = require_string(outcome.get("outcome_status"), field=f"{item_prefix}.outcome_status")
-    if outcome_status not in BATCH_ITEM_STATUSES:
-        raise TaskRecordContractError("batch item_outcome.outcome_status 不在允许值范围内")
-    result_envelope = outcome.get("result_envelope")
-    error_envelope = outcome.get("error_envelope")
-    if outcome_status == "succeeded":
-        if not isinstance(result_envelope, Mapping):
-            raise TaskRecordContractError("succeeded batch item_outcome 必须包含 result_envelope")
-        validate_batch_item_result_projection(result_envelope, operation=operation, adapter_key=outcome["adapter_key"])
-        if error_envelope is not None:
-            raise TaskRecordContractError("succeeded batch item_outcome 不得包含 error_envelope")
-    elif outcome_status == "failed":
-        if not isinstance(error_envelope, Mapping):
-            raise TaskRecordContractError("failed batch item_outcome 必须包含 error_envelope")
-        if result_envelope is not None:
-            if not isinstance(result_envelope, Mapping):
-                raise TaskRecordContractError("failed batch item_outcome.result_envelope 必须是对象")
-            validate_batch_item_result_projection(
-                result_envelope,
-                operation=operation,
-                adapter_key=outcome["adapter_key"],
-            )
-    elif result_envelope is not None or error_envelope is not None or outcome.get("dataset_record_ref") is not None:
-        raise TaskRecordContractError("duplicate_skipped batch item_outcome 不得包含 result/error/dataset refs")
-    if (
-        "source_trace" in outcome
-        and outcome["source_trace"] is not None
-        and not isinstance(outcome["source_trace"], Mapping)
-    ):
-        raise TaskRecordContractError("batch item_outcome.source_trace 必须是对象或 null")
-    audit = outcome.get("audit")
+def _batch_item_outcome_from_projection(item: Any, *, index: int) -> Any:
+    from syvert.batch_dataset import BatchItemOutcome
+
+    if not isinstance(item, Mapping):
+        raise TaskRecordContractError("batch item_outcomes 项必须是对象")
+    field_prefix = f"result.envelope.item_outcomes[{index}]"
+    audit = item.get("audit")
     if not isinstance(audit, Mapping):
         raise TaskRecordContractError("batch item_outcome.audit 必须是对象")
+    return BatchItemOutcome(
+        item_id=require_string(item.get("item_id"), field=f"{field_prefix}.item_id"),
+        operation=require_string(item.get("operation"), field=f"{field_prefix}.operation"),
+        adapter_key=require_string(item.get("adapter_key"), field=f"{field_prefix}.adapter_key"),
+        target_ref=require_string(item.get("target_ref"), field=f"{field_prefix}.target_ref"),
+        outcome_status=require_string(item.get("outcome_status"), field=f"{field_prefix}.outcome_status"),
+        result_envelope=_optional_mapping_dict(item.get("result_envelope"), field=f"{field_prefix}.result_envelope"),
+        error_envelope=_optional_mapping_dict(item.get("error_envelope"), field=f"{field_prefix}.error_envelope"),
+        dataset_record_ref=require_optional_string(
+            item.get("dataset_record_ref"),
+            field=f"{field_prefix}.dataset_record_ref",
+        ),
+        source_trace=_optional_mapping_dict(item.get("source_trace"), field=f"{field_prefix}.source_trace"),
+        audit=dict(audit),
+    )
 
 
-def validate_batch_item_result_projection(
-    result_envelope: Mapping[str, Any],
-    *,
-    operation: str,
-    adapter_key: str,
-) -> None:
-    if result_envelope.get("status") != "success":
-        raise TaskRecordContractError("batch item result_envelope.status 必须为 success")
-    if result_envelope.get("capability") != operation:
-        raise TaskRecordContractError("batch item result_envelope.capability 与 operation 不一致")
-    if result_envelope.get("adapter_key") != adapter_key:
-        raise TaskRecordContractError("batch item result_envelope.adapter_key 与 item adapter_key 不一致")
-
-
-def _batch_result_status_from_items(item_outcomes: list[Any]) -> str:
-    non_duplicate = [
-        outcome
-        for outcome in item_outcomes
-        if isinstance(outcome, Mapping) and outcome.get("outcome_status") != "duplicate_skipped"
-    ]
-    succeeded = any(outcome.get("outcome_status") == "succeeded" for outcome in non_duplicate)
-    failed = any(outcome.get("outcome_status") == "failed" for outcome in non_duplicate)
-    if succeeded and failed:
-        return "partial_success"
-    if failed:
-        return "all_failed"
-    return "complete"
+def _optional_mapping_dict(value: Any, *, field: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TaskRecordContractError(f"{field} 必须是对象或 null")
+    return dict(value)
 
 
 def validate_terminal_envelope_observability_contract(record: TaskRecord, envelope: Mapping[str, Any]) -> None:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -22,6 +22,54 @@ TASK_LOG_STAGE_ORDER = {"admission": 0, "execution": 1, "completion": 2}
 BATCH_EXECUTION_OPERATION = "batch_execution"
 BATCH_TARGET_TYPE = "operation_batch"
 BATCH_COLLECTION_MODE = "batch"
+BATCH_TERMINAL_ENVELOPE_FIELDS = frozenset(
+    {
+        "task_id",
+        "adapter_key",
+        "capability",
+        "status",
+        "task_record_ref",
+        "runtime_result_refs",
+        "execution_control_events",
+        "runtime_failure_signal",
+        "runtime_failure_signals",
+        "runtime_structured_log_events",
+        "runtime_execution_metric_samples",
+        "batch_id",
+        "operation",
+        "result_status",
+        "item_outcomes",
+        "resume_token",
+        "dataset_sink_ref",
+        "dataset_id",
+        "audit_trace",
+    }
+)
+BATCH_ITEM_OUTCOME_FIELDS = frozenset(
+    {
+        "item_id",
+        "operation",
+        "adapter_key",
+        "target_ref",
+        "outcome_status",
+        "result_envelope",
+        "error_envelope",
+        "dataset_record_ref",
+        "source_trace",
+        "audit",
+    }
+)
+BATCH_RESUME_TOKEN_FIELDS = frozenset(
+    {
+        "resume_token",
+        "batch_id",
+        "target_set_hash",
+        "next_item_index",
+        "issued_at",
+        "dataset_sink_ref",
+        "dataset_id",
+    }
+)
 SHARED_CAPABILITIES = frozenset(
     {
         "content_detail_by_url",
@@ -789,6 +837,7 @@ def validate_request_snapshot(snapshot: TaskRequestSnapshot) -> None:
             raise TaskRecordContractError("batch TaskRequestSnapshot.target_type 必须为 operation_batch")
         if collection_mode != BATCH_COLLECTION_MODE:
             raise TaskRecordContractError("batch TaskRequestSnapshot.collection_mode 必须为 batch")
+        validate_batch_public_ref(target_value, field="TaskRequestSnapshot.target_value")
         return
     if capability not in SHARED_CAPABILITIES:
         raise TaskRecordContractError("TaskRequestSnapshot.capability 不在共享请求模型允许值范围内")
@@ -1113,6 +1162,9 @@ def validate_terminal_envelope_contract(record: TaskRecord, envelope: Mapping[st
 
 
 def validate_batch_success_terminal_envelope(record: TaskRecord, envelope: Mapping[str, Any]) -> None:
+    extra_fields = sorted(set(envelope) - BATCH_TERMINAL_ENVELOPE_FIELDS)
+    if extra_fields:
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope 包含未批准字段")
     if "raw" in envelope or "normalized" in envelope:
         raise TaskRecordContractError("batch TaskTerminalResult.envelope 不得包含 raw/normalized 顶层 payload")
     if envelope.get("operation") != BATCH_EXECUTION_OPERATION:
@@ -1144,6 +1196,9 @@ def _validate_canonical_batch_result_projection(envelope: Mapping[str, Any]) -> 
     if resume_token_payload is not None:
         if not isinstance(resume_token_payload, Mapping):
             raise TaskRecordContractError("batch TaskTerminalResult.envelope.resume_token 必须是对象")
+        extra_resume_fields = sorted(set(resume_token_payload) - BATCH_RESUME_TOKEN_FIELDS)
+        if extra_resume_fields:
+            raise TaskRecordContractError("batch TaskTerminalResult.envelope.resume_token 包含未批准字段")
         resume_token = BatchResumeToken(
             resume_token=require_string(
                 resume_token_payload.get("resume_token"),
@@ -1189,6 +1244,9 @@ def _batch_item_outcome_from_projection(item: Any, *, index: int) -> Any:
 
     if not isinstance(item, Mapping):
         raise TaskRecordContractError("batch item_outcomes 项必须是对象")
+    extra_fields = sorted(set(item) - BATCH_ITEM_OUTCOME_FIELDS)
+    if extra_fields:
+        raise TaskRecordContractError("batch item_outcome 包含未批准字段")
     field_prefix = f"result.envelope.item_outcomes[{index}]"
     audit = item.get("audit")
     if not isinstance(audit, Mapping):
@@ -1216,6 +1274,15 @@ def _optional_mapping_dict(value: Any, *, field: str) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):
         raise TaskRecordContractError(f"{field} 必须是对象或 null")
     return dict(value)
+
+
+def validate_batch_public_ref(value: str, *, field: str) -> None:
+    from syvert.batch_dataset import _validate_sanitized_ref
+
+    try:
+        _validate_sanitized_ref(value, field=field)
+    except Exception as error:
+        raise TaskRecordContractError(f"{field} 不满足 batch public ref 约束") from error
 
 
 def validate_terminal_envelope_observability_contract(record: TaskRecord, envelope: Mapping[str, Any]) -> None:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -1182,10 +1182,24 @@ def validate_batch_success_terminal_envelope(record: TaskRecord, envelope: Mappi
 
 def _validate_canonical_batch_result_projection(envelope: Mapping[str, Any]) -> None:
     from syvert.batch_dataset import (
-        BatchItemOutcome,
+        BatchDatasetContractError,
+        validate_batch_result_envelope,
+    )
+
+    canonical = _batch_result_envelope_from_projection(envelope)
+    try:
+        validate_batch_result_envelope(canonical)
+    except BatchDatasetContractError as error:
+        if _is_missing_public_cursor_context_error(error):
+            _validate_batch_result_projection_with_public_cursor_omission(canonical)
+            return
+        raise
+
+
+def _batch_result_envelope_from_projection(envelope: Mapping[str, Any]) -> Any:
+    from syvert.batch_dataset import (
         BatchResultEnvelope,
         BatchResumeToken,
-        validate_batch_result_envelope,
     )
 
     item_outcomes = envelope.get("item_outcomes")
@@ -1204,7 +1218,10 @@ def _validate_canonical_batch_result_projection(envelope: Mapping[str, Any]) -> 
                 resume_token_payload.get("resume_token"),
                 field="result.envelope.resume_token.resume_token",
             ),
-            batch_id=require_string(resume_token_payload.get("batch_id"), field="result.envelope.resume_token.batch_id"),
+            batch_id=require_string(
+                resume_token_payload.get("batch_id"),
+                field="result.envelope.resume_token.batch_id",
+            ),
             target_set_hash=require_string(
                 resume_token_payload.get("target_set_hash"),
                 field="result.envelope.resume_token.target_set_hash",
@@ -1213,7 +1230,10 @@ def _validate_canonical_batch_result_projection(envelope: Mapping[str, Any]) -> 
                 resume_token_payload.get("next_item_index"),
                 field="result.envelope.resume_token.next_item_index",
             ),
-            issued_at=require_string(resume_token_payload.get("issued_at"), field="result.envelope.resume_token.issued_at"),
+            issued_at=require_string(
+                resume_token_payload.get("issued_at"),
+                field="result.envelope.resume_token.issued_at",
+            ),
             dataset_sink_ref=require_optional_string(
                 resume_token_payload.get("dataset_sink_ref"),
                 field="result.envelope.resume_token.dataset_sink_ref",
@@ -1226,17 +1246,169 @@ def _validate_canonical_batch_result_projection(envelope: Mapping[str, Any]) -> 
     audit_trace = envelope.get("audit_trace")
     if not isinstance(audit_trace, Mapping):
         raise TaskRecordContractError("batch TaskTerminalResult.envelope.audit_trace 必须是对象")
-    canonical = BatchResultEnvelope(
+    return BatchResultEnvelope(
         batch_id=require_string(envelope.get("batch_id"), field="result.envelope.batch_id"),
         operation=require_string(envelope.get("operation"), field="result.envelope.operation"),
         result_status=require_string(envelope.get("result_status"), field="result.envelope.result_status"),
-        item_outcomes=tuple(_batch_item_outcome_from_projection(item, index=index) for index, item in enumerate(item_outcomes)),
+        item_outcomes=tuple(
+            _batch_item_outcome_from_projection(item, index=index)
+            for index, item in enumerate(item_outcomes)
+        ),
         resume_token=resume_token,
-        dataset_sink_ref=require_optional_string(envelope.get("dataset_sink_ref"), field="result.envelope.dataset_sink_ref"),
+        dataset_sink_ref=require_optional_string(
+            envelope.get("dataset_sink_ref"),
+            field="result.envelope.dataset_sink_ref",
+        ),
         dataset_id=require_optional_string(envelope.get("dataset_id"), field="result.envelope.dataset_id"),
         audit_trace=dict(audit_trace),
     )
-    validate_batch_result_envelope(canonical)
+
+
+def _is_missing_public_cursor_context_error(error: Exception) -> bool:
+    return (
+        getattr(error, "code", None) == "result_envelope_boundary_mismatch"
+        and "requires request_cursor context" in str(getattr(error, "message", error))
+    )
+
+
+def _validate_batch_result_projection_with_public_cursor_omission(envelope: Any) -> None:
+    from syvert.batch_dataset import (
+        BatchItemOutcome,
+        BatchResultEnvelope,
+        validate_batch_result_envelope,
+    )
+
+    cursor_restored_outcomes = []
+    for outcome in envelope.item_outcomes:
+        if _outcome_uses_public_cursor_omission(outcome):
+            request_cursor_context = _validate_cursor_sensitive_public_result_envelope(outcome)
+            cursor_restored_outcomes.append(
+                BatchItemOutcome(
+                    item_id=outcome.item_id,
+                    operation=outcome.operation,
+                    adapter_key=outcome.adapter_key,
+                    target_ref=outcome.target_ref,
+                    outcome_status=outcome.outcome_status,
+                    result_envelope=outcome.result_envelope,
+                    error_envelope=outcome.error_envelope,
+                    dataset_record_ref=outcome.dataset_record_ref,
+                    source_trace=outcome.source_trace,
+                    audit=outcome.audit,
+                    request_cursor_context=request_cursor_context,
+                )
+            )
+            continue
+        cursor_restored_outcomes.append(outcome)
+    if len(cursor_restored_outcomes) == len(envelope.item_outcomes) and all(
+        not _outcome_uses_public_cursor_omission(outcome) for outcome in envelope.item_outcomes
+    ):
+        raise TaskRecordContractError("batch public carrier cursor context fallback 未命中")
+    validate_batch_result_envelope(
+        BatchResultEnvelope(
+            batch_id=envelope.batch_id,
+            operation=envelope.operation,
+            result_status=envelope.result_status,
+            item_outcomes=tuple(cursor_restored_outcomes),
+            resume_token=envelope.resume_token,
+            dataset_sink_ref=envelope.dataset_sink_ref,
+            dataset_id=envelope.dataset_id,
+            audit_trace=envelope.audit_trace,
+        )
+    )
+
+
+def _outcome_uses_public_cursor_omission(outcome: Any) -> bool:
+    from syvert.batch_dataset import _comment_result_requires_cursor_context
+
+    return (
+        outcome.operation == COMMENT_COLLECTION_OPERATION
+        and outcome.result_envelope is not None
+        and _comment_result_requires_cursor_context(outcome.result_envelope)
+    )
+
+
+def _validate_cursor_sensitive_public_result_envelope(outcome: Any) -> Mapping[str, Any]:
+    from syvert.batch_dataset import (
+        _RESULT_ENVELOPE_WRAPPER_FIELDS,
+        _SUCCESS_PAYLOAD_FIELDS_BY_OPERATION,
+        TARGET_TYPE_BY_OPERATION,
+        _validate_public_continuation_carriers,
+        _validate_result_envelope_wrapper,
+        _validate_source_trace,
+    )
+
+    result_envelope = outcome.result_envelope
+    if not isinstance(result_envelope, Mapping):
+        raise TaskRecordContractError("batch item result_envelope 必须是对象")
+    payload_fields = _SUCCESS_PAYLOAD_FIELDS_BY_OPERATION[outcome.operation]
+    extra_fields = sorted(set(result_envelope) - (payload_fields | _RESULT_ENVELOPE_WRAPPER_FIELDS))
+    if extra_fields:
+        raise TaskRecordContractError("batch item result_envelope 包含未批准字段")
+    _validate_result_envelope_wrapper(
+        operation=outcome.operation,
+        adapter_key=outcome.adapter_key,
+        result_envelope=result_envelope,
+        item_id=outcome.item_id,
+        code="result_envelope_boundary_mismatch",
+        index=None,
+    )
+    if isinstance(result_envelope.get("source_trace"), Mapping):
+        _validate_source_trace(result_envelope["source_trace"], adapter_key=outcome.adapter_key)
+    payload = {field: result_envelope[field] for field in payload_fields if field in result_envelope}
+    comment_envelope = comment_collection_result_envelope_from_dict(payload)
+    target = result_envelope.get("target")
+    if not isinstance(target, Mapping):
+        raise TaskRecordContractError("batch item result_envelope.target 必须是对象")
+    if (
+        target.get("operation") != outcome.operation
+        or target.get("target_type") != TARGET_TYPE_BY_OPERATION[outcome.operation]
+        or target.get("target_ref") != outcome.target_ref
+    ):
+        raise TaskRecordContractError("batch item result_envelope target 与 item 不一致")
+    _validate_public_continuation_carriers(
+        result_envelope.get("next_continuation"),
+        field="result_envelope.next_continuation",
+    )
+    thread_ref = _infer_public_comment_thread_ref(comment_envelope)
+    return {"reply_cursor": {"resume_comment_ref": thread_ref}}
+
+
+def _infer_public_comment_thread_ref(comment_envelope: Any) -> str:
+    continuation = comment_envelope.next_continuation
+    continuation_ref = getattr(continuation, "resume_comment_ref", None)
+    if isinstance(continuation_ref, str) and continuation_ref:
+        return continuation_ref
+
+    candidates: list[str] = []
+    cursor_sensitive_items = []
+    for item in comment_envelope.items:
+        normalized = item.normalized
+        if normalized.parent_comment_ref is None and normalized.target_comment_ref is None:
+            continue
+        cursor_sensitive_items.append(item)
+        for value in (
+            normalized.root_comment_ref,
+            normalized.parent_comment_ref,
+            normalized.target_comment_ref,
+        ):
+            if isinstance(value, str) and value and value not in candidates:
+                candidates.append(value)
+    for candidate in candidates:
+        if all(_comment_public_item_binds_ref(item, candidate) for item in cursor_sensitive_items):
+            return candidate
+    raise TaskRecordContractError("batch public carrier 缺少可验证的 comment cursor thread")
+
+
+def _comment_public_item_binds_ref(item: Any, comment_ref: str) -> bool:
+    normalized = item.normalized
+    return (
+        normalized.root_comment_ref == comment_ref
+        or normalized.parent_comment_ref == comment_ref
+        or (
+            normalized.parent_comment_ref != normalized.root_comment_ref
+            and normalized.target_comment_ref == comment_ref
+        )
+    )
 
 
 def _batch_item_outcome_from_projection(item: Any, *, index: int) -> Any:

--- a/syvert/task_record.py
+++ b/syvert/task_record.py
@@ -19,6 +19,20 @@ TASK_RECORD_STATUSES = frozenset({"accepted", "running", "succeeded", "failed"})
 TASK_LOG_STAGES = frozenset({"admission", "execution", "completion"})
 TASK_LOG_LEVELS = frozenset({"info", "error"})
 TASK_LOG_STAGE_ORDER = {"admission": 0, "execution": 1, "completion": 2}
+BATCH_EXECUTION_OPERATION = "batch_execution"
+BATCH_TARGET_TYPE = "operation_batch"
+BATCH_COLLECTION_MODE = "batch"
+BATCH_RESULT_STATUSES = frozenset({"complete", "partial_success", "all_failed", "resumable"})
+BATCH_ITEM_STATUSES = frozenset({"succeeded", "failed", "duplicate_skipped"})
+BATCH_ITEM_OPERATIONS = frozenset(
+    {
+        "content_search_by_keyword",
+        "content_list_by_creator",
+        "comment_collection",
+        "creator_profile_by_id",
+        "media_asset_fetch_by_ref",
+    }
+)
 SHARED_CAPABILITIES = frozenset(
     {
         "content_detail_by_url",
@@ -779,14 +793,20 @@ def validate_request_snapshot(snapshot: TaskRequestSnapshot) -> None:
     target_type = require_string(snapshot.target_type, field="TaskRequestSnapshot.target_type")
     target_value = require_string(snapshot.target_value, field="TaskRequestSnapshot.target_value")
     collection_mode = require_string(snapshot.collection_mode, field="TaskRequestSnapshot.collection_mode")
+    if not adapter_key:
+        raise TaskRecordContractError("TaskRequestSnapshot.adapter_key 必须为非空字符串")
+    if capability == BATCH_EXECUTION_OPERATION:
+        if target_type != BATCH_TARGET_TYPE:
+            raise TaskRecordContractError("batch TaskRequestSnapshot.target_type 必须为 operation_batch")
+        if collection_mode != BATCH_COLLECTION_MODE:
+            raise TaskRecordContractError("batch TaskRequestSnapshot.collection_mode 必须为 batch")
+        return
     if capability not in SHARED_CAPABILITIES:
         raise TaskRecordContractError("TaskRequestSnapshot.capability 不在共享请求模型允许值范围内")
     if target_type not in SHARED_TARGET_TYPES:
         raise TaskRecordContractError("TaskRequestSnapshot.target_type 不在共享请求模型允许值范围内")
     if collection_mode not in SHARED_COLLECTION_MODES:
         raise TaskRecordContractError("TaskRequestSnapshot.collection_mode 不在共享请求模型允许值范围内")
-    if not adapter_key:
-        raise TaskRecordContractError("TaskRequestSnapshot.adapter_key 必须为非空字符串")
     if capability == "creator_profile_by_id" and target_type == "creator":
         _require_sanitized_creator_ref(target_value, field="TaskRequestSnapshot.target_value")
     if capability == "media_asset_fetch_by_ref" and target_type == "media_ref":
@@ -1060,6 +1080,11 @@ def validate_terminal_envelope_contract(record: TaskRecord, envelope: Mapping[st
 
     status = terminal_record_status(envelope)
     if status == "succeeded":
+        if capability == BATCH_EXECUTION_OPERATION:
+            validate_batch_success_terminal_envelope(record, envelope)
+            if "error" in envelope:
+                raise TaskRecordContractError("success TaskTerminalResult.envelope 不得包含 error")
+            return
         validate_success_terminal_envelope(envelope)
         if capability in READ_SIDE_COLLECTION_OPERATIONS:
             collection = collection_result_envelope_from_dict(_collection_result_payload_from_terminal_envelope(envelope))
@@ -1096,6 +1121,142 @@ def validate_terminal_envelope_contract(record: TaskRecord, envelope: Mapping[st
     validate_failed_terminal_envelope(envelope)
     if "raw" in envelope or "normalized" in envelope:
         raise TaskRecordContractError("failed TaskTerminalResult.envelope 不得包含 success payload 字段")
+
+
+def validate_batch_success_terminal_envelope(record: TaskRecord, envelope: Mapping[str, Any]) -> None:
+    if "raw" in envelope or "normalized" in envelope:
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope 不得包含 raw/normalized 顶层 payload")
+    if envelope.get("operation") != BATCH_EXECUTION_OPERATION:
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope.operation 必须为 batch_execution")
+    batch_id = require_string(envelope.get("batch_id"), field="result.envelope.batch_id")
+    if batch_id != record.request.target_value:
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope.batch_id 与请求快照不一致")
+    result_status = require_string(envelope.get("result_status"), field="result.envelope.result_status")
+    if result_status not in BATCH_RESULT_STATUSES:
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope.result_status 不在允许值范围内")
+    item_outcomes = envelope.get("item_outcomes")
+    if not isinstance(item_outcomes, list):
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope.item_outcomes 必须是数组")
+    if result_status != "resumable" and not item_outcomes:
+        raise TaskRecordContractError("terminal batch TaskTerminalResult.envelope 必须包含 item_outcomes")
+    for index, outcome in enumerate(item_outcomes):
+        if not isinstance(outcome, Mapping):
+            raise TaskRecordContractError("batch item_outcomes 项必须是对象")
+        validate_batch_item_outcome_projection(outcome, index=index)
+    if result_status != "resumable" and result_status != _batch_result_status_from_items(item_outcomes):
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope.result_status 与 item_outcomes 不一致")
+    resume_token = envelope.get("resume_token")
+    if result_status == "resumable":
+        if not isinstance(resume_token, Mapping):
+            raise TaskRecordContractError("resumable batch TaskTerminalResult.envelope 必须包含 resume_token")
+        if require_string(resume_token.get("batch_id"), field="result.envelope.resume_token.batch_id") != batch_id:
+            raise TaskRecordContractError("batch resume_token.batch_id 与 batch_id 不一致")
+        next_item_index = coerce_int(
+            resume_token.get("next_item_index"),
+            field="result.envelope.resume_token.next_item_index",
+        )
+        if next_item_index != len(item_outcomes):
+            raise TaskRecordContractError("batch resume_token.next_item_index 必须指向已处理 item 前缀")
+    elif resume_token is not None:
+        raise TaskRecordContractError("terminal batch TaskTerminalResult.envelope 不得包含 resume_token")
+    dataset_sink_ref = require_optional_string(
+        envelope.get("dataset_sink_ref"),
+        field="result.envelope.dataset_sink_ref",
+    )
+    dataset_id = require_optional_string(envelope.get("dataset_id"), field="result.envelope.dataset_id")
+    if dataset_sink_ref is not None and dataset_id is None:
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope.dataset_sink_ref 必须绑定 dataset_id")
+    for outcome in item_outcomes:
+        dataset_record_ref = require_optional_string(
+            outcome.get("dataset_record_ref"),
+            field="result.envelope.item_outcomes.dataset_record_ref",
+        )
+        if dataset_sink_ref is not None and outcome.get("outcome_status") == "succeeded" and dataset_record_ref is None:
+            raise TaskRecordContractError("sink-bound batch succeeded item 必须包含 dataset_record_ref")
+        if dataset_sink_ref is None and dataset_record_ref is not None:
+            raise TaskRecordContractError("sinkless batch item 不得包含 dataset_record_ref")
+    audit_trace = envelope.get("audit_trace")
+    if not isinstance(audit_trace, Mapping):
+        raise TaskRecordContractError("batch TaskTerminalResult.envelope.audit_trace 必须是对象")
+    if audit_trace.get("batch_id") != batch_id:
+        raise TaskRecordContractError("batch audit_trace.batch_id 与 batch_id 不一致")
+    if "item_count" in audit_trace and coerce_int(
+        audit_trace.get("item_count"),
+        field="result.envelope.audit_trace.item_count",
+    ) != len(item_outcomes):
+        raise TaskRecordContractError("batch audit_trace.item_count 与 item_outcomes 不一致")
+
+
+def validate_batch_item_outcome_projection(outcome: Mapping[str, Any], *, index: int) -> None:
+    item_prefix = f"result.envelope.item_outcomes[{index}]"
+    require_string(outcome.get("item_id"), field=f"{item_prefix}.item_id")
+    operation = require_string(outcome.get("operation"), field=f"{item_prefix}.operation")
+    if operation not in BATCH_ITEM_OPERATIONS:
+        raise TaskRecordContractError("batch item_outcome.operation 不在允许值范围内")
+    require_string(outcome.get("adapter_key"), field=f"{item_prefix}.adapter_key")
+    require_string(outcome.get("target_ref"), field=f"{item_prefix}.target_ref")
+    outcome_status = require_string(outcome.get("outcome_status"), field=f"{item_prefix}.outcome_status")
+    if outcome_status not in BATCH_ITEM_STATUSES:
+        raise TaskRecordContractError("batch item_outcome.outcome_status 不在允许值范围内")
+    result_envelope = outcome.get("result_envelope")
+    error_envelope = outcome.get("error_envelope")
+    if outcome_status == "succeeded":
+        if not isinstance(result_envelope, Mapping):
+            raise TaskRecordContractError("succeeded batch item_outcome 必须包含 result_envelope")
+        validate_batch_item_result_projection(result_envelope, operation=operation, adapter_key=outcome["adapter_key"])
+        if error_envelope is not None:
+            raise TaskRecordContractError("succeeded batch item_outcome 不得包含 error_envelope")
+    elif outcome_status == "failed":
+        if not isinstance(error_envelope, Mapping):
+            raise TaskRecordContractError("failed batch item_outcome 必须包含 error_envelope")
+        if result_envelope is not None:
+            if not isinstance(result_envelope, Mapping):
+                raise TaskRecordContractError("failed batch item_outcome.result_envelope 必须是对象")
+            validate_batch_item_result_projection(
+                result_envelope,
+                operation=operation,
+                adapter_key=outcome["adapter_key"],
+            )
+    elif result_envelope is not None or error_envelope is not None or outcome.get("dataset_record_ref") is not None:
+        raise TaskRecordContractError("duplicate_skipped batch item_outcome 不得包含 result/error/dataset refs")
+    if (
+        "source_trace" in outcome
+        and outcome["source_trace"] is not None
+        and not isinstance(outcome["source_trace"], Mapping)
+    ):
+        raise TaskRecordContractError("batch item_outcome.source_trace 必须是对象或 null")
+    audit = outcome.get("audit")
+    if not isinstance(audit, Mapping):
+        raise TaskRecordContractError("batch item_outcome.audit 必须是对象")
+
+
+def validate_batch_item_result_projection(
+    result_envelope: Mapping[str, Any],
+    *,
+    operation: str,
+    adapter_key: str,
+) -> None:
+    if result_envelope.get("status") != "success":
+        raise TaskRecordContractError("batch item result_envelope.status 必须为 success")
+    if result_envelope.get("capability") != operation:
+        raise TaskRecordContractError("batch item result_envelope.capability 与 operation 不一致")
+    if result_envelope.get("adapter_key") != adapter_key:
+        raise TaskRecordContractError("batch item result_envelope.adapter_key 与 item adapter_key 不一致")
+
+
+def _batch_result_status_from_items(item_outcomes: list[Any]) -> str:
+    non_duplicate = [
+        outcome
+        for outcome in item_outcomes
+        if isinstance(outcome, Mapping) and outcome.get("outcome_status") != "duplicate_skipped"
+    ]
+    succeeded = any(outcome.get("outcome_status") == "succeeded" for outcome in non_duplicate)
+    failed = any(outcome.get("outcome_status") == "failed" for outcome in non_duplicate)
+    if succeeded and failed:
+        return "partial_success"
+    if failed:
+        return "all_failed"
+    return "complete"
 
 
 def validate_terminal_envelope_observability_contract(record: TaskRecord, envelope: Mapping[str, Any]) -> None:

--- a/tests/runtime/test_cli_http_same_path.py
+++ b/tests/runtime/test_cli_http_same_path.py
@@ -272,7 +272,6 @@ def make_batch_success_envelope(task_id: str, batch_id: str = "batch-001") -> di
         "audit_trace": {
             "batch_id": batch_id,
             "started_at": "2026-04-24T00:00:00Z",
-            "finished_at": "2026-04-24T00:00:02Z",
             "finished": True,
             "item_count": 1,
             "item_trace_refs": [f"audit:batch:{batch_id}:item-1"],

--- a/tests/runtime/test_cli_http_same_path.py
+++ b/tests/runtime/test_cli_http_same_path.py
@@ -205,6 +205,82 @@ def make_failed_envelope(
     }
 
 
+def make_batch_request_snapshot(batch_id: str = "batch-001") -> TaskRequestSnapshot:
+    return TaskRequestSnapshot(
+        adapter_key="core",
+        capability="batch_execution",
+        target_type="operation_batch",
+        target_value=batch_id,
+        collection_mode="batch",
+    )
+
+
+def make_batch_success_envelope(task_id: str, batch_id: str = "batch-001") -> dict[str, object]:
+    return {
+        "task_id": task_id,
+        "adapter_key": "core",
+        "capability": "batch_execution",
+        "status": "success",
+        "task_record_ref": f"task_record:{task_id}",
+        "batch_id": batch_id,
+        "operation": "batch_execution",
+        "result_status": "complete",
+        "dataset_sink_ref": "sink:reference",
+        "dataset_id": f"dataset:{batch_id}",
+        "item_outcomes": [
+            {
+                "item_id": "item-1",
+                "operation": "content_search_by_keyword",
+                "adapter_key": TEST_ADAPTER_KEY,
+                "target_ref": "deep learning",
+                "outcome_status": "succeeded",
+                "result_envelope": {
+                    "task_id": "batch-item-1",
+                    "adapter_key": TEST_ADAPTER_KEY,
+                    "capability": "content_search_by_keyword",
+                    "status": "success",
+                    "operation": "content_search_by_keyword",
+                    "target": {
+                        "operation": "content_search_by_keyword",
+                        "target_type": "keyword",
+                        "target_ref": "deep learning",
+                    },
+                    "items": [],
+                    "has_more": False,
+                    "next_continuation": None,
+                    "result_status": "complete",
+                    "error_classification": "platform_failed",
+                    "raw_payload_ref": "raw://page-1",
+                    "source_trace": {
+                        "adapter_key": TEST_ADAPTER_KEY,
+                        "provider_path": "provider://sanitized",
+                        "fetched_at": "2026-04-24T00:00:01Z",
+                        "evidence_alias": "alias://batch-item-1",
+                    },
+                    "audit": {},
+                },
+                "dataset_record_ref": f"dataset:{batch_id}:item-1",
+                "source_trace": {
+                    "adapter_key": TEST_ADAPTER_KEY,
+                    "provider_path": "provider://sanitized",
+                    "fetched_at": "2026-04-24T00:00:01Z",
+                    "evidence_alias": "alias://batch-item-1",
+                },
+                "audit": {"reason": "dataset_record_written"},
+            }
+        ],
+        "audit_trace": {
+            "batch_id": batch_id,
+            "started_at": "2026-04-24T00:00:00Z",
+            "finished_at": "2026-04-24T00:00:02Z",
+            "finished": True,
+            "item_count": 1,
+            "item_trace_refs": [f"audit:batch:{batch_id}:item-1"],
+            "evidence_refs": ["evidence:batch:item"],
+        },
+    }
+
+
 class CliHttpSamePathTests(ResourceStoreEnvMixin, unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -563,6 +639,36 @@ class CliHttpSamePathTests(ResourceStoreEnvMixin, unittest.TestCase):
                 self.assertEqual(result_response.body["status"], "failed")
                 self.assertEqual(result_response.body["error"]["category"], "invalid_input")
                 self.assertEqual(result_response.body["error"]["code"], "result_not_ready")
+
+    def test_batch_task_record_query_and_http_result_share_public_carrier(self) -> None:
+        task_id = "task-batch-query-same-path"
+        accepted = create_task_record(
+            task_id,
+            make_batch_request_snapshot("batch-001"),
+            occurred_at="2026-04-24T00:00:00Z",
+        )
+        running = start_task_record(accepted, occurred_at="2026-04-24T00:00:01Z")
+        terminal = finish_task_record(
+            running,
+            make_batch_success_envelope(task_id, "batch-001"),
+            occurred_at="2026-04-24T00:00:02Z",
+        )
+        self.write_record_lifecycle(terminal)
+
+        query_exit_code, query_payload, query_stream = self.query_cli_task(task_id)
+        status_response = self.make_http_service().status(task_id)
+        result_response = self.make_http_service().result(task_id)
+
+        self.assertEqual(query_exit_code, 0)
+        self.assertEqual(query_stream, "stdout")
+        self.assertEqual(status_response.status_code, 200)
+        self.assertEqual(status_response.body, query_payload)
+        self.assertEqual(result_response.status_code, 200)
+        self.assertEqual(result_response.body, query_payload["result"]["envelope"])
+        self.assertEqual(result_response.body["operation"], "batch_execution")
+        self.assertEqual(result_response.body["dataset_id"], "dataset:batch-001")
+        self.assertEqual(result_response.body["item_outcomes"][0]["dataset_record_ref"], "dataset:batch-001:item-1")
+        self.assertNotIn("request_cursor_context", repr(result_response.body))
 
     def test_runtime_result_refs_are_preserved_across_cli_query_and_http_result(self) -> None:
         task_id = "task-observability-same-path"

--- a/tests/runtime/test_cli_http_same_path.py
+++ b/tests/runtime/test_cli_http_same_path.py
@@ -280,6 +280,102 @@ def make_batch_success_envelope(task_id: str, batch_id: str = "batch-001") -> di
     }
 
 
+def make_cursor_comment_batch_success_envelope(
+    task_id: str,
+    batch_id: str = "batch-comments",
+) -> dict[str, object]:
+    return {
+        "task_id": task_id,
+        "adapter_key": "core",
+        "capability": "batch_execution",
+        "status": "success",
+        "task_record_ref": f"task_record:{task_id}",
+        "batch_id": batch_id,
+        "operation": "batch_execution",
+        "result_status": "complete",
+        "dataset_sink_ref": "sink:reference",
+        "dataset_id": f"dataset:{batch_id}",
+        "item_outcomes": [
+            {
+                "item_id": "comments",
+                "operation": "comment_collection",
+                "adapter_key": TEST_ADAPTER_KEY,
+                "target_ref": "content:alpha",
+                "outcome_status": "succeeded",
+                "result_envelope": {
+                    "task_id": "batch-comment-item-1",
+                    "adapter_key": TEST_ADAPTER_KEY,
+                    "capability": "comment_collection",
+                    "status": "success",
+                    "operation": "comment_collection",
+                    "target": {
+                        "operation": "comment_collection",
+                        "target_type": "content",
+                        "target_ref": "content:alpha",
+                    },
+                    "items": [
+                        {
+                            "item_type": "comment",
+                            "dedup_key": "comment:reply-1",
+                            "source_id": "reply-1",
+                            "source_ref": "comment://reply-1",
+                            "normalized": {
+                                "source_platform": TEST_ADAPTER_KEY,
+                                "source_type": "comment",
+                                "source_id": "reply-1",
+                                "canonical_ref": "comment:reply-1",
+                                "body_text_hint": "reply",
+                                "author_ref": "creator-1",
+                                "published_at": "2026-04-24T00:00:01Z",
+                                "root_comment_ref": "comment:root-1",
+                                "parent_comment_ref": "comment:root-1",
+                                "target_comment_ref": "comment:root-1",
+                            },
+                            "visibility_status": "visible",
+                            "reply_cursor": None,
+                            "raw_payload_ref": "raw://comment/reply-1",
+                            "source_trace": {
+                                "adapter_key": TEST_ADAPTER_KEY,
+                                "provider_path": "provider://sanitized",
+                                "fetched_at": "2026-04-24T00:00:01Z",
+                                "evidence_alias": "alias://comment-reply-1",
+                            },
+                        }
+                    ],
+                    "has_more": False,
+                    "next_continuation": None,
+                    "result_status": "partial_result",
+                    "error_classification": "parse_failed",
+                    "raw_payload_ref": "raw://comment/page-1",
+                    "source_trace": {
+                        "adapter_key": TEST_ADAPTER_KEY,
+                        "provider_path": "provider://sanitized",
+                        "fetched_at": "2026-04-24T00:00:01Z",
+                        "evidence_alias": "alias://comment-page-1",
+                    },
+                    "audit": {"page_index": 1},
+                },
+                "dataset_record_ref": f"dataset:{batch_id}:comments",
+                "source_trace": {
+                    "adapter_key": TEST_ADAPTER_KEY,
+                    "provider_path": "provider://sanitized",
+                    "fetched_at": "2026-04-24T00:00:01Z",
+                    "evidence_alias": "alias://batch-comment-item-1",
+                },
+                "audit": {"reason": "dataset_record_written"},
+            }
+        ],
+        "audit_trace": {
+            "batch_id": batch_id,
+            "started_at": "2026-04-24T00:00:00Z",
+            "finished": True,
+            "item_count": 1,
+            "item_trace_refs": [f"audit:batch:{batch_id}:comments"],
+            "evidence_refs": ["evidence:batch:item"],
+        },
+    }
+
+
 class CliHttpSamePathTests(ResourceStoreEnvMixin, unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -667,6 +763,31 @@ class CliHttpSamePathTests(ResourceStoreEnvMixin, unittest.TestCase):
         self.assertEqual(result_response.body["operation"], "batch_execution")
         self.assertEqual(result_response.body["dataset_id"], "dataset:batch-001")
         self.assertEqual(result_response.body["item_outcomes"][0]["dataset_record_ref"], "dataset:batch-001:item-1")
+        self.assertNotIn("request_cursor_context", repr(result_response.body))
+
+    def test_cursor_comment_batch_query_and_http_result_share_public_carrier(self) -> None:
+        task_id = "task-batch-comment-query-same-path"
+        accepted = create_task_record(
+            task_id,
+            make_batch_request_snapshot("batch-comments"),
+            occurred_at="2026-04-24T00:00:00Z",
+        )
+        running = start_task_record(accepted, occurred_at="2026-04-24T00:00:01Z")
+        terminal = finish_task_record(
+            running,
+            make_cursor_comment_batch_success_envelope(task_id, "batch-comments"),
+            occurred_at="2026-04-24T00:00:02Z",
+        )
+        self.write_record_lifecycle(terminal)
+
+        query_exit_code, query_payload, query_stream = self.query_cli_task(task_id)
+        result_response = self.make_http_service().result(task_id)
+
+        self.assertEqual(query_exit_code, 0)
+        self.assertEqual(query_stream, "stdout")
+        self.assertEqual(result_response.status_code, 200)
+        self.assertEqual(result_response.body, query_payload["result"]["envelope"])
+        self.assertEqual(result_response.body["item_outcomes"][0]["operation"], "comment_collection")
         self.assertNotIn("request_cursor_context", repr(result_response.body))
 
     def test_runtime_result_refs_are_preserved_across_cli_query_and_http_result(self) -> None:

--- a/tests/runtime/test_operation_taxonomy_consumers.py
+++ b/tests/runtime/test_operation_taxonomy_consumers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import unittest
+from unittest import mock
 
 from syvert.adapter_capability_requirement import (
     ADAPTER_REQUIREMENT_STATUS_INVALID,
@@ -13,7 +15,14 @@ from syvert.adapter_provider_compatibility_decision import (
     COMPATIBILITY_DECISION_STATUS_INVALID_CONTRACT,
     decide_adapter_provider_compatibility,
 )
-from syvert.batch_dataset import BatchDatasetContractError, BatchTargetItem, validate_batch_target_item
+from syvert.batch_dataset import (
+    BatchDatasetContractError,
+    BatchRequest,
+    BatchTargetItem,
+    ReferenceDatasetSink,
+    execute_batch_request,
+    validate_batch_target_item,
+)
 from syvert.operation_taxonomy import stable_operation_entry
 from syvert.provider_capability_offer import (
     APPROVED_CAPABILITY_OFFER,
@@ -24,6 +33,28 @@ from syvert.provider_capability_offer import (
 from tests.runtime.adapter_capability_requirement_fixtures import copy_requirement
 from tests.runtime.adapter_provider_compatibility_decision_fixtures import copy_decision_input
 from tests.runtime.provider_capability_offer_fixtures import copy_offer
+from tests.runtime.test_task_record import TEST_ADAPTER_KEY, make_comment_collection_result
+
+
+class CursorCommentAdapter:
+    supported_capabilities = frozenset({"comment_collection"})
+    supported_targets = frozenset({"content"})
+    supported_collection_modes = frozenset({"paginated"})
+
+    def __init__(self) -> None:
+        self.request_cursors = []
+
+    def execute(self, request):
+        self.request_cursors.append(request.input.comment_request_cursor)
+        payload = make_comment_collection_result(target_ref=request.input.content_ref or "")
+        payload["items"][0]["dedup_key"] = "comment:reply-1"
+        payload["items"][0]["source_id"] = "reply-1"
+        payload["items"][0]["source_ref"] = "comment://reply-1"
+        payload["items"][0]["normalized"]["source_id"] = "reply-1"
+        payload["items"][0]["normalized"]["canonical_ref"] = "comment:reply-1"
+        payload["items"][0]["normalized"]["parent_comment_ref"] = "comment:root-1"
+        payload["items"][0]["normalized"]["target_comment_ref"] = "comment:root-1"
+        return payload
 
 
 class OperationTaxonomyConsumerMigrationTests(unittest.TestCase):
@@ -169,6 +200,52 @@ class OperationTaxonomyConsumerMigrationTests(unittest.TestCase):
 
                 self.assertTrue(stable.runtime_delivery)
                 self.assertEqual(validate_batch_target_item(item), item)
+
+    def test_batch_runtime_consumes_cursor_comment_runtime_slice(self) -> None:
+        stable = stable_operation_entry(
+            operation="comment_collection",
+            target_type="content",
+            collection_mode="paginated",
+        )
+        cursor = {
+            "reply_cursor": {
+                "reply_cursor_token": "reply-cursor-1",
+                "reply_cursor_family": "opaque",
+                "resume_target_ref": "content:alpha",
+                "resume_comment_ref": "comment:root-1",
+                "issued_at": "2026-05-09T10:00:00Z",
+            }
+        }
+        item = BatchTargetItem(
+            item_id="comments",
+            operation=stable.operation,
+            adapter_key=TEST_ADAPTER_KEY,
+            target_type=stable.target_type,
+            target_ref="content:alpha",
+            dedup_key="dedup:comments",
+            request_cursor=cursor,
+        )
+        adapter = CursorCommentAdapter()
+
+        with mock.patch.dict("syvert.runtime.RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE", {}, clear=True):
+            result = execute_batch_request(
+                BatchRequest(
+                    batch_id="batch-comments",
+                    target_set=(item,),
+                    dataset_sink_ref="sink:reference",
+                    audit_context={"evidence_ref": "evidence:batch"},
+                ),
+                adapters={TEST_ADAPTER_KEY: adapter},
+                dataset_sink=ReferenceDatasetSink(),
+                task_id_factory=lambda: "task-comment-batch",
+                now_factory=lambda: datetime(2026, 5, 16, 10, 0, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(adapter.request_cursors, [cursor])
+        self.assertEqual(result.result_status, "complete")
+        self.assertEqual(result.item_outcomes[0].operation, "comment_collection")
+        self.assertEqual(result.item_outcomes[0].request_cursor_context, cursor)
+        self.assertEqual(result.item_outcomes[0].dataset_record_ref, "dataset:batch-comments:comments")
 
     def test_batch_target_item_rejects_provider_compatibility_as_operation(self) -> None:
         with self.assertRaises(BatchDatasetContractError):

--- a/tests/runtime/test_operation_taxonomy_consumers.py
+++ b/tests/runtime/test_operation_taxonomy_consumers.py
@@ -13,6 +13,7 @@ from syvert.adapter_provider_compatibility_decision import (
     COMPATIBILITY_DECISION_STATUS_INVALID_CONTRACT,
     decide_adapter_provider_compatibility,
 )
+from syvert.batch_dataset import BatchDatasetContractError, BatchTargetItem, validate_batch_target_item
 from syvert.operation_taxonomy import stable_operation_entry
 from syvert.provider_capability_offer import (
     APPROVED_CAPABILITY_OFFER,
@@ -135,6 +136,79 @@ class OperationTaxonomyConsumerMigrationTests(unittest.TestCase):
         self.assertEqual(decision.decision_status, "matched")
         self.assertEqual(decision.capability, "comment_collection")
         self.assertEqual(decision.execution_slice.operation, "comment_collection")
+
+    def test_batch_target_items_consume_stable_read_side_runtime_slices(self) -> None:
+        cases = (
+            ("content_search_by_keyword", "keyword", "deep learning"),
+            ("content_list_by_creator", "creator", "creator-001"),
+            ("comment_collection", "content", "content-001"),
+            ("creator_profile_by_id", "creator", "creator-001"),
+            ("media_asset_fetch_by_ref", "media_ref", "media:asset-001"),
+        )
+
+        for operation, target_type, target_ref in cases:
+            with self.subTest(operation=operation):
+                collection_mode = (
+                    "paginated"
+                    if operation in {"content_search_by_keyword", "content_list_by_creator", "comment_collection"}
+                    else "direct"
+                )
+                stable = stable_operation_entry(
+                    operation=operation,
+                    target_type=target_type,
+                    collection_mode=collection_mode,
+                )
+                item = BatchTargetItem(
+                    item_id=f"item-{operation}",
+                    operation=operation,
+                    adapter_key="xhs",
+                    target_type=target_type,
+                    target_ref=target_ref,
+                    dedup_key=f"dedup:{operation}",
+                )
+
+                self.assertTrue(stable.runtime_delivery)
+                self.assertEqual(validate_batch_target_item(item), item)
+
+    def test_batch_target_item_rejects_provider_compatibility_as_operation(self) -> None:
+        with self.assertRaises(BatchDatasetContractError):
+            validate_batch_target_item(
+                BatchTargetItem(
+                    item_id="item-provider",
+                    operation="provider_compatibility_decision",
+                    adapter_key="xhs",
+                    target_type="content",
+                    target_ref="content-001",
+                    dedup_key="dedup:provider",
+                )
+            )
+
+    def test_compatibility_consumers_do_not_accept_dataset_normalized_payload(self) -> None:
+        private_dataset_payload = {
+            "dataset_record": {
+                "normalized_payload": {
+                    "private_creator": "creator-private",
+                    "provider_route": "provider:fallback:marketplace",
+                }
+            }
+        }
+
+        requirement = copy_requirement()
+        requirement.update(private_dataset_payload)
+        self.assertEqual(
+            validate_adapter_capability_requirement(requirement).status,
+            ADAPTER_REQUIREMENT_STATUS_INVALID,
+        )
+
+        offer = copy_offer()
+        offer.update(private_dataset_payload)
+        self.assertEqual(validate_provider_capability_offer(offer).status, PROVIDER_OFFER_STATUS_INVALID)
+
+        decision_input = copy_decision_input()
+        decision_input.update(private_dataset_payload)
+        decision = decide_adapter_provider_compatibility(decision_input)
+        self.assertEqual(decision.decision_status, COMPATIBILITY_DECISION_STATUS_INVALID_CONTRACT)
+        self.assertEqual(decision.matched_profiles, ())
 
     def test_adapter_requirement_rejects_proposed_taxonomy_candidate(self) -> None:
         requirement = copy_requirement()

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -485,7 +485,6 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
                 "audit_trace": {
                     "batch_id": "batch-001",
                     "started_at": "2026-05-16T10:00:00Z",
-                    "finished_at": "2026-05-16T10:00:01Z",
                     "finished": True,
                     "item_count": 1,
                     "item_trace_refs": ["audit:batch:batch-001:item-1"],
@@ -539,6 +538,38 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
     def test_rejects_batch_execution_top_level_raw_payload(self) -> None:
         payload = task_record_to_dict(self.make_batch_record())
         payload["result"]["envelope"]["raw"] = {"provider_batch": True}
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_failed_batch_item_with_dataset_record_ref(self) -> None:
+        payload = task_record_to_dict(self.make_batch_record())
+        item = payload["result"]["envelope"]["item_outcomes"][0]
+        item["outcome_status"] = "failed"
+        item.pop("result_envelope")
+        item["error_envelope"] = {
+            "category": "runtime_contract",
+            "code": "dataset_write_failed",
+            "message": "dataset write failed",
+            "details": {"reason": "sink_unavailable"},
+        }
+        payload["result"]["envelope"]["result_status"] = "all_failed"
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_batch_item_result_envelope_target_drift(self) -> None:
+        payload = task_record_to_dict(self.make_batch_record())
+        payload["result"]["envelope"]["item_outcomes"][0]["result_envelope"]["target"]["target_ref"] = "other-query"
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_batch_item_result_envelope_private_source_trace(self) -> None:
+        payload = task_record_to_dict(self.make_batch_record())
+        payload["result"]["envelope"]["item_outcomes"][0]["result_envelope"]["source_trace"][
+            "provider_path"
+        ] = "cache/state.json"
 
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(payload)

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -494,6 +494,99 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
             occurred_at="2026-05-16T10:00:02Z",
         )
 
+    def make_record_from_batch_envelope(self, *, task_id: str, batch_id: str, envelope: dict[str, object]):
+        record = start_task_record(
+            create_task_record(
+                task_id,
+                TaskRequestSnapshot(
+                    adapter_key="core",
+                    capability="batch_execution",
+                    target_type="operation_batch",
+                    target_value=batch_id,
+                    collection_mode="batch",
+                ),
+                occurred_at="2026-05-16T10:00:00Z",
+            ),
+            occurred_at="2026-05-16T10:00:01Z",
+        )
+        return finish_task_record(record, envelope, occurred_at="2026-05-16T10:00:02Z")
+
+    def make_cursor_sensitive_batch_envelope(
+        self,
+        *,
+        task_id: str = "task-record-batch-comments",
+        batch_id: str = "batch-comments",
+    ) -> dict[str, object]:
+        from syvert.batch_dataset import BatchItemOutcome, BatchResultEnvelope, batch_result_envelope_to_dict
+
+        cursor = {
+            "reply_cursor": {
+                "reply_cursor_token": "reply-cursor-1",
+                "reply_cursor_family": "opaque",
+                "resume_target_ref": "content:alpha",
+                "resume_comment_ref": "comment:root-1",
+                "issued_at": "2026-05-09T10:00:00Z",
+            }
+        }
+        result_envelope = {
+            "task_id": "batch-comment-item-1",
+            "adapter_key": TEST_ADAPTER_KEY,
+            "capability": "comment_collection",
+            "status": "success",
+            **make_comment_collection_result(target_ref="content:alpha"),
+        }
+        result_envelope["items"][0]["source_id"] = "reply-1"
+        result_envelope["items"][0]["source_ref"] = "comment://reply-1"
+        result_envelope["items"][0]["dedup_key"] = "comment:reply-1"
+        result_envelope["items"][0]["normalized"]["source_id"] = "reply-1"
+        result_envelope["items"][0]["normalized"]["canonical_ref"] = "comment:reply-1"
+        result_envelope["items"][0]["normalized"]["parent_comment_ref"] = "comment:root-1"
+        result_envelope["items"][0]["normalized"]["target_comment_ref"] = "comment:root-1"
+        batch_payload = batch_result_envelope_to_dict(
+            BatchResultEnvelope(
+                batch_id=batch_id,
+                operation="batch_execution",
+                result_status="complete",
+                item_outcomes=(
+                    BatchItemOutcome(
+                        item_id="comments",
+                        operation="comment_collection",
+                        adapter_key=TEST_ADAPTER_KEY,
+                        target_ref="content:alpha",
+                        outcome_status="succeeded",
+                        result_envelope=result_envelope,
+                        dataset_record_ref=f"dataset:{batch_id}:comments",
+                        source_trace={
+                            "adapter_key": TEST_ADAPTER_KEY,
+                            "provider_path": "provider://sanitized",
+                            "fetched_at": "2026-05-16T10:00:01Z",
+                            "evidence_alias": "alias://batch-comment-item-1",
+                        },
+                        audit={"reason": "dataset_record_written"},
+                        request_cursor_context=cursor,
+                    ),
+                ),
+                dataset_sink_ref="sink:reference",
+                dataset_id=f"dataset:{batch_id}",
+                audit_trace={
+                    "batch_id": batch_id,
+                    "started_at": "2026-05-16T10:00:00Z",
+                    "finished": True,
+                    "item_count": 1,
+                    "item_trace_refs": [f"audit:batch:{batch_id}:comments"],
+                    "evidence_refs": ["evidence:batch:item"],
+                },
+            )
+        )
+        return {
+            "task_id": task_id,
+            "adapter_key": "core",
+            "capability": "batch_execution",
+            "status": "success",
+            "task_record_ref": f"task_record:{task_id}",
+            **batch_payload,
+        }
+
     def test_round_trips_success_record(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
@@ -528,101 +621,146 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(restored.result.envelope["item_outcomes"][0]["dataset_record_ref"], "dataset:batch-001:item-1")
         self.assertNotIn("request_cursor_context", repr(payload))
 
-    def test_round_trips_serialized_cursor_sensitive_batch_result(self) -> None:
-        from syvert.batch_dataset import BatchItemOutcome, BatchResultEnvelope, batch_result_envelope_to_dict
+    def test_round_trips_sinkless_and_non_complete_batch_boundaries(self) -> None:
+        complete_payload = task_record_to_dict(self.make_batch_record())["result"]["envelope"]
 
-        cursor = {
-            "reply_cursor": {
-                "reply_cursor_token": "reply-cursor-1",
-                "reply_cursor_family": "opaque",
-                "resume_target_ref": "content:alpha",
-                "resume_comment_ref": "comment:root-1",
-                "issued_at": "2026-05-09T10:00:00Z",
-            }
-        }
-        result_envelope = {
-            "task_id": "batch-comment-item-1",
+        sinkless = json.loads(json.dumps(complete_payload))
+        sinkless["task_id"] = "task-record-batch-sinkless"
+        sinkless["task_record_ref"] = "task_record:task-record-batch-sinkless"
+        sinkless["batch_id"] = "batch-sinkless"
+        sinkless["dataset_sink_ref"] = None
+        sinkless["dataset_id"] = None
+        sinkless["item_outcomes"][0].pop("dataset_record_ref")
+        sinkless["audit_trace"]["batch_id"] = "batch-sinkless"
+        sinkless["audit_trace"]["item_trace_refs"] = ["audit:batch:batch-sinkless:item-1"]
+
+        failed_item = {
+            "item_id": "item-2",
+            "operation": "content_search_by_keyword",
             "adapter_key": TEST_ADAPTER_KEY,
-            "capability": "comment_collection",
-            "status": "success",
-            **make_comment_collection_result(target_ref="content:alpha"),
+            "target_ref": "graph learning",
+            "outcome_status": "failed",
+            "error_envelope": {
+                "category": "runtime_contract",
+                "code": "adapter_failed",
+                "message": "adapter failed",
+                "details": {"reason": "platform_unavailable"},
+            },
+            "audit": {"reason": "adapter_failed"},
         }
-        result_envelope["items"][0]["source_id"] = "reply-1"
-        result_envelope["items"][0]["source_ref"] = "comment://reply-1"
-        result_envelope["items"][0]["normalized"]["source_id"] = "reply-1"
-        result_envelope["items"][0]["normalized"]["canonical_ref"] = "comment:reply-1"
-        result_envelope["items"][0]["normalized"]["parent_comment_ref"] = "comment:root-1"
-        result_envelope["items"][0]["normalized"]["target_comment_ref"] = "comment:root-1"
-        batch_payload = batch_result_envelope_to_dict(
-            BatchResultEnvelope(
-                batch_id="batch-comments",
-                operation="batch_execution",
-                result_status="complete",
-                item_outcomes=(
-                    BatchItemOutcome(
-                        item_id="comments",
-                        operation="comment_collection",
-                        adapter_key=TEST_ADAPTER_KEY,
-                        target_ref="content:alpha",
-                        outcome_status="succeeded",
-                        result_envelope=result_envelope,
-                        dataset_record_ref="dataset:batch-comments:comments",
-                        source_trace={
-                            "adapter_key": TEST_ADAPTER_KEY,
-                            "provider_path": "provider://sanitized",
-                            "fetched_at": "2026-05-16T10:00:01Z",
-                            "evidence_alias": "alias://batch-comment-item-1",
-                        },
-                        audit={"reason": "dataset_record_written"},
-                        request_cursor_context=cursor,
-                    ),
-                ),
-                dataset_sink_ref="sink:reference",
-                dataset_id="dataset:batch-comments",
-                audit_trace={
-                    "batch_id": "batch-comments",
-                    "started_at": "2026-05-16T10:00:00Z",
-                    "finished": True,
-                    "item_count": 1,
-                    "item_trace_refs": ["audit:batch:batch-comments:comments"],
-                    "evidence_refs": ["evidence:batch:item"],
-                },
-            )
+        partial = json.loads(json.dumps(complete_payload))
+        partial["task_id"] = "task-record-batch-partial"
+        partial["task_record_ref"] = "task_record:task-record-batch-partial"
+        partial["batch_id"] = "batch-partial"
+        partial["dataset_id"] = "dataset:batch-partial"
+        partial["result_status"] = "partial_success"
+        partial["item_outcomes"].append(failed_item)
+        partial["audit_trace"]["batch_id"] = "batch-partial"
+        partial["audit_trace"]["item_count"] = 2
+        partial["audit_trace"]["item_trace_refs"] = [
+            "audit:batch:batch-partial:item-1",
+            "audit:batch:batch-partial:item-2",
+        ]
+
+        all_failed = json.loads(json.dumps(partial))
+        all_failed["task_id"] = "task-record-batch-all-failed"
+        all_failed["task_record_ref"] = "task_record:task-record-batch-all-failed"
+        all_failed["batch_id"] = "batch-all-failed"
+        all_failed["dataset_id"] = "dataset:batch-all-failed"
+        all_failed["result_status"] = "all_failed"
+        all_failed["item_outcomes"] = [failed_item]
+        all_failed["audit_trace"]["batch_id"] = "batch-all-failed"
+        all_failed["audit_trace"]["item_count"] = 1
+        all_failed["audit_trace"]["item_trace_refs"] = ["audit:batch:batch-all-failed:item-2"]
+
+        resumable = json.loads(json.dumps(complete_payload))
+        resumable["task_id"] = "task-record-batch-resumable"
+        resumable["task_record_ref"] = "task_record:task-record-batch-resumable"
+        resumable["batch_id"] = "batch-resumable"
+        resumable["dataset_id"] = "dataset:batch-resumable"
+        resumable["result_status"] = "resumable"
+        resumable["resume_token"] = {
+            "resume_token": "resume:batch-resumable:1",
+            "batch_id": "batch-resumable",
+            "target_set_hash": "sha256:batch-resumable",
+            "next_item_index": 1,
+            "issued_at": "2026-05-16T10:00:02Z",
+            "dataset_sink_ref": "sink:reference",
+            "dataset_id": "dataset:batch-resumable",
+        }
+        resumable["audit_trace"]["batch_id"] = "batch-resumable"
+        resumable["audit_trace"]["finished"] = False
+        resumable["audit_trace"]["item_trace_refs"] = ["audit:batch:batch-resumable:item-1"]
+        resumable["audit_trace"]["stop_reason"] = "interrupted"
+
+        cases = (
+            ("sinkless", sinkless, "batch-sinkless"),
+            ("partial", partial, "batch-partial"),
+            ("all_failed", all_failed, "batch-all-failed"),
+            ("resumable", resumable, "batch-resumable"),
         )
-        record = start_task_record(
-            create_task_record(
-                "task-record-batch-comments",
-                TaskRequestSnapshot(
-                    adapter_key="core",
-                    capability="batch_execution",
-                    target_type="operation_batch",
-                    target_value="batch-comments",
-                    collection_mode="batch",
-                ),
-                occurred_at="2026-05-16T10:00:00Z",
-            ),
-            occurred_at="2026-05-16T10:00:01Z",
-        )
+        for label, envelope, batch_id in cases:
+            with self.subTest(label=label):
+                restored = task_record_from_dict(
+                    task_record_to_dict(
+                        self.make_record_from_batch_envelope(
+                            task_id=str(envelope["task_id"]),
+                            batch_id=batch_id,
+                            envelope=envelope,
+                        )
+                    )
+                )
+
+                self.assertEqual(restored.result.envelope["batch_id"], batch_id)
+                self.assertEqual(restored.result.envelope["result_status"], envelope["result_status"])
+
+    def test_round_trips_serialized_cursor_sensitive_batch_result(self) -> None:
+        envelope = self.make_cursor_sensitive_batch_envelope()
 
         restored = task_record_from_dict(
             task_record_to_dict(
-                finish_task_record(
-                    record,
-                    {
-                        "task_id": "task-record-batch-comments",
-                        "adapter_key": "core",
-                        "capability": "batch_execution",
-                        "status": "success",
-                        "task_record_ref": "task_record:task-record-batch-comments",
-                        **batch_payload,
-                    },
-                    occurred_at="2026-05-16T10:00:02Z",
+                self.make_record_from_batch_envelope(
+                    task_id="task-record-batch-comments",
+                    batch_id="batch-comments",
+                    envelope=envelope,
                 )
             )
         )
 
         self.assertEqual(restored.result.envelope["batch_id"], "batch-comments")
         self.assertNotIn("request_cursor_context", repr(restored.result.envelope))
+
+    def test_rejects_cursor_sensitive_batch_result_target_drift(self) -> None:
+        envelope = self.make_cursor_sensitive_batch_envelope()
+        envelope["item_outcomes"][0]["result_envelope"]["target"]["target_ref"] = "content:other"
+
+        with self.assertRaises(TaskRecordContractError):
+            self.make_record_from_batch_envelope(
+                task_id="task-record-batch-comments",
+                batch_id="batch-comments",
+                envelope=envelope,
+            )
+
+    def test_rejects_cursor_sensitive_batch_result_ambiguous_public_thread(self) -> None:
+        envelope = self.make_cursor_sensitive_batch_envelope()
+        result_envelope = envelope["item_outcomes"][0]["result_envelope"]
+        second_item = json.loads(json.dumps(result_envelope["items"][0]))
+        second_item["dedup_key"] = "comment:reply-2"
+        second_item["source_id"] = "reply-2"
+        second_item["source_ref"] = "comment://reply-2"
+        second_item["normalized"]["source_id"] = "reply-2"
+        second_item["normalized"]["canonical_ref"] = "comment:reply-2"
+        second_item["normalized"]["root_comment_ref"] = "comment:other-root"
+        second_item["normalized"]["parent_comment_ref"] = "comment:other-root"
+        second_item["normalized"]["target_comment_ref"] = "comment:other-root"
+        result_envelope["items"].append(second_item)
+
+        with self.assertRaises(TaskRecordContractError):
+            self.make_record_from_batch_envelope(
+                task_id="task-record-batch-comments",
+                batch_id="batch-comments",
+                envelope=envelope,
+            )
 
     def test_rejects_batch_execution_result_status_drift(self) -> None:
         payload = task_record_to_dict(self.make_batch_record())

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -429,6 +429,72 @@ class MediaAssetFetchAdapter:
 
 
 class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
+    def make_batch_record(self):
+        request = TaskRequestSnapshot(
+            adapter_key="core",
+            capability="batch_execution",
+            target_type="operation_batch",
+            target_value="batch-001",
+            collection_mode="batch",
+        )
+        record = start_task_record(
+            create_task_record(
+                "task-record-batch-1",
+                request=request,
+                occurred_at="2026-05-16T10:00:00Z",
+            ),
+            occurred_at="2026-05-16T10:00:01Z",
+        )
+        return finish_task_record(
+            record,
+            {
+                "task_id": "task-record-batch-1",
+                "adapter_key": "core",
+                "capability": "batch_execution",
+                "status": "success",
+                "task_record_ref": "task_record:task-record-batch-1",
+                "batch_id": "batch-001",
+                "operation": "batch_execution",
+                "result_status": "complete",
+                "dataset_sink_ref": "sink:reference",
+                "dataset_id": "dataset:batch-001",
+                "item_outcomes": [
+                    {
+                        "item_id": "item-1",
+                        "operation": "content_search_by_keyword",
+                        "adapter_key": TEST_ADAPTER_KEY,
+                        "target_ref": "deep learning",
+                        "outcome_status": "succeeded",
+                        "result_envelope": {
+                            "task_id": "batch-item-1",
+                            "adapter_key": TEST_ADAPTER_KEY,
+                            "capability": "content_search_by_keyword",
+                            "status": "success",
+                            **make_collection_result(target_ref="deep learning"),
+                        },
+                        "dataset_record_ref": "dataset:batch-001:item-1",
+                        "source_trace": {
+                            "adapter_key": TEST_ADAPTER_KEY,
+                            "provider_path": "provider://sanitized",
+                            "fetched_at": "2026-05-16T10:00:01Z",
+                            "evidence_alias": "alias://batch-item-1",
+                        },
+                        "audit": {"reason": "dataset_record_written"},
+                    }
+                ],
+                "audit_trace": {
+                    "batch_id": "batch-001",
+                    "started_at": "2026-05-16T10:00:00Z",
+                    "finished_at": "2026-05-16T10:00:01Z",
+                    "finished": True,
+                    "item_count": 1,
+                    "item_trace_refs": ["audit:batch:batch-001:item-1"],
+                    "evidence_refs": ["evidence:batch:item"],
+                },
+            },
+            occurred_at="2026-05-16T10:00:02Z",
+        )
+
     def test_round_trips_success_record(self) -> None:
         outcome = execute_task_with_record(
             TaskRequest(
@@ -448,6 +514,34 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
 
         self.assertEqual(restored, outcome.task_record)
         self.assertEqual(restored.status, "succeeded")
+
+    def test_round_trips_batch_execution_record(self) -> None:
+        record = self.make_batch_record()
+
+        payload = task_record_to_dict(record)
+        restored = task_record_from_dict(payload)
+
+        self.assertEqual(restored, record)
+        self.assertEqual(restored.request.capability, "batch_execution")
+        self.assertEqual(restored.request.target_type, "operation_batch")
+        self.assertEqual(restored.request.collection_mode, "batch")
+        self.assertEqual(restored.result.envelope["operation"], "batch_execution")
+        self.assertEqual(restored.result.envelope["item_outcomes"][0]["dataset_record_ref"], "dataset:batch-001:item-1")
+        self.assertNotIn("request_cursor_context", repr(payload))
+
+    def test_rejects_batch_execution_result_status_drift(self) -> None:
+        payload = task_record_to_dict(self.make_batch_record())
+        payload["result"]["envelope"]["result_status"] = "all_failed"
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_batch_execution_top_level_raw_payload(self) -> None:
+        payload = task_record_to_dict(self.make_batch_record())
+        payload["result"]["envelope"]["raw"] = {"provider_batch": True}
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
 
     def test_round_trips_comment_collection_record(self) -> None:
         outcome = execute_task_with_record(

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -730,6 +730,36 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(restored.result.envelope["batch_id"], "batch-comments")
         self.assertNotIn("request_cursor_context", repr(restored.result.envelope))
 
+    def test_cursor_sensitive_batch_result_restores_cursor_for_downstream_validation(self) -> None:
+        import syvert.batch_dataset as batch_dataset
+
+        envelope = self.make_cursor_sensitive_batch_envelope()
+        validation_attempts = []
+        original_validate = batch_dataset.validate_batch_result_envelope
+
+        def recording_validate(candidate):
+            validation_attempts.append(candidate)
+            return original_validate(candidate)
+
+        with mock.patch("syvert.batch_dataset.validate_batch_result_envelope", side_effect=recording_validate):
+            restored = task_record_from_dict(
+                task_record_to_dict(
+                    self.make_record_from_batch_envelope(
+                        task_id="task-record-batch-comments",
+                        batch_id="batch-comments",
+                        envelope=envelope,
+                    )
+                )
+            )
+
+        self.assertEqual(restored.result.envelope["batch_id"], "batch-comments")
+        self.assertGreaterEqual(len(validation_attempts), 2)
+        self.assertIsNone(validation_attempts[0].item_outcomes[0].request_cursor_context)
+        self.assertEqual(
+            validation_attempts[1].item_outcomes[0].request_cursor_context,
+            {"reply_cursor": {"resume_comment_ref": "comment:root-1"}},
+        )
+
     def test_rejects_cursor_sensitive_batch_result_target_drift(self) -> None:
         envelope = self.make_cursor_sensitive_batch_envelope()
         envelope["item_outcomes"][0]["result_envelope"]["target"]["target_ref"] = "content:other"

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -528,6 +528,102 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         self.assertEqual(restored.result.envelope["item_outcomes"][0]["dataset_record_ref"], "dataset:batch-001:item-1")
         self.assertNotIn("request_cursor_context", repr(payload))
 
+    def test_round_trips_serialized_cursor_sensitive_batch_result(self) -> None:
+        from syvert.batch_dataset import BatchItemOutcome, BatchResultEnvelope, batch_result_envelope_to_dict
+
+        cursor = {
+            "reply_cursor": {
+                "reply_cursor_token": "reply-cursor-1",
+                "reply_cursor_family": "opaque",
+                "resume_target_ref": "content:alpha",
+                "resume_comment_ref": "comment:root-1",
+                "issued_at": "2026-05-09T10:00:00Z",
+            }
+        }
+        result_envelope = {
+            "task_id": "batch-comment-item-1",
+            "adapter_key": TEST_ADAPTER_KEY,
+            "capability": "comment_collection",
+            "status": "success",
+            **make_comment_collection_result(target_ref="content:alpha"),
+        }
+        result_envelope["items"][0]["source_id"] = "reply-1"
+        result_envelope["items"][0]["source_ref"] = "comment://reply-1"
+        result_envelope["items"][0]["normalized"]["source_id"] = "reply-1"
+        result_envelope["items"][0]["normalized"]["canonical_ref"] = "comment:reply-1"
+        result_envelope["items"][0]["normalized"]["parent_comment_ref"] = "comment:root-1"
+        result_envelope["items"][0]["normalized"]["target_comment_ref"] = "comment:root-1"
+        batch_payload = batch_result_envelope_to_dict(
+            BatchResultEnvelope(
+                batch_id="batch-comments",
+                operation="batch_execution",
+                result_status="complete",
+                item_outcomes=(
+                    BatchItemOutcome(
+                        item_id="comments",
+                        operation="comment_collection",
+                        adapter_key=TEST_ADAPTER_KEY,
+                        target_ref="content:alpha",
+                        outcome_status="succeeded",
+                        result_envelope=result_envelope,
+                        dataset_record_ref="dataset:batch-comments:comments",
+                        source_trace={
+                            "adapter_key": TEST_ADAPTER_KEY,
+                            "provider_path": "provider://sanitized",
+                            "fetched_at": "2026-05-16T10:00:01Z",
+                            "evidence_alias": "alias://batch-comment-item-1",
+                        },
+                        audit={"reason": "dataset_record_written"},
+                        request_cursor_context=cursor,
+                    ),
+                ),
+                dataset_sink_ref="sink:reference",
+                dataset_id="dataset:batch-comments",
+                audit_trace={
+                    "batch_id": "batch-comments",
+                    "started_at": "2026-05-16T10:00:00Z",
+                    "finished": True,
+                    "item_count": 1,
+                    "item_trace_refs": ["audit:batch:batch-comments:comments"],
+                    "evidence_refs": ["evidence:batch:item"],
+                },
+            )
+        )
+        record = start_task_record(
+            create_task_record(
+                "task-record-batch-comments",
+                TaskRequestSnapshot(
+                    adapter_key="core",
+                    capability="batch_execution",
+                    target_type="operation_batch",
+                    target_value="batch-comments",
+                    collection_mode="batch",
+                ),
+                occurred_at="2026-05-16T10:00:00Z",
+            ),
+            occurred_at="2026-05-16T10:00:01Z",
+        )
+
+        restored = task_record_from_dict(
+            task_record_to_dict(
+                finish_task_record(
+                    record,
+                    {
+                        "task_id": "task-record-batch-comments",
+                        "adapter_key": "core",
+                        "capability": "batch_execution",
+                        "status": "success",
+                        "task_record_ref": "task_record:task-record-batch-comments",
+                        **batch_payload,
+                    },
+                    occurred_at="2026-05-16T10:00:02Z",
+                )
+            )
+        )
+
+        self.assertEqual(restored.result.envelope["batch_id"], "batch-comments")
+        self.assertNotIn("request_cursor_context", repr(restored.result.envelope))
+
     def test_rejects_batch_execution_result_status_drift(self) -> None:
         payload = task_record_to_dict(self.make_batch_record())
         payload["result"]["envelope"]["result_status"] = "all_failed"

--- a/tests/runtime/test_task_record.py
+++ b/tests/runtime/test_task_record.py
@@ -542,6 +542,36 @@ class TaskRecordCodecTests(TaskRecordStoreEnvMixin, unittest.TestCase):
         with self.assertRaises(TaskRecordContractError):
             task_record_from_dict(payload)
 
+    def test_rejects_batch_execution_top_level_extra_private_field(self) -> None:
+        payload = task_record_to_dict(self.make_batch_record())
+        payload["result"]["envelope"]["provider_route"] = "provider:fallback:marketplace"
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
+    def test_rejects_batch_execution_request_snapshot_unsafe_batch_id(self) -> None:
+        with self.assertRaises(TaskRecordContractError):
+            create_task_record(
+                "task-record-batch-unsafe-id",
+                TaskRequestSnapshot(
+                    adapter_key="core",
+                    capability="batch_execution",
+                    target_type="operation_batch",
+                    target_value="file:///tmp/raw-batch",
+                    collection_mode="batch",
+                ),
+                occurred_at="2026-05-16T10:00:00Z",
+            )
+
+    def test_rejects_batch_item_extra_private_field(self) -> None:
+        payload = task_record_to_dict(self.make_batch_record())
+        payload["result"]["envelope"]["item_outcomes"][0]["request_cursor_context"] = {
+            "provider_route": "provider:fallback:marketplace"
+        }
+
+        with self.assertRaises(TaskRecordContractError):
+            task_record_from_dict(payload)
+
     def test_rejects_failed_batch_item_with_dataset_record_ref(self) -> None:
         payload = task_record_to_dict(self.make_batch_record())
         item = payload["result"]["envelope"]["item_outcomes"][0]


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：迁移 #448 TaskRecord/result query/runtime admission/compatibility consumers，使 #447 batch/dataset public carrier 可被公共消费者读取。
- 主要改动：
  - TaskRecord 支持 `batch_execution / operation_batch / batch` consumer-side request/result projection。
  - TaskRecord batch 读取复用 #447 canonical `BatchResultEnvelope` public carrier validator，并拒绝原始 envelope / item outcome / resume token 额外字段漂移。
  - TaskRecord 兼容 `batch_result_envelope_to_dict` 序列化后的 cursor-sensitive comment batch public carrier，不暴露 `request_cursor_context`。
  - CLI query、HTTP status/result 复用同一 batch TaskRecord public carrier。
  - batch target item admission consumer 覆盖稳定 read-side runtime slices；compatibility consumers 对 dataset normalized payload fail-closed。

## 关联事项

- Issue: #448
- Parent FR: #445
- item_key: `CHORE-0448-v1-6-batch-dataset-consumers`
- item_type: `CHORE`
- release: `v1.6.0`
- sprint: `2026-S25`
- Branch: `issue-448-445-v1-6-0-batch-dataset-consumers`
- Worktree: `/Users/mc/code/worktrees/syvert/issue-448-445-v1-6-0-batch-dataset-consumers`
- PR head: `5dd3c1c3791d49fad9b12da3d155da5ec30f511c`
- Closing: Fixes #448

## Review Artifacts

- Active exec-plan: `docs/exec-plans/CHORE-0448-v1-6-batch-dataset-consumers.md`
- Governing spec / bootstrap contract: `docs/specs/FR-0445-batch-dataset-core-contract/spec.md`
- Review artifact: `code_review.md`
- Validation evidence: `python3 scripts/governance_gate.py --base-ref origin/main --head-ref HEAD`

## 风险

- 本 PR 不重新打开 #447 runtime carrier；direct `execute_task(batch_execution)` 仍 fail-closed。
- TaskRecord consumer 读取 public batch result carrier 时复用 canonical batch/dataset validator；cursor-sensitive comment public carrier 的私有 request cursor omission 仅在 consumer 读回中按公开字段受控恢复验证上下文。
- `python3 .loom/bin/loom_check.py .` 已运行但失败，失败项为 Loom full-runtime/adoption scaffold 缺失，不属于 #448 consumer migration 范围；Syvert repo-native guards 与 GitHub checks 作为本 PR 验证来源。

## 验证

- `python3 -m unittest tests.runtime.test_task_record.TaskRecordCodecTests.test_round_trips_serialized_cursor_sensitive_batch_result`
- `python3 -m unittest tests.runtime.test_task_record`
- `python3 -m unittest tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers tests.runtime.test_batch_dataset tests.runtime.test_runtime tests.runtime.test_provider_no_leakage_guard tests.runtime.test_adapter_provider_compatibility_decision`
- `python3 -m unittest discover`
- `python3 scripts/spec_guard.py --mode ci --all`
- `python3 scripts/docs_guard.py`
- `python3 scripts/workflow_guard.py`
- `python3 scripts/version_guard.py`
- `python3 scripts/governance_gate.py --base-ref origin/main --head-ref HEAD`
- `git diff --check`
- GitHub checks：green for head `5dd3c1c3791d49fad9b12da3d155da5ec30f511c`
- Guardian：APPROVE for head `5dd3c1c3791d49fad9b12da3d155da5ec30f511c`
- Merge gate：passed; merged into `main` at `23cbce712138e5edaba8e199cba419ff31dd0956`

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: check_required
- shared_contract_changed: yes
- integration_ref: #445
- external_dependency: none
- merge_gate: integration_check_required
- contract_surface: raw_normalized
- joint_acceptance_needed: no
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: yes
<!-- integration-check-end -->

## 回滚

- 如需回滚，使用独立 revert PR 撤销本 Work Item 的 TaskRecord consumer 与测试增量。
