### PR TITLE
test: 补齐批处理数据集证据矩阵

### DIFF
--- a/docs/exec-plans/CHORE-0449-v1-6-batch-dataset-evidence.md
+++ b/docs/exec-plans/CHORE-0449-v1-6-batch-dataset-evidence.md
@@ -11,7 +11,7 @@
 - Parent FR：`#445`
 - 关联 spec：`docs/specs/FR-0445-batch-dataset-core-contract/spec.md`
 - 关联 artifact：`docs/exec-plans/artifacts/CHORE-0449-v1-6-batch-dataset-evidence.md`
-- 关联 PR：
+- 关联 PR：`#454`
 - 状态：`active`
 
 ## 目标
@@ -41,6 +41,7 @@
 - Work Item `#447`：runtime carrier PR `#452` 已合入，merge commit `926a378dbec0c93fe2766eff8f4e3277083797c5`。
 - Work Item `#448`：consumer PR `#453` 已合入，merge commit `23cbce712138e5edaba8e199cba419ff31dd0956`。
 - Work Item `#449`：active evidence。
+- PR：`#454`
 - Workspace key：`issue-449-445-v1-6-0-batch-dataset-evidence`
 - Branch：`issue-449-445-v1-6-0-batch-dataset-evidence`
 - Worktree：formal issue-scoped worktree for `#449`

--- a/docs/exec-plans/CHORE-0449-v1-6-batch-dataset-evidence.md
+++ b/docs/exec-plans/CHORE-0449-v1-6-batch-dataset-evidence.md
@@ -1,0 +1,109 @@
+# CHORE-0449 v1.6 batch / dataset evidence 执行计划
+
+## 关联信息
+
+- item_key：`CHORE-0449-v1-6-batch-dataset-evidence`
+- Issue：`#449`
+- item_type：`CHORE`
+- release：`v1.6.0`
+- sprint：`2026-S25`
+- Parent Phase：`#444`
+- Parent FR：`#445`
+- 关联 spec：`docs/specs/FR-0445-batch-dataset-core-contract/spec.md`
+- 关联 artifact：`docs/exec-plans/artifacts/CHORE-0449-v1-6-batch-dataset-evidence.md`
+- 关联 PR：
+- 状态：`active`
+
+## 目标
+
+- 交付 `FR-0445` 的 sanitized fake/reference evidence 与 replay matrix。
+- 覆盖 partial success / partial failure、all failed、resume、timeout resumable、duplicate target、dataset replay、resource boundary 与 public carrier leakage prevention。
+- 只使用 sanitized fake/reference carriers；不引入真实账号、原始 payload 文件、私有 provider 数据、source names、本地路径、storage handles、私有 media/account/creator 字段、scheduler、UI、BI 或写侧流程。
+
+## 范围
+
+- 本次纳入：
+  - `docs/exec-plans/artifacts/CHORE-0449-v1-6-batch-dataset-evidence.md` 的 embedded JSON evidence snapshot。
+  - `tests/runtime/test_batch_dataset_evidence.py` 的 replay / sanitizer / leakage prevention 测试。
+  - 本执行计划。
+- 本次不纳入：
+  - `syvert/batch_dataset.py` runtime carrier 语义改写。
+  - TaskRecord/result query/compatibility consumer migration。
+  - release closeout、annotated tag、GitHub Release 或 published truth carrier。
+  - scheduler、write-side、content library、BI、UI、provider selector/fallback/marketplace。
+  - raw payload files、真实账号凭据、provider source names、本地路径、storage handles、私有 media/account/creator values。
+
+## 当前停点
+
+- Phase `#444`：open。
+- FR `#445`：open，显式绑定 `v1.6.0 / 2026-S25`。
+- Work Item `#446`：spec PR `#451` 已合入。
+- Work Item `#447`：runtime carrier PR `#452` 已合入，merge commit `926a378dbec0c93fe2766eff8f4e3277083797c5`。
+- Work Item `#448`：consumer PR `#453` 已合入，merge commit `23cbce712138e5edaba8e199cba419ff31dd0956`。
+- Work Item `#449`：active evidence。
+- Workspace key：`issue-449-445-v1-6-0-batch-dataset-evidence`
+- Branch：`issue-449-445-v1-6-0-batch-dataset-evidence`
+- Worktree：formal issue-scoped worktree for `#449`
+- Baseline：`23cbce712138e5edaba8e199cba419ff31dd0956`
+
+## 已实现证据
+
+- 新增 replayable evidence artifact，嵌入由测试重建的 structured JSON snapshot。
+- replay matrix 使用 `execute_batch_request`、`ReferenceDatasetSink` 与 sanitized fake/reference adapter。
+- 覆盖场景：
+  - `partial_success_failure`：一个成功 item 与一个 `permission_denied` failed item；只写成功 dataset record。
+  - `all_failed`：所有 item failed；不写 dataset records。
+  - `resume`：中断只返回已处理前缀，恢复后返回完整 canonical outcomes，并复用 dedup/write state。
+  - `timeout_resumable`：已 dispatch timeout item 作为 failed outcome，suffix 由 resume token 继续。
+  - `duplicate_target`：相同 `dedup_key` first-wins，duplicate item 为 `duplicate_skipped`，不重复写 record。
+  - `dataset_replay`：`read_by_dataset`、`read_by_batch` 与 `audit_replay` 返回 JSON-safe public record/replay summary。
+  - `resource_boundary`：batch admission 不要求真实账号；item path 继续通过 existing resource governance fail-closed。
+  - `public_carrier_leakage_prevention`：dataset/result/resume public carrier 对 raw inline、path/ref、storage、private entity field、routing marker 等泄漏 fail-closed。
+- Snapshot sanitization 记录：
+  - no raw payload files / embedded raw payload。
+  - no source names / local paths / storage handles。
+  - no private account/media/creator fields。
+  - no provider selector / marketplace semantics。
+  - no real account credentials required。
+
+## 已验证项
+
+- Initial focused evidence replay:
+  - `python3 -m unittest tests.runtime.test_batch_dataset_evidence.BatchDatasetEvidenceTests.test_evidence_snapshot_covers_fr_0445_matrix tests.runtime.test_batch_dataset_evidence.BatchDatasetEvidenceTests.test_evidence_snapshot_has_no_private_or_raw_fragments tests.runtime.test_batch_dataset_evidence.BatchDatasetEvidenceTests.test_public_carrier_leakage_matrix_fails_closed`
+  - 结果：通过，3 tests。
+- Evidence artifact replay:
+  - `python3 -m unittest tests.runtime.test_batch_dataset_evidence`
+  - 结果：通过，4 tests。
+- Evidence / replay / consumer matrix:
+  - `python3 -m unittest tests.runtime.test_batch_dataset_evidence tests.runtime.test_batch_dataset tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers`
+  - 结果：通过，180 tests。
+- Full unittest discovery:
+  - `python3 -m unittest discover`
+  - 结果：通过，527 tests。
+- Guards:
+  - `python3 scripts/spec_guard.py --mode ci --all`
+  - 结果：通过。
+  - `python3 scripts/docs_guard.py --mode ci`
+  - 结果：通过。
+  - `python3 scripts/workflow_guard.py --mode ci`
+  - 结果：通过。
+  - `python3 scripts/version_guard.py --mode ci`
+  - 结果：通过。
+  - `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
+  - 结果：通过。
+  - `git diff --check`
+  - 结果：通过。
+
+## 未决风险
+
+- 当前 evidence 只证明 repo-backed sanitized fake/reference matrix；不证明真实 provider 行为。
+- `#450` 仍需消费本 evidence、完成 release/sprint/FR/Phase truth reconciliation 和 explicit `v1.6.0` release decision。
+
+## 回滚方式
+
+- 使用独立 revert PR 撤销本 Work Item 的 evidence artifact、replay tests 与执行计划增量。
+- 保留 #445 / #447 / #448 truth，由后续 Work Item 重新补证据。
+
+## 最近一次 checkpoint 对应的 head SHA
+
+- Evidence replay checkpoint：pending local commit。

--- a/docs/exec-plans/CHORE-0449-v1-6-batch-dataset-evidence.md
+++ b/docs/exec-plans/CHORE-0449-v1-6-batch-dataset-evidence.md
@@ -106,4 +106,4 @@
 
 ## 最近一次 checkpoint 对应的 head SHA
 
-- Evidence replay checkpoint：pending local commit。
+- Evidence replay checkpoint：`0a340654d03ecbfeb52fa6a52e1e7c55fa4a4169`。

--- a/docs/exec-plans/artifacts/CHORE-0449-v1-6-batch-dataset-evidence.md
+++ b/docs/exec-plans/artifacts/CHORE-0449-v1-6-batch-dataset-evidence.md
@@ -1,0 +1,174 @@
+# CHORE-0449 v1.6 batch / dataset evidence
+
+## Purpose
+
+This artifact records sanitized fake/reference evidence for `FR-0445` after the runtime carrier and consumer Work Items merged. It proves Batch / Dataset Foundation can replay partial success/failure, all failed, resume, timeout, duplicate target, dataset replay, resource boundary, and public-carrier leakage prevention without committing raw payload files, real account credentials, source names, local paths, storage handles, or private provider data.
+
+## Evidence Summary
+
+- release：`v1.6.0`
+- fr_ref：`FR-0445`
+- work_item_ref：`#449 / CHORE-0449-v1-6-batch-dataset-evidence`
+- governing_spec_ref：`docs/specs/FR-0445-batch-dataset-core-contract/`
+- predecessor_pr_refs：
+  - `#451`
+  - `#452`
+  - `#453`
+- status：`pass`
+- covered scenarios：
+  - partial success / partial failure
+  - all failed
+  - resume after interruption
+  - timeout resumable boundary
+  - duplicate target first-wins
+  - dataset readback and audit replay
+  - item-scoped resource boundary
+  - public carrier leakage prevention
+
+## Structured Evidence Snapshot
+
+`tests.runtime.test_batch_dataset_evidence` rebuilds this report from sanitized fake/reference runtime carriers and compares it to the JSON snapshot below.
+
+<!-- syvert:batch-dataset-evidence-json:start -->
+```json
+{
+  "fr_ref": "FR-0445",
+  "governing_spec_ref": "docs/specs/FR-0445-batch-dataset-core-contract/",
+  "predecessor_pr_refs": [
+    "#451",
+    "#452",
+    "#453"
+  ],
+  "release": "v1.6.0",
+  "replay_matrix": {
+    "dataset_sink": "ReferenceDatasetSink",
+    "fixture_family": "sanitized_fake_reference",
+    "provider_private_data_required": false,
+    "raw_payload_files_required": false,
+    "runtime_entry": "execute_batch_request",
+    "snapshot_rebuilt_by": "tests.runtime.test_batch_dataset_evidence"
+  },
+  "report_id": "CHORE-0449-v1-6-batch-dataset-evidence",
+  "sanitization": {
+    "opaque_storage_free": true,
+    "path_free": true,
+    "private_entity_fields_present": false,
+    "provider_routing_policy_present": false,
+    "raw_payload_embedded": false,
+    "raw_payload_files_required": false,
+    "real_account_credentials_required": false,
+    "source_alias_only": true
+  },
+  "scenario_matrix": {
+    "all_failed": {
+      "dataset_record_count": 0,
+      "item_errors_preserved": [
+        "permission_denied",
+        "permission_denied"
+      ],
+      "item_statuses": [
+        "failed",
+        "failed"
+      ],
+      "result_status": "all_failed"
+    },
+    "dataset_replay": {
+      "raw_payload_files_required": false,
+      "read_by_batch_count": 2,
+      "read_by_dataset_count": 2,
+      "replay_count": 2,
+      "replay_record_keys": [
+        "adapter_key",
+        "batch_id",
+        "batch_item_id",
+        "dataset_id",
+        "dataset_record_id",
+        "dedup_key",
+        "evidence_ref",
+        "normalized_payload",
+        "source_operation",
+        "target_ref"
+      ],
+      "result_status": "complete",
+      "storage_handles_returned": false
+    },
+    "duplicate_target": {
+      "dataset_record_count": 1,
+      "duplicate_wrote_dataset_record": false,
+      "item_statuses": [
+        "succeeded",
+        "duplicate_skipped"
+      ],
+      "result_status": "complete"
+    },
+    "partial_success_failure": {
+      "dataset_record_count": 1,
+      "failed_error_code": "permission_denied",
+      "item_statuses": [
+        "succeeded",
+        "failed"
+      ],
+      "raw_payload_files_required": false,
+      "result_status": "partial_success"
+    },
+    "public_carrier_leakage_prevention": {
+      "fail_closed_cases": {
+        "dataset_opaque_storage_field": "invalid_dataset_record",
+        "dataset_path_ref": "unsafe_ref",
+        "dataset_private_entity_field": "unsafe_public_payload",
+        "dataset_raw_payload_inline_field": "invalid_dataset_record",
+        "result_opaque_storage_audit": "unsafe_public_payload",
+        "result_routing_resume": "unsafe_ref"
+      },
+      "raw_payload_files_required": false,
+      "sanitized_aliases_only": true
+    },
+    "resource_boundary": {
+      "batch_admission_requires_real_account": false,
+      "dataset_record_count": 0,
+      "item_error_code": "invalid_resource_requirement",
+      "item_resource_governance_preserved": true
+    },
+    "resume": {
+      "dataset_record_count": 2,
+      "dedup_write_state_reused": true,
+      "interrupted_outcome_count": 1,
+      "interrupted_result_status": "resumable",
+      "resume_next_item_index": 1,
+      "terminal_outcome_count": 2,
+      "terminal_result_status": "complete"
+    },
+    "timeout_resumable": {
+      "audit_finished": false,
+      "audit_stop_reason": "execution_timeout",
+      "failed_error_code": "execution_timeout",
+      "item_statuses": [
+        "failed"
+      ],
+      "result_status": "resumable",
+      "resume_next_item_index": 1,
+      "undispatched_suffix_outcome_count": 0
+    }
+  },
+  "status": "pass",
+  "validation_commands": [
+    "python3 -m unittest tests.runtime.test_batch_dataset_evidence tests.runtime.test_batch_dataset tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers",
+    "python3 -m unittest discover",
+    "python3 scripts/spec_guard.py --mode ci --all",
+    "python3 scripts/docs_guard.py --mode ci",
+    "python3 scripts/workflow_guard.py --mode ci",
+    "python3 scripts/version_guard.py --mode ci",
+    "python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD",
+    "git diff --check"
+  ],
+  "work_item_ref": "#449"
+}
+```
+<!-- syvert:batch-dataset-evidence-json:end -->
+
+## Scenario Notes
+
+- All evidence is rebuilt from sanitized fake/reference carriers through `execute_batch_request` and `ReferenceDatasetSink`.
+- Dataset replay returns public record metadata and normalized payload only; it does not require raw payload files or storage handles.
+- Resource boundary evidence keeps batch admission independent from real accounts while proving item execution still consumes existing resource governance.
+- Leakage prevention cases are fail-closed by public carrier validators and record only error codes, not private values.

--- a/tests/runtime/test_batch_dataset_evidence.py
+++ b/tests/runtime/test_batch_dataset_evidence.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from syvert.batch_dataset import (
+    BATCH_ITEM_FAILED,
+    BATCH_RESULT_ALL_FAILED,
+    BatchDatasetContractError,
+    BatchItemOutcome,
+    BatchRequest,
+    BatchResultEnvelope,
+    BatchTargetItem,
+    DatasetRecord,
+    ReferenceDatasetSink,
+    batch_result_envelope_to_dict,
+    canonical_dataset_record,
+    execute_batch_request,
+    validate_batch_result_envelope,
+    validate_dataset_record,
+)
+
+
+ARTIFACT_PATH = Path("docs/exec-plans/artifacts/CHORE-0449-v1-6-batch-dataset-evidence.md")
+ADAPTER_KEY = "reference_adapter_alpha"
+DATASET_SINK_REF = "dataset-sink:reference"
+FIXED_NOW = datetime(2026, 5, 17, 10, 0, 0, tzinfo=timezone.utc)
+
+FORBIDDEN_PUBLIC_CARRIER_FRAGMENTS = (
+    "/Users/",
+    "/home/",
+    "/tmp/",
+    "/var/",
+    "\\Users\\",
+    "C:/",
+    "D:/",
+    "file://",
+    "storage://",
+    "s3://",
+    "gs://",
+    "token=secret",
+    "credential",
+    "session_token",
+    "storage_handle",
+    "local_path",
+    "source_name",
+    "private_account",
+    "private_creator",
+    "private_media",
+    "provider:fallback",
+    "marketplace",
+)
+
+
+class ReferenceCollectionAdapter:
+    supported_capabilities = frozenset({"content_search"})
+    supported_targets = frozenset({"keyword"})
+    supported_collection_modes = frozenset({"paginated"})
+
+    def execute(self, request):
+        target_ref = request.input.keyword or ""
+        return make_collection_result(target_ref=target_ref)
+
+
+class KeywordFailingCollectionAdapter(ReferenceCollectionAdapter):
+    def __init__(self, failing_keywords: set[str]) -> None:
+        self.failing_keywords = failing_keywords
+
+    def execute(self, request):
+        from syvert.runtime import PlatformAdapterError
+
+        if request.input.keyword in self.failing_keywords:
+            raise PlatformAdapterError(
+                code="permission_denied",
+                message="permission denied",
+                details={"evidence_ref": "evidence:permission-denied"},
+            )
+        return make_collection_result(target_ref=request.input.keyword or "")
+
+
+class TimeoutCollectionAdapter(ReferenceCollectionAdapter):
+    def execute(self, request):
+        from syvert.runtime import PlatformAdapterError
+
+        raise PlatformAdapterError(
+            code="execution_timeout",
+            message="execution timed out",
+            details={"control_code": "execution_timeout", "evidence_ref": "evidence:timeout"},
+        )
+
+
+def fixed_now() -> datetime:
+    return FIXED_NOW
+
+
+def make_collection_result(*, target_ref: str) -> dict[str, object]:
+    return {
+        "operation": "content_search_by_keyword",
+        "target": {
+            "operation": "content_search_by_keyword",
+            "target_type": "keyword",
+            "target_ref": target_ref,
+            "target_display_hint": target_ref,
+        },
+        "items": [
+            {
+                "item_type": "content_summary",
+                "dedup_key": f"content:{target_ref}",
+                "source_id": f"source-{target_ref}",
+                "source_ref": f"content://{target_ref}/item-1",
+                "normalized": {
+                    "source_platform": ADAPTER_KEY,
+                    "source_type": "post",
+                    "source_id": f"source-{target_ref}",
+                    "canonical_ref": f"content://{target_ref}/item-1",
+                    "title_or_text_hint": f"public hint {target_ref}",
+                    "creator_ref": f"creator:{target_ref}",
+                    "published_at": "2026-05-17T10:00:00Z",
+                    "media_refs": [f"media://{target_ref}/1"],
+                },
+                "raw_payload_ref": f"raw://batch-dataset/{target_ref}/item-1",
+                "source_trace": make_source_trace(evidence_alias=f"alias://batch-dataset/{target_ref}/page-1"),
+            }
+        ],
+        "has_more": False,
+        "next_continuation": None,
+        "result_status": "complete",
+        "error_classification": "platform_failed",
+        "raw_payload_ref": f"raw://batch-dataset/{target_ref}/page-1",
+        "source_trace": make_source_trace(evidence_alias=f"alias://batch-dataset/{target_ref}/page-1"),
+        "audit": {"scenario": f"batch-dataset:{target_ref}"},
+    }
+
+
+def make_source_trace(*, evidence_alias: str) -> dict[str, object]:
+    return {
+        "adapter_key": ADAPTER_KEY,
+        "provider_path": "provider://sanitized",
+        "resource_profile_ref": "resource-profile:reference-read-side",
+        "fetched_at": "2026-05-17T10:00:00Z",
+        "evidence_alias": evidence_alias,
+    }
+
+
+def target(item_id: str, target_ref: str, *, dedup_key: str | None = None) -> BatchTargetItem:
+    return BatchTargetItem(
+        item_id=item_id,
+        operation="content_search_by_keyword",
+        adapter_key=ADAPTER_KEY,
+        target_type="keyword",
+        target_ref=target_ref,
+        dedup_key=dedup_key or f"dedup:{target_ref}",
+    )
+
+
+def request(*items: BatchTargetItem, resume_token=None) -> BatchRequest:
+    return BatchRequest(
+        batch_id="batch-0449",
+        target_set=items,
+        resume_token=resume_token,
+        dataset_sink_ref=DATASET_SINK_REF,
+        audit_context={"evidence_ref": "evidence:batch-dataset"},
+    )
+
+
+class BatchDatasetEvidenceTests(unittest.TestCase):
+    def test_evidence_artifact_matches_replayable_snapshot(self) -> None:
+        self.assertEqual(self.load_artifact_report(), self.build_report())
+
+    def test_evidence_snapshot_covers_fr_0445_matrix(self) -> None:
+        report = self.build_report()
+
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(
+            sorted(report["scenario_matrix"]),
+            [
+                "all_failed",
+                "dataset_replay",
+                "duplicate_target",
+                "partial_success_failure",
+                "public_carrier_leakage_prevention",
+                "resource_boundary",
+                "resume",
+                "timeout_resumable",
+            ],
+        )
+        self.assertEqual(report["scenario_matrix"]["partial_success_failure"]["result_status"], "partial_success")
+        self.assertEqual(report["scenario_matrix"]["all_failed"]["dataset_record_count"], 0)
+        self.assertEqual(report["scenario_matrix"]["resume"]["terminal_result_status"], "complete")
+        self.assertEqual(report["scenario_matrix"]["duplicate_target"]["item_statuses"], ["succeeded", "duplicate_skipped"])
+        self.assertTrue(report["scenario_matrix"]["dataset_replay"]["raw_payload_files_required"] is False)
+        self.assertTrue(report["scenario_matrix"]["resource_boundary"]["batch_admission_requires_real_account"] is False)
+
+    def test_evidence_snapshot_has_no_private_or_raw_fragments(self) -> None:
+        snapshot_values = "\n".join(str(value) for value in self.public_leaf_values(self.build_report()))
+
+        for fragment in FORBIDDEN_PUBLIC_CARRIER_FRAGMENTS:
+            with self.subTest(fragment=fragment):
+                self.assertNotIn(fragment, snapshot_values)
+
+    def test_public_carrier_leakage_matrix_fails_closed(self) -> None:
+        matrix = self.build_report()["scenario_matrix"]["public_carrier_leakage_prevention"]["fail_closed_cases"]
+
+        self.assertEqual(
+            matrix,
+            {
+                "dataset_raw_payload_inline_field": "invalid_dataset_record",
+                "dataset_opaque_storage_field": "invalid_dataset_record",
+                "dataset_path_ref": "unsafe_ref",
+                "dataset_private_entity_field": "unsafe_public_payload",
+                "result_opaque_storage_audit": "unsafe_public_payload",
+                "result_routing_resume": "unsafe_ref",
+            },
+        )
+
+    def build_report(self) -> dict[str, object]:
+        return {
+            "report_id": "CHORE-0449-v1-6-batch-dataset-evidence",
+            "release": "v1.6.0",
+            "fr_ref": "FR-0445",
+            "work_item_ref": "#449",
+            "status": "pass",
+            "governing_spec_ref": "docs/specs/FR-0445-batch-dataset-core-contract/",
+            "predecessor_pr_refs": ["#451", "#452", "#453"],
+            "sanitization": {
+                "raw_payload_files_required": False,
+                "raw_payload_embedded": False,
+                "source_alias_only": True,
+                "path_free": True,
+                "opaque_storage_free": True,
+                "private_entity_fields_present": False,
+                "provider_routing_policy_present": False,
+                "real_account_credentials_required": False,
+            },
+            "replay_matrix": {
+                "fixture_family": "sanitized_fake_reference",
+                "runtime_entry": "execute_batch_request",
+                "dataset_sink": "ReferenceDatasetSink",
+                "snapshot_rebuilt_by": "tests.runtime.test_batch_dataset_evidence",
+                "raw_payload_files_required": False,
+                "provider_private_data_required": False,
+            },
+            "scenario_matrix": {
+                "partial_success_failure": self.partial_success_failure(),
+                "all_failed": self.all_failed(),
+                "resume": self.resume(),
+                "timeout_resumable": self.timeout_resumable(),
+                "duplicate_target": self.duplicate_target(),
+                "dataset_replay": self.dataset_replay(),
+                "resource_boundary": self.resource_boundary(),
+                "public_carrier_leakage_prevention": self.public_carrier_leakage_prevention(),
+            },
+            "validation_commands": [
+                "python3 -m unittest tests.runtime.test_batch_dataset_evidence tests.runtime.test_batch_dataset tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers",
+                "python3 -m unittest discover",
+                "python3 scripts/spec_guard.py --mode ci --all",
+                "python3 scripts/docs_guard.py --mode ci",
+                "python3 scripts/workflow_guard.py --mode ci",
+                "python3 scripts/version_guard.py --mode ci",
+                "python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD",
+                "git diff --check",
+            ],
+        }
+
+    def partial_success_failure(self) -> dict[str, object]:
+        sink = ReferenceDatasetSink()
+        result = self.execute(
+            request(target("item-success", "alpha"), target("item-failed", "beta")),
+            adapters={ADAPTER_KEY: KeywordFailingCollectionAdapter({"beta"})},
+            sink=sink,
+        )
+
+        return {
+            "result_status": result.result_status,
+            "item_statuses": [outcome.outcome_status for outcome in result.item_outcomes],
+            "failed_error_code": result.item_outcomes[1].error_envelope["code"],
+            "dataset_record_count": len(sink.read_by_dataset("dataset:batch-0449")),
+            "raw_payload_files_required": False,
+        }
+
+    def all_failed(self) -> dict[str, object]:
+        sink = ReferenceDatasetSink()
+        result = self.execute(
+            request(target("item-failed-1", "alpha"), target("item-failed-2", "beta")),
+            adapters={ADAPTER_KEY: KeywordFailingCollectionAdapter({"alpha", "beta"})},
+            sink=sink,
+        )
+
+        return {
+            "result_status": result.result_status,
+            "item_statuses": [outcome.outcome_status for outcome in result.item_outcomes],
+            "dataset_record_count": len(sink.read_by_dataset("dataset:batch-0449")),
+            "item_errors_preserved": [outcome.error_envelope["code"] for outcome in result.item_outcomes],
+        }
+
+    def resume(self) -> dict[str, object]:
+        sink = ReferenceDatasetSink()
+        items = (target("item-1", "alpha"), target("item-2", "beta"))
+        first = self.execute(request(*items), sink=sink, stop_after_items=1, stop_reason="execution_timeout")
+        resumed = self.execute(
+            request(*items, resume_token=first.resume_token),
+            sink=sink,
+            prior_item_outcomes=first.item_outcomes,
+        )
+
+        return {
+            "interrupted_result_status": first.result_status,
+            "interrupted_outcome_count": len(first.item_outcomes),
+            "resume_next_item_index": first.resume_token.next_item_index,
+            "terminal_result_status": resumed.result_status,
+            "terminal_outcome_count": len(resumed.item_outcomes),
+            "dataset_record_count": len(sink.read_by_dataset("dataset:batch-0449")),
+            "dedup_write_state_reused": len(sink.read_by_dataset("dataset:batch-0449")) == 2,
+        }
+
+    def timeout_resumable(self) -> dict[str, object]:
+        sink = ReferenceDatasetSink()
+        result = self.execute(
+            request(target("item-timeout", "alpha"), target("item-suffix", "beta")),
+            adapters={ADAPTER_KEY: TimeoutCollectionAdapter()},
+            sink=sink,
+        )
+
+        return {
+            "result_status": result.result_status,
+            "item_statuses": [outcome.outcome_status for outcome in result.item_outcomes],
+            "failed_error_code": result.item_outcomes[0].error_envelope["code"],
+            "resume_next_item_index": result.resume_token.next_item_index,
+            "audit_finished": result.audit_trace["finished"],
+            "audit_stop_reason": result.audit_trace["stop_reason"],
+            "undispatched_suffix_outcome_count": len(result.item_outcomes) - result.resume_token.next_item_index,
+        }
+
+    def duplicate_target(self) -> dict[str, object]:
+        sink = ReferenceDatasetSink()
+        result = self.execute(
+            request(
+                target("item-original", "alpha", dedup_key="dedup:shared"),
+                target("item-duplicate", "alpha", dedup_key="dedup:shared"),
+            ),
+            sink=sink,
+        )
+
+        return {
+            "result_status": result.result_status,
+            "item_statuses": [outcome.outcome_status for outcome in result.item_outcomes],
+            "dataset_record_count": len(sink.read_by_dataset("dataset:batch-0449")),
+            "duplicate_wrote_dataset_record": result.item_outcomes[1].dataset_record_ref is not None,
+        }
+
+    def dataset_replay(self) -> dict[str, object]:
+        sink = ReferenceDatasetSink()
+        result = self.execute(request(target("item-1", "alpha"), target("item-2", "beta")), sink=sink)
+        replay = sink.audit_replay(result.dataset_id)
+
+        return {
+            "result_status": result.result_status,
+            "read_by_dataset_count": len(sink.read_by_dataset(result.dataset_id)),
+            "read_by_batch_count": len(sink.read_by_batch(result.batch_id)),
+            "replay_count": len(replay),
+            "replay_record_keys": sorted(replay[0]),
+            "raw_payload_files_required": False,
+            "storage_handles_returned": False,
+        }
+
+    def resource_boundary(self) -> dict[str, object]:
+        sink = ReferenceDatasetSink()
+        result = execute_batch_request(
+            request(target("item-resource", "alpha")),
+            adapters={ADAPTER_KEY: ReferenceCollectionAdapter()},
+            dataset_sink=sink,
+            task_id_factory=self.task_id_factory(),
+            now_factory=fixed_now,
+        )
+
+        return {
+            "batch_admission_requires_real_account": False,
+            "item_resource_governance_preserved": result.item_outcomes[0].outcome_status == BATCH_ITEM_FAILED,
+            "item_error_code": result.item_outcomes[0].error_envelope["code"],
+            "dataset_record_count": len(sink.read_by_dataset("dataset:batch-0449")),
+        }
+
+    def public_carrier_leakage_prevention(self) -> dict[str, object]:
+        return {
+            "fail_closed_cases": {
+                "dataset_raw_payload_inline_field": self.dataset_record_error(raw_payload={"private": True}),
+                "dataset_opaque_storage_field": self.dataset_record_error(storage_handle="opaque-handle"),
+                "dataset_path_ref": self.dataset_record_error(raw_payload_ref="raw://var/private/raw.json"),
+                "dataset_private_entity_field": self.dataset_record_error(
+                    normalized_payload={"items": [{"private_creator": "creator-secret"}]},
+                ),
+                "result_opaque_storage_audit": self.result_error(audit_trace={"storage_ref": "storage://redacted"}),
+                "result_routing_resume": self.resume_token_error("resume:batch-0449:1:provider:fallback-route"),
+            },
+            "sanitized_aliases_only": True,
+            "raw_payload_files_required": False,
+        }
+
+    def dataset_record_error(self, **overrides) -> str:
+        record = {
+            "dataset_record_id": "record-leakage",
+            "dataset_id": "dataset-leakage",
+            "source_operation": "content_search_by_keyword",
+            "adapter_key": ADAPTER_KEY,
+            "target_ref": "alpha",
+            "raw_payload_ref": "raw://batch-dataset/alpha/page-1",
+            "normalized_payload": {"items": [{"title_or_text_hint": "safe"}]},
+            "evidence_ref": "evidence:batch-dataset",
+            "source_trace": make_source_trace(evidence_alias="alias://batch-dataset/leakage"),
+            "dedup_key": "dedup:alpha",
+            "batch_id": "batch-0449",
+            "batch_item_id": "item-leakage",
+            "recorded_at": "2026-05-17T10:00:00Z",
+            **overrides,
+        }
+        try:
+            if set(overrides) - set(DatasetRecord.__dataclass_fields__):
+                canonical_dataset_record(record)
+            else:
+                validate_dataset_record(DatasetRecord(**record))
+        except BatchDatasetContractError as error:
+            return error.code
+        self.fail(f"dataset record leakage case unexpectedly passed: {overrides}")
+
+    def result_error(self, *, audit_trace: dict[str, object]) -> str:
+        outcome = BatchItemOutcome(
+            item_id="item-1",
+            operation="content_search_by_keyword",
+            adapter_key=ADAPTER_KEY,
+            target_ref="alpha",
+            outcome_status=BATCH_ITEM_FAILED,
+            error_envelope={
+                "category": "runtime",
+                "code": "permission_denied",
+                "message": "permission denied",
+                "details": {"evidence_ref": "evidence:permission-denied"},
+            },
+            audit={"reason": "failed"},
+        )
+        envelope = BatchResultEnvelope(
+            batch_id="batch-0449",
+            operation="batch_execution",
+            result_status=BATCH_RESULT_ALL_FAILED,
+            item_outcomes=(outcome,),
+            dataset_sink_ref=DATASET_SINK_REF,
+            dataset_id="dataset:batch-0449",
+            audit_trace={
+                "batch_id": "batch-0449",
+                "started_at": "2026-05-17T10:00:00Z",
+                "finished": True,
+                "item_count": 1,
+                "item_trace_refs": ("audit:batch:batch-0449:item-1",),
+                "evidence_refs": ("evidence:batch-dataset",),
+                **audit_trace,
+            },
+        )
+        try:
+            validate_batch_result_envelope(envelope)
+        except BatchDatasetContractError as error:
+            return error.code
+        self.fail(f"batch result leakage case unexpectedly passed: {audit_trace}")
+
+    def resume_token_error(self, resume_token_value: str) -> str:
+        first = self.execute(
+            request(target("item-1", "alpha"), target("item-2", "beta")),
+            sink=ReferenceDatasetSink(),
+            stop_after_items=1,
+            stop_reason="execution_timeout",
+        )
+        forged = BatchResultEnvelope(
+            batch_id=first.batch_id,
+            operation=first.operation,
+            result_status=first.result_status,
+            item_outcomes=first.item_outcomes,
+            resume_token=type(first.resume_token)(**{**first.resume_token.__dict__, "resume_token": resume_token_value}),
+            dataset_sink_ref=first.dataset_sink_ref,
+            dataset_id=first.dataset_id,
+            audit_trace=first.audit_trace,
+        )
+        try:
+            batch_result_envelope_to_dict(forged)
+        except BatchDatasetContractError as error:
+            return error.code
+        self.fail("resume token leakage case unexpectedly passed")
+
+    def execute(self, batch_request: BatchRequest, *, adapters=None, sink=None, **kwargs):
+        with mock.patch.dict("syvert.runtime.RESOURCE_SLOTS_BY_OPERATION_AND_COLLECTION_MODE", {}, clear=True):
+            return execute_batch_request(
+                batch_request,
+                adapters=adapters or {ADAPTER_KEY: ReferenceCollectionAdapter()},
+                dataset_sink=sink if sink is not None else ReferenceDatasetSink(),
+                task_id_factory=self.task_id_factory(),
+                now_factory=fixed_now,
+                **kwargs,
+            )
+
+    @staticmethod
+    def task_id_factory():
+        task_ids = iter(f"task-0449-{index}" for index in range(1, 20))
+        return lambda: next(task_ids)
+
+    def load_artifact_report(self) -> dict[str, object]:
+        text = ARTIFACT_PATH.read_text(encoding="utf-8")
+        match = re.search(
+            r"<!-- syvert:batch-dataset-evidence-json:start -->\s*```json\s*(\{.*?\})\s*```",
+            text,
+            re.S,
+        )
+        self.assertIsNotNone(match)
+        return json.loads(match.group(1))
+
+    def public_leaf_values(self, value):
+        if isinstance(value, dict):
+            for item in value.values():
+                yield from self.public_leaf_values(item)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                yield from self.public_leaf_values(item)
+        elif isinstance(value, str):
+            yield value
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

- PR Class: `implementation`
- 变更目的：为 `#449` 交付 `FR-0445` Batch / Dataset Foundation 的 sanitized fake/reference evidence 与 replay matrix。
- 主要改动：新增 batch/dataset evidence artifact、replay/sanitizer 测试、`#449` exec-plan。

## Issue 摘要

## Goal

交付目标：交付 sanitized fake/reference evidence，覆盖 partial success、partial failure、all failed、resume、duplicate target、dataset replay 与 resource boundary。

验证方式：Focused dataset evidence unittest, leakage scans, full unittest discovery, governance/doc/version gates, git diff --check, PR guardian.

回滚方式：使用独立 revert PR 撤销本 Work Item 的增量；#445 保持开放并由后续 Work Item 重新收敛。

## Scope

Included:
- Sanitized evidence artifact
- Replayable fake/reference payload descriptors without raw payload files
- Evidence tests for partial success/failure, duplicate target, resume token, dataset replay, resource boundary
- Leakage scans for source names/local paths/storage handles/private account/media/creator fields

Excluded:
- Raw fixture payload files
- Real account/login-state requirement as Core prerequisite
- Content library, BI, UI, scheduler, write-side evidence
- Provider selector/fallback/marketplace evidence

## 关联事项

- Issue: #449
- item_key: `CHORE-0449-v1-6-batch-dataset-evidence`
- item_type: `CHORE`
- release: `v1.6.0`
- sprint: `2026-S25`
- Closing: Fixes #449

## Review Artifacts

- Active exec-plan: `docs/exec-plans/CHORE-0449-v1-6-batch-dataset-evidence.md`
- Governing spec / bootstrap contract: `docs/specs/FR-0445-batch-dataset-core-contract`
- Review artifact: `code_review.md`
- Validation evidence: `python3 -m unittest tests.runtime.test_batch_dataset_evidence`; `python3 -m unittest tests.runtime.test_batch_dataset_evidence tests.runtime.test_batch_dataset tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers`; `python3 -m unittest discover`; `python3 scripts/spec_guard.py --mode ci --all`; `python3 scripts/docs_guard.py --mode ci`; `python3 scripts/workflow_guard.py --mode ci`; `python3 scripts/version_guard.py --mode ci`; `python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`; `git diff --check`

## 风险

- 风险级别：`normal`
- 审查关注：evidence artifact 只证明 sanitized fake/reference replay，不证明真实 provider 行为；`#450` 仍需消费本 evidence 完成 release closeout。

## 验证

- 已执行：`python3 -m unittest tests.runtime.test_batch_dataset_evidence`（4 tests）
- 已执行：`python3 -m unittest tests.runtime.test_batch_dataset_evidence tests.runtime.test_batch_dataset tests.runtime.test_task_record tests.runtime.test_cli_http_same_path tests.runtime.test_operation_taxonomy_consumers`（180 tests）
- 已执行：`python3 -m unittest discover`（527 tests）
- 已执行：`python3 scripts/spec_guard.py --mode ci --all`
- 已执行：`python3 scripts/docs_guard.py --mode ci`
- 已执行：`python3 scripts/workflow_guard.py --mode ci`
- 已执行：`python3 scripts/version_guard.py --mode ci`
- 已执行：`python3 scripts/governance_gate.py --mode ci --base-ref origin/main --head-ref HEAD`
- 已执行：`git diff --check`
- 未执行：guardian / merge gate pending after GitHub checks

## integration_check

Canonical integration contract source: `scripts/policy/integration_contract.json` / `scripts/integration_contract.py`

- integration_touchpoint: check_required
- shared_contract_changed: yes
- integration_ref: #445
- external_dependency: none
- merge_gate: integration_check_required
- contract_surface: raw_normalized
- joint_acceptance_needed: no
- integration_status_checked_before_pr: yes
- integration_status_checked_before_merge: no
补充说明：

- 按 canonical contract 填写并校验 `integration_check`。
- `merge_gate` 的触发条件、`integration_ref` 的可核查格式与归一规则，以 canonical contract 为准。
- `integration_check_required` 的最终复核发生在 merge gate，不要把 merge-time recheck 写成 reviewer 已完成动作。

## 回滚

- 回滚方式：如需回滚，使用独立 revert PR 撤销本次变更。

## Loom Runtime Locator

- Loom companion: `.loom/companion/README.md`
- Loom runtime: `.loom/bin/loom_flow.py`

## Summary

- Loom-compatible summary: see `## 摘要`.

## Validation

- Loom-compatible validation: see `## 验证`.

## Risks And Follow-ups

- Loom-compatible risks and follow-ups: see `## 风险`.

## Related Work

- Loom-compatible related work: see `## 关联事项`.